### PR TITLE
fix: don't invalidate when code is invalid

### DIFF
--- a/packages/plugin-react/src/fast-refresh.ts
+++ b/packages/plugin-react/src/fast-refresh.ts
@@ -92,6 +92,7 @@ function isReactRefreshBoundary(mod) {
 }
 
 import.meta.hot.accept(mod => {
+  if (!mod) return;
   if (isReactRefreshBoundary(mod)) {
     ${timeout}
   } else {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
```js
import.meta.hot.accept(mod => {
  // mod is undefined when the code contains invalid syntax
  if (isReactRefreshBoundary(mod)) { // isReactRefreshBoundary(undefined) returns false
    ${timeout}
  } else {
    import.meta.hot.invalidate(); // this invalidate is called
  }
}
```
This PR adds `if (!mod) return` to fix invalidate happening.

This fixes https://github.com/vitejs/vite/issues/11365.

### Additional context

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite-plugin-react/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
