### PR TITLE
chore!: drop jsxPure

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -32,12 +32,6 @@ export interface Options {
    */
   jsxImportSource?: string
   /**
-   * Set this to `true` to annotate the JSX factory with `\/* @__PURE__ *\/`.
-   * This option is ignored when `jsxRuntime` is not `"automatic"`.
-   * @default true
-   */
-  jsxPure?: boolean
-  /**
    * Babel configuration applied in both dev and prod.
    */
   babel?:
@@ -128,7 +122,6 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
             },
             jsx: 'transform',
             jsxImportSource: opts.jsxImportSource,
-            jsxSideEffects: opts.jsxPure === false,
           },
         }
       } else {
@@ -136,7 +129,6 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
           esbuild: {
             jsx: 'automatic',
             jsxImportSource: opts.jsxImportSource,
-            jsxSideEffects: opts.jsxPure === false,
           },
         }
       }

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -149,6 +149,11 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
           '[@vitejs/plugin-react] Support for classic runtime is deprecated.',
         )
       }
+      if ('jsxPure' in opts) {
+        config.logger.warnOnce(
+          '[@vitejs/plugin-react] jsxPure was removed. You can configure esbuild.jsxSideEffects directly.',
+        )
+      }
 
       runPluginOverrides = (babelOptions, context) => {
         const hooks = config.plugins


### PR DESCRIPTION
This is a really niche custom property that is passed down to esbuild. If you need it, set jsxSideEffects: true in the esbuild config directly.