### PR TITLE
chore: deprecate classic runtime

### DIFF
--- a/packages/plugin-react/README.md
+++ b/packages/plugin-react/README.md
@@ -3,8 +3,7 @@
 The all-in-one Vite plugin for React projects.
 
 - enable [Fast Refresh](https://www.npmjs.com/package/react-refresh) in development
-- use the [automatic JSX runtime](https://github.com/alloc/vite-react-jsx#faq)
-- avoid manual `import React` in `.jsx` and `.tsx` modules
+- use the [automatic JSX runtime](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)
 - dedupe the `react` and `react-dom` packages
 - use custom Babel plugins/presets
 
@@ -40,16 +39,6 @@ Control where the JSX factory is imported from. This option is ignored for class
 ```js
 react({
   jsxImportSource: '@emotion/react',
-})
-```
-
-## Opting out of the automatic JSX runtime
-
-By default, the plugin uses the [automatic JSX runtime](https://github.com/alloc/vite-react-jsx#faq). However, if you encounter any issues, you may opt out using the `jsxRuntime` option.
-
-```js
-react({
-  jsxRuntime: 'classic',
 })
 ```
 


### PR DESCRIPTION
This also remove previous warnings. I think the plugin has been here long enough so they are not needed.

I updated the link for jsx runtime to not point to the @aleclarson archived repo that can be confusing now that jsx is handled via esbuild and doesn't have extra cost