### PR TITLE
fix!: don't force optimization of jsx-runtime

### DIFF
--- a/packages/plugin-react/README.md
+++ b/packages/plugin-react/README.md
@@ -34,12 +34,10 @@ react({
 
 ### Configure the JSX import source
 
-Control where the JSX factory is imported from. This option is ignored for classic `jsxRuntime`.
+Control where the JSX factory is imported from. For TS projects this is inferred from the tsconfig.
 
 ```js
-react({
-  jsxImportSource: '@emotion/react',
-})
+react({ jsxImportSource: '@emotion/react' })
 ```
 
 ## Babel configuration

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -27,8 +27,8 @@ export interface Options {
   jsxRuntime?: 'classic' | 'automatic'
   /**
    * Control where the JSX factory is imported from.
-   * This option is ignored when `jsxRuntime` is not `"automatic"`.
-   * @default "react"
+   * https://esbuild.github.io/api/#jsx-import-source
+   * For TS projects this is read from tsconfig
    */
   jsxImportSource?: string
   /**
@@ -314,6 +314,12 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
     name: 'vite:react-refresh',
     enforce: 'pre',
     config: () => ({
+      optimizeDeps: {
+        // We can't add `react-dom` because the dependency is `react-dom/client`
+        // for React 18 while it's `react-dom` for React 17. We'd need to detect
+        // what React version the user has installed.
+        include: ['react'],
+      },
       resolve: {
         dedupe: ['react', 'react-dom'],
       },
@@ -340,24 +346,7 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
     },
   }
 
-  const reactJsxRuntimeId = 'react/jsx-runtime'
-  const reactJsxDevRuntimeId = 'react/jsx-dev-runtime'
-  const viteReactJsx: Plugin = {
-    name: 'vite:react-jsx',
-    enforce: 'pre',
-    config() {
-      return {
-        optimizeDeps: {
-          // We can't add `react-dom` because the dependency is `react-dom/client`
-          // for React 18 while it's `react-dom` for React 17. We'd need to detect
-          // what React version the user has installed.
-          include: [reactJsxRuntimeId, reactJsxDevRuntimeId, 'react'],
-        },
-      }
-    },
-  }
-
-  return [viteBabel, viteReactRefresh, useAutomaticRuntime && viteReactJsx]
+  return [viteBabel, viteReactRefresh]
 }
 
 viteReact.preambleCode = preambleCode

--- a/playground/ssr-react/vite.config.js
+++ b/playground/ssr-react/vite.config.js
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
+  optimizeDeps: { include: ['react/jsx-dev-runtime'] },
   build: {
     minify: false,
   },


### PR DESCRIPTION
On my testing I found that this is correctly found by the optimiser. 
No body also complain about the missing entry when not using the default one.

There is one edge case in the ssr test that fails on windows and ubuntu (node 14&16, not 18 🤦‍♂️). This is due to Vite returning an error for non variable/on going reprocessed of the pre-bundled deps. As this happens on a very particular setup, only in dev, and can be fixed by manually passing it in the config, I think the change should be part of the major.

With that we can make it clear that this is not expected to be set for TS projects, which was asked by some, and allow the niche case asked once of different runtime inside the same app (works great if not set thanks to tsconfck)

This other option is to invite people to pass is and have something like this: https://github.com/vitejs/vite-plugin-react-swc/blob/7fde2e9d748fc502f4463e81484cf8d6e34f69b5/src/index.ts#L65 