### PR TITLE
chore: remove `esbuild.logOverride['this-is-undefined-in-esm']`

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -116,9 +116,6 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
       if (opts.jsxRuntime === 'classic') {
         return {
           esbuild: {
-            logOverride: {
-              'this-is-undefined-in-esm': 'silent',
-            },
             jsx: 'transform',
             jsxImportSource: opts.jsxImportSource,
           },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
We no longer need to set this because esbuild 0.15.8 changed `this-is-undefined-in-esm` to a debug log from a warning (https://github.com/evanw/esbuild/commit/93e068df8a9d2346cb11596076e59eded72d92d7).

refs https://github.com/vitejs/vite/pull/8674

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite-plugin-react/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
