### PR TITLE
chore: remove parser plugins included by default in Babel core

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -252,17 +252,7 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
           }
         }
 
-        const parserPlugins: typeof babelOptions.parserOpts.plugins = [
-          ...babelOptions.parserOpts.plugins,
-          'importMeta',
-          // This plugin is applied before esbuild transforms the code,
-          // so we need to enable some stage 3 syntax that is supported in
-          // TypeScript and some environments already.
-          'topLevelAwait',
-          'classProperties',
-          'classPrivateProperties',
-          'classPrivateMethods',
-        ]
+        const parserPlugins = [...babelOptions.parserOpts.plugins]
 
         if (!extension.endsWith('.ts')) {
           parserPlugins.push('jsx')


### PR DESCRIPTION
Re: https://github.com/vitejs/vite-plugin-react/pull/122#discussion_r1153441013

import.meta is also included: https://babeljs.io/docs/babel-plugin-syntax-import-meta