### PR TITLE
perf: cache load plugin

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -435,8 +435,18 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
 
 viteReact.preambleCode = preambleCode
 
-function loadPlugin(path: string): Promise<any> {
-  return import(path).then((module) => module.default || module)
+const loadedPlugin = new Map<string, any>()
+function loadPlugin(path: string): any {
+  const cached = loadedPlugin.get(path)
+  if (cached) return cached
+
+  const promise = import(path).then((module) => {
+    const value = module.default || module
+    loadedPlugin.set(path, value)
+    return value
+  })
+  loadedPlugin.set(path, promise)
+  return promise
 }
 
 function createBabelOptions(rawOptions?: BabelOptions) {


### PR DESCRIPTION
### Description
It seems node calls `importModuleDynamicallyCallback` everytime `import` is called.
By caching this call, it reduced the start up time of https://github.com/sapphi-red/performance-compare from ~5100ms to ~4700ms.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite-plugin-react/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
