### PR TITLE
fix!: don't auto import React with classic runtime

### DIFF
--- a/packages/plugin-react/README.md
+++ b/packages/plugin-react/README.md
@@ -46,6 +46,14 @@ Control where the JSX factory is imported from. Default to `'react'`
 react({ jsxImportSource: '@emotion/react' })
 ```
 
+## jsxRuntime
+
+By default, the plugin uses the [automatic JSX runtime](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html). However, if you encounter any issues, you may opt out using the `jsxRuntime` option.
+
+```js
+react({ jsxRuntime: 'classic' })
+```
+
 ### babel
 
 The `babel` option lets you add plugins, presets, and [other configuration](https://babeljs.io/docs/en/options) to the Babel transformation performed on each included file.

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -42,7 +42,6 @@
     "@babel/core": "^7.21.4",
     "@babel/plugin-transform-react-jsx-self": "^7.21.0",
     "@babel/plugin-transform-react-jsx-source": "^7.19.6",
-    "magic-string": "^0.30.0",
     "react-refresh": "^0.14.0"
   },
   "peerDependencies": {

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -127,11 +127,6 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
       isProduction = config.isProduction
       skipFastRefresh = isProduction || config.command === 'build'
 
-      if (opts.jsxRuntime === 'classic') {
-        config.logger.warnOnce(
-          '[@vitejs/plugin-react] Support for classic runtime is deprecated.',
-        )
-      }
       if ('jsxPure' in opts) {
         config.logger.warnOnce(
           '[@vitejs/plugin-react] jsxPure was removed. You can configure esbuild.jsxSideEffects directly.',

--- a/playground/react-classic/App.jsx
+++ b/playground/react-classic/App.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import React, { useState } from 'react'
 
 function App() {
   const [count, setCount] = useState(0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,13 +63,11 @@ importers:
       '@babel/core': ^7.21.4
       '@babel/plugin-transform-react-jsx-self': ^7.21.0
       '@babel/plugin-transform-react-jsx-source': ^7.19.6
-      magic-string: ^0.30.0
       react-refresh: ^0.14.0
     dependencies:
       '@babel/core': 7.21.4
       '@babel/plugin-transform-react-jsx-self': 7.21.0_@babel+core@7.21.4
       '@babel/plugin-transform-react-jsx-source': 7.19.6_@babel+core@7.21.4
-      magic-string: 0.30.0
       react-refresh: 0.14.0
 
   playground:
@@ -4120,6 +4118,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.14
+    dev: true
 
   /map-obj/1.0.1:
     resolution: {integrity: sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==}


### PR DESCRIPTION
fix #149

I'm removing the deprecation because I don't think keeping the classic runtime wihtout this hacky "feature" is an issue