### PR TITLE
fix(plugin-react): import react-refresh babel with full path

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -174,7 +174,7 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
             : importReactRE.test(code)))
       if (useFastRefresh) {
         plugins.push([
-          await loadPlugin('react-refresh/babel'),
+          await loadPlugin('react-refresh/babel.js'),
           { skipEnvCheck: true },
         ])
       }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

In a few cases where the plugin is being imported from a ESM MJS environment the import for `react-refresh` fails. The reason for that is that ESM NodeJS doesn't accept bare extensions imports, the full path is needed.

Because this package distributes a `.mjs` version of the plugin, we should comply with this rule from ESM nodejs 

Specifying the full path with extensions shouldn't be a problem with CJS, and only impact codes that is already setup as MJS.

### Additional context

One such error was found by me while migrating a project from Storybook v6 webpack to Storybook v7 Vite. I don't have the full reason why the `.mjs` distributed file was pick up, but manually patching the import to `react-refresh/babel.js` fixes the issue.

Screenshot of the Storybook error:
![image](https://github.com/vitejs/vite-plugin-react/assets/5845160/ae79d236-2212-4e03-a1a8-fd0e9f8dc26c)


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite-plugin-react/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
