### PR TITLE
feat: vitest deps.experimentalOptimizer

### DIFF
--- a/packages/plugin-react/CHANGELOG.md
+++ b/packages/plugin-react/CHANGELOG.md
@@ -1,4 +1,8 @@
+# Changelog
+
 ## Unreleased
+
+- Support [Vitest deps.experimentalOptimizer](https://vitest.dev/config/#deps-experimentaloptimizer)
 
 ## 4.0.0 (2023-04-20)
 

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -125,7 +125,10 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
       devBase = config.base
       projectRoot = config.root
       isProduction = config.isProduction
-      skipFastRefresh = isProduction || config.command === 'build'
+      skipFastRefresh =
+        isProduction ||
+        config.command === 'build' ||
+        (!!process.env.TEST && !process.env.VITE_TEST_HMR)
 
       if ('jsxPure' in opts) {
         config.logger.warnOnce(

--- a/playground/vitestGlobalSetup.ts
+++ b/playground/vitestGlobalSetup.ts
@@ -9,6 +9,7 @@ const DIR = path.join(os.tmpdir(), 'vitest_playwright_global_setup')
 let browserServer: BrowserServer | undefined
 
 export async function setup(): Promise<void> {
+  process.env.VITE_TEST_HMR = 'true' // To force HMR transformation in test environment
   process.env.NODE_ENV = process.env.VITE_TEST_BUILD
     ? 'production'
     : 'development'


### PR DESCRIPTION
So actually this change is less safer than I though because it can break people using testing Vite HMR like @brillout.

I will merge this now and see the result in ecosystem CI tomorrow. My current idea is that this is rare and asking few framework authors to set this variable is ok.

Another more long term fix could be for vitest to add a flag in the transform call (like `ssr`) so that plugin can adapt more properly to this case.

Related PR in the [SWC plugin](https://github.com/vitejs/vite-plugin-react-swc/pull/115). Original issue: https://github.com/vitejs/vite-plugin-react-swc/issues/111