### PR TITLE
fix: disable hot reloading if in a WebWorker

### DIFF
--- a/packages/plugin-react/src/fast-refresh.ts
+++ b/packages/plugin-react/src/fast-refresh.ts
@@ -31,10 +31,11 @@ window.__vite_plugin_react_preamble_installed__ = true
 const header = `
 import RefreshRuntime from "${runtimePublicPath}";
 
+const inWebWorker = typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope;
 let prevRefreshReg;
 let prevRefreshSig;
 
-if (import.meta.hot) {
+if (import.meta.hot && !inWebWorker) {
   if (!window.__vite_plugin_react_preamble_installed__) {
     throw new Error(
       "@vitejs/plugin-react can't detect preamble. Something is wrong. " +

--- a/packages/plugin-react/src/fast-refresh.ts
+++ b/packages/plugin-react/src/fast-refresh.ts
@@ -52,7 +52,7 @@ if (import.meta.hot && !inWebWorker) {
 }`.replace(/\n+/g, '')
 
 const footer = `
-if (import.meta.hot) {
+if (import.meta.hot && !inWebWorker) {
   window.$RefreshReg$ = prevRefreshReg;
   window.$RefreshSig$ = prevRefreshSig;
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Related to issue #152  If React is used in a WebWorker (for instance when using a web worker to render static HTML), `plugin-react` will error because of the use of `window`, which is unavailable in WebWorkers. This patch disables hot reloading when in a WebWorker, which will hopefully prevent the crashes.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite-plugin-react/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
