### PR TITLE
fix: fix fast-refresh for files that are transformed into jsx

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,9 +117,9 @@ To use breakpoints and explore code execution, you can use the ["Run and Debug"]
 
 Some errors are masked and hidden away because of the layers of abstraction and sandboxed nature added by Vitest, Playwright, and Chromium. In order to see what's actually going wrong and the contents of the devtools console in those instances, follow this setup:
 
-1. Add a `debugger` statement to the `playground/vitestSetup.ts` -> `afterAll` hook. This will pause execution before the tests quit and the Playwright browser instance exits.
+1. Add a `debugger` statement to the `playground/vitestSetup.ts` -> `afterAll` hook. This will pause execution before the tests quit and the Playwright browser instance exits. You can also add `debugger` statements in your tests (`.spec.ts`) files.
 
-2. Run the tests with the `debug-serve` script command, which will enable remote debugging: `pnpm run debug-serve react-sourcemap`.
+2. Run the tests with the `debug-serve` script command, which will enable remote debugging: `pnpm run debug-serve react-sourcemap`. Remember to run this command within the **"JavaScript Debug Terminal"** of VS Code.
 
 3. Wait for inspector devtools to open in your browser and the debugger to attach.
 

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -173,8 +173,8 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
         !ssr &&
         (isJSX ||
           (opts.jsxRuntime === 'classic'
-            ? code.includes(devRuntime)
-            : importReactRE.test(code)))
+            ? importReactRE.test(code)
+            : code.includes(devRuntime)))
       if (useFastRefresh) {
         plugins.push([
           await loadPlugin('react-refresh/babel'),

--- a/playground/mdx/__tests__/mdx.spec.ts
+++ b/playground/mdx/__tests__/mdx.spec.ts
@@ -11,6 +11,12 @@ test('should render', async () => {
   expect(await page.textContent('h1')).toMatch('Vite + MDX')
 })
 
+test('.md extension should work', async () => {
+  expect(await page.getByText('.md extension works.').textContent()).toEqual(
+    '.md extension works. This is bold text.',
+  )
+})
+
 if (isServe) {
   test('should hmr', async () => {
     editFile('src/demo.mdx', (code) => code.replace('Vite + MDX', 'Updated'))
@@ -19,5 +25,19 @@ if (isServe) {
       '[vite] hot updated: /src/demo.mdx',
     )
     await untilUpdated(() => page.textContent('h1'), 'Updated')
+  })
+
+  test('should hmr with .md extension', async () => {
+    await untilBrowserLogAfter(
+      () =>
+        editFile('src/demo2.md', (code) =>
+          code.replace('`.md` extension works.', '`.md` extension hmr works.'),
+        ),
+      '[vite] hot updated: /src/demo2.md',
+    )
+    await untilUpdated(
+      () => page.getByText('.md extension hmr works.').textContent(),
+      '.md extension hmr works. This is bold text.',
+    )
   })
 }

--- a/playground/mdx/src/demo2.md
+++ b/playground/mdx/src/demo2.md
@@ -1,0 +1,3 @@
+## test md extension
+
+`.md` extension works. This is **bold text**.

--- a/playground/mdx/src/main.tsx
+++ b/playground/mdx/src/main.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import Demo from './demo.mdx'
+import Demo2 from './demo2.md'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <Demo />
+    <Demo2 />
   </React.StrictMode>,
 )

--- a/playground/mdx/src/vite-env.d.ts
+++ b/playground/mdx/src/vite-env.d.ts
@@ -4,3 +4,8 @@ declare module '*.mdx' {
   import { JSX } from 'react'
   export default () => JSX.Element
 }
+
+declare module '*.md' {
+  import { JSX } from 'react'
+  export default () => JSX.Element
+}

--- a/playground/mdx/vite.config.ts
+++ b/playground/mdx/vite.config.ts
@@ -6,6 +6,6 @@ import mdx from '@mdx-js/rollup'
 export default defineConfig({
   plugins: [
     { enforce: 'pre', ...mdx() },
-    react({ include: /\.(mdx|ts|tsx)$/ }),
+    react({ include: /\.(mdx|md|ts|tsx)$/ }),
   ],
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Previous [useFastRefresh check](https://github.com/vitejs/vite-plugin-react/blob/f8bfc8d45b5a815ae94f9934018b740e5f5cf4e2/packages/plugin-react/src/index.ts#L176) is wrong. It causes fast-refresh not working for files with extension such as `.md`. Checkout the updated playground and the test as a demo.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

The first commit update the test that fails and demonstrates the issue. The second commit fix the issue and make the test pass.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite-plugin-react/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
