### PR TITLE
revert: throw when refresh runtime is loaded twice (#108) (fixes #193)

### DIFF
--- a/packages/plugin-react/CHANGELOG.md
+++ b/packages/plugin-react/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Revert [#108](https://github.com/vitejs/vite-plugin-react/pull/108): Remove throw when refresh runtime is loaded twice to enable usage in micro frontend apps. This was added to help fix setup usage, and this is not worth an annoying warning for others or a config parameter.
+
 ## 4.0.2 (2023-07-06)
 
 - Fix fast-refresh for files that are transformed into jsx ([#188](https://github.com/vitejs/vite-plugin-react/pull/188))

--- a/packages/plugin-react/src/refreshUtils.js
+++ b/packages/plugin-react/src/refreshUtils.js
@@ -1,13 +1,3 @@
-/* eslint-disable no-undef */
-if (typeof window !== 'undefined') {
-  if (window.__vite_plugin_react_runtime_loaded__) {
-    throw new Error(
-      'React refresh runtime was loaded twice. Maybe you forgot the base path?',
-    )
-  }
-  window.__vite_plugin_react_runtime_loaded__ = true
-}
-
 function debounce(fn, delay) {
   let handle
   return () => {
@@ -16,6 +6,7 @@ function debounce(fn, delay) {
   }
 }
 
+/* eslint-disable no-undef */
 const enqueueUpdate = debounce(exports.performReactRefresh, 16)
 
 // Taken from https://github.com/pmmmwh/react-refresh-webpack-plugin/blob/main/lib/runtime/RefreshUtils.js#L141


### PR DESCRIPTION
Fixes #193

Revert [#108](https://github.com/vitejs/vite-plugin-react/pull/108): Remove throw when refresh runtime is loaded twice to enable usage in micro frontend apps. This was added to help fix setup usage, and this is not worth an annoying warning for others or a config parameter.