### PR TITLE
perf: lazy load `@babel/core`

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -1,5 +1,7 @@
+// eslint-disable-next-line import/no-duplicates
+import type * as babelCore from '@babel/core'
+// eslint-disable-next-line import/no-duplicates
 import type { ParserOptions, TransformOptions } from '@babel/core'
-import * as babel from '@babel/core'
 import { createFilter } from 'vite'
 import type {
   BuildOptions,
@@ -14,6 +16,15 @@ import {
   runtimeCode,
   runtimePublicPath,
 } from './fast-refresh'
+
+// lazy load babel since it's not used during build if plugins are not used
+let babel: typeof babelCore | undefined
+async function loadBabel() {
+  if (!babel) {
+    babel = await import('@babel/core')
+  }
+  return babel
+}
 
 export interface Options {
   include?: string | RegExp | Array<string | RegExp>
@@ -215,6 +226,7 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
         parserPlugins.push('typescript')
       }
 
+      const babel = await loadBabel()
       const result = await babel.transformAsync(code, {
         ...babelOptions,
         root: projectRoot,


### PR DESCRIPTION
### Description
Importing `@babel/core` takes ~300ms on my machine. `@babel/core` won't be used during build if no plugins are added.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite-plugin-react/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
