### PR TITLE
chore: add Vite 5 to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "tsx": "^3.12.7",
     "typescript": "^5.1.6",
     "unbuild": "^1.2.1",
-    "vite": "^4.4.8",
+    "vite": "^5.0.0-beta.1",
     "vitest": "^0.34.1"
   },
   "simple-git-hooks": {

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -46,6 +46,6 @@
     "react-refresh": "^0.14.0"
   },
   "peerDependencies": {
-    "vite": "^4.2.0"
+    "vite": "^4.2.0 || ^5.0.0-beta.0 || ^5.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: false
@@ -6026,4 +6026,5 @@ packages:
   file:playground/react/jsx-entry:
     resolution: {directory: playground/react/jsx-entry, type: directory}
     name: jsx-entry
+    version: 0.0.0
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,8 +72,8 @@ importers:
         specifier: ^1.2.1
         version: 1.2.1
       vite:
-        specifier: ^4.4.8
-        version: 4.4.8(@types/node@18.17.3)
+        specifier: ^5.0.0-beta.1
+        version: 5.0.0-beta.1(@types/node@18.17.3)
       vitest:
         specifier: ^0.34.1
         version: 0.34.1
@@ -5071,6 +5071,14 @@ packages:
       fsevents: 2.3.2
     dev: true
 
+  /rollup@3.29.1:
+    resolution: {integrity: sha512-c+ebvQz0VIH4KhhCpDsI+Bik0eT8ZFEVZEYw0cGMVqIP8zc+gnwl7iXCamTw7vzv2MeuZFZfdx5JJIq+ehzDlg==}
+    engines: {node: '>=14.18.0', npm: '>=8.0.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
   /run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
@@ -5860,7 +5868,43 @@ packages:
       '@types/node': 18.17.3
       esbuild: 0.18.17
       postcss: 8.4.27
-      rollup: 3.27.2
+      rollup: 3.29.1
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /vite@5.0.0-beta.1(@types/node@18.17.3):
+    resolution: {integrity: sha512-3e7DWCaxrLyIE7aP4Lfs38yPnIQxFyC8IraY1AhM3/ngPhtPA2tT+0Yi21SPa7mnpC0daMTygffr39cVHZVSKw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 18.17.3
+      esbuild: 0.18.17
+      postcss: 8.4.27
+      rollup: 3.29.1
     optionalDependencies:
       fsevents: 2.3.2
     dev: true


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes https://github.com/vitejs/vite-plugin-react/issues/218 by adding vite 5 and 5 beta to the `peerDependencies` range.

Updates the dev version to 5.0.0-beta.1

### Additional context

I don't really know if there are changes needed here to support Vite 5, but it doesn't seem so.
---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite-plugin-react/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [] Ideally, include relevant tests that fail without this PR but pass with it.
