### PR TITLE
feat: add support for non-dev jsx runtime

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -98,7 +98,9 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
   // Provide default values for Rollup compat.
   let devBase = '/'
   const filter = createFilter(opts.include ?? defaultIncludeRE, opts.exclude)
-  const devRuntime = `${opts.jsxImportSource ?? 'react'}/jsx-dev-runtime`
+  const jsxImportSource = opts.jsxImportSource ?? 'react'
+  const jsxImportRuntime = `${jsxImportSource}/jsx-runtime`
+  const jsxImportDevRuntime = `${jsxImportSource}/jsx-dev-runtime`
   let isProduction = true
   let projectRoot = process.cwd()
   let skipFastRefresh = false
@@ -188,7 +190,8 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
         (isJSX ||
           (opts.jsxRuntime === 'classic'
             ? importReactRE.test(code)
-            : code.includes(devRuntime)))
+            : code.includes(jsxImportDevRuntime) ||
+              code.includes(jsxImportRuntime)))
       if (useFastRefresh) {
         plugins.push([
           await loadPlugin('react-refresh/babel'),
@@ -265,7 +268,7 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
         // We can't add `react-dom` because the dependency is `react-dom/client`
         // for React 18 while it's `react-dom` for React 17. We'd need to detect
         // what React version the user has installed.
-        include: ['react', devRuntime],
+        include: ['react', jsxImportDevRuntime, jsxImportRuntime],
       },
       resolve: {
         dedupe: ['react', 'react-dom'],

--- a/playground/react/App.jsx
+++ b/playground/react/App.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import Button from 'jsx-entry'
 import Dummy from './components/Dummy?qs-should-not-break-plugin-react'
 import Parent from './hmr/parent'
+import { JsxImportRuntime } from './hmr/jsx-import-runtime'
 import { CountProvider } from './context/CountProvider'
 import { ContextButton } from './context/ContextButton'
 
@@ -37,6 +38,7 @@ function App() {
 
       <Dummy />
       <Parent />
+      <JsxImportRuntime />
       <Button>button</Button>
     </div>
   )

--- a/playground/react/__tests__/react.spec.ts
+++ b/playground/react/__tests__/react.spec.ts
@@ -115,4 +115,27 @@ if (!isBuild) {
       'context provider updated',
     )
   })
+
+  test('should hmr files with "react/jsx-runtime"', async () => {
+    expect(await page.textContent('#state-button')).toMatch('count is: 0')
+    await page.click('#state-button')
+    expect(await page.textContent('#state-button')).toMatch('count is: 1')
+
+    await untilBrowserLogAfter(
+      () =>
+        editFile('hmr/jsx-import-runtime.js', (code) =>
+          code.replace(
+            'JSX import runtime works',
+            'JSX import runtime updated',
+          ),
+        ),
+      ['[vite] hot updated: /hmr/jsx-import-runtime.js'],
+    )
+    await untilUpdated(
+      () => page.textContent('#jsx-import-runtime'),
+      'JSX import runtime updated',
+    )
+
+    expect(await page.textContent('#state-button')).toMatch('count is: 1')
+  })
 }

--- a/playground/react/hmr/jsx-import-runtime.js
+++ b/playground/react/hmr/jsx-import-runtime.js
@@ -1,0 +1,8 @@
+import * as JsxRuntime from 'react/jsx-runtime'
+
+export function JsxImportRuntime() {
+  return JsxRuntime.jsx('p', {
+    id: 'jsx-import-runtime',
+    children: 'JSX import runtime works',
+  })
+}


### PR DESCRIPTION
### Description

I stumble across an issue where the *Fast Refresh* feature doesn't work with [a Vite plugin](https://github.com/jihchi/vite-plugin-rescript) I'm maintaining. After examination, I identified the root cause: The generated code with `.js` extension uses `react/jsx-runtime` for JSX transformation instead of `react/jsx-dev-runtime`, because of this, the generated code is no longer eligible for applying Fest Refresh, which results in a full page reloaded.

<details> <summary>Here is a JS file generated by the compiler, for example (click to expand)</summary>

Filename: `Res.bs.js`

```js
// Generated by ReScript, PLEASE EDIT WITH CARE

import * as JsxRuntime from "react/jsx-runtime";

function Res(props) {
  return JsxRuntime.jsx("h3", {
    children: "ReScript Component",
    className: "text-blue-100",
  });
}

var make = Res;

export { make };
/* react/jsx-runtime Not a pure module */
```
</details>

In order to fix it, this PR adds an extra check for such case so that the Fast Refresh works as expected.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite-plugin-react/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
