### PR TITLE
fix: file extension could be mocked/overridden in querystring

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -167,7 +167,7 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
     async transform(code, id, options) {
       if (id.includes('/node_modules/')) return
 
-      const [filepath] = id.split('?')
+      const [filepath] = id.split(/\?|#/)
       if (!filter(filepath)) return
 
       const ssr = options?.ssr === true


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
The file extension can be mocked or overridden using the query string in the fragment identifier ("#").
When the import path contains "#jsx", it indicates that the module will be treated as a JSX module.

![image](https://github.com/ant-design/ant-design/assets/134256421/b79c3608-7154-4191-86e3-409dba04493f)


> When importing modules, some common query symbols that can be used without affecting the import itself include:
?: Used to add a query string parameter. For example: import module from './module.tsx?key=value'.
#: Used to add a fragment identifier, which specifies a specific fragment when importing. This is often used when importing CSS stylesheets. For example: import './styles.css#section1'.
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite-plugin-react/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
