### PR TITLE
fix: enable retainLines to get correct line numbers for jsxDev

### DIFF
--- a/packages/plugin-react/CHANGELOG.md
+++ b/packages/plugin-react/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Enable retainLines to get correct line numbers for jsxDev (fix [#235](https://github.com/vitejs/vite-plugin-react/issues/235))
+
 ## 4.1.0 (2023-09-24)
 
 - Add `@types/babel__cores` to dependencies (fix [#211](https://github.com/vitejs/vite-plugin-react/issues/211))

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -235,6 +235,8 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
         root: projectRoot,
         filename: id,
         sourceFileName: filepath,
+        // Required for esbuild.jsxDev to provide correct line numbers
+        retainLines: !isProduction && isJSX && opts.jsxRuntime !== 'classic',
         parserOpts: {
           ...babelOptions.parserOpts,
           sourceType: 'module',


### PR DESCRIPTION
Fix #235

I did some benchmarking and using retainLines has no impact on transformation time, but using the babel JSX transform plugin slowdown by around 40% the pipeline. I think this fix is a good trade off and avoid to break other plugins that now rely on the JSX transformation to be done at the esbuild step.