### PR TITLE
feat: update peer dep for vite 5

### DIFF
--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -45,6 +45,6 @@
     "react-refresh": "^0.14.0"
   },
   "peerDependencies": {
-    "vite": "^4.2.0"
+    "vite": "^4.2.0 || ^5.0.0"
   }
 }


### PR DESCRIPTION
Relax peer dep to cover Vite 5. Keeping the dev dependencies as v4 for now, depends on how we want to support Vite 5 later.

Fixes #218
