### PR TITLE
fix(ssr-react): remove `context` from `render`

### DIFF
--- a/playground/ssr-react/prerender.js
+++ b/playground/ssr-react/prerender.js
@@ -22,8 +22,7 @@ const routesToPrerender = fs
 ;(async () => {
   // pre-render each route...
   for (const url of routesToPrerender) {
-    const context = {}
-    const appHtml = await render(url, context)
+    const appHtml = await render(url)
 
     const html = template.replace(`<!--app-html-->`, appHtml)
 

--- a/playground/ssr-react/server.js
+++ b/playground/ssr-react/server.js
@@ -73,13 +73,7 @@ export async function createServer(
         render = (await import('./dist/server/entry-server.js')).render
       }
 
-      const context = {}
-      const appHtml = render(url, context)
-
-      if (context.url) {
-        // Somewhere a `<Redirect>` was rendered
-        return res.redirect(301, context.url)
-      }
+      const appHtml = render(url)
 
       const html = template.replace(`<!--app-html-->`, appHtml)
 

--- a/playground/ssr-react/src/entry-server.jsx
+++ b/playground/ssr-react/src/entry-server.jsx
@@ -2,9 +2,9 @@ import ReactDOMServer from 'react-dom/server'
 import { StaticRouter } from 'react-router-dom/server'
 import { App } from './App'
 
-export function render(url, context) {
+export function render(url) {
   return ReactDOMServer.renderToString(
-    <StaticRouter location={url} context={context}>
+    <StaticRouter location={url}>
       <App />
     </StaticRouter>,
   )


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

closes #227 

The example seems not to be using "Data Router". In that case, we [only provide `location` without `context`](https://reactrouter.com/en/main/guides/ssr#without-a-data-router) to  `<StaticRouter />`. Therefore, I just removed `context` out of the files regarding it.

If it needs an example with "Data Router", I can add one. However, since `react-router` uses `vite`, I don't think the example won't be so much different than the [`react-router` one](https://github.com/remix-run/react-router/tree/dev/examples/ssr-data-router).

So the bottom line is:

1. I have fixed the playground example
2. I think ssr with vite is better explained in `react-router`'s repository

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

I would like to add some tests around RSC, however because `react-router` only support `loader` pattern of `remix`, not the RSC, it won't be easy.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite-plugin-react/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
