### PR TITLE
fix: define stubs for react-refresh in Web Worker

### DIFF
--- a/packages/plugin-react/src/fast-refresh.ts
+++ b/packages/plugin-react/src/fast-refresh.ts
@@ -35,20 +35,25 @@ const inWebWorker = typeof WorkerGlobalScope !== 'undefined' && self instanceof 
 let prevRefreshReg;
 let prevRefreshSig;
 
-if (import.meta.hot && !inWebWorker) {
-  if (!window.__vite_plugin_react_preamble_installed__) {
-    throw new Error(
-      "@vitejs/plugin-react can't detect preamble. Something is wrong. " +
-      "See https://github.com/vitejs/vite-plugin-react/pull/11#discussion_r430879201"
-    );
-  }
+if (import.meta.hot) {
+  if (inWebWorker) {
+    globalThis.$RefreshReg$ = () => {};
+    globalThis.$RefreshSig$ = () => (type) => type;
+  } else {
+    if (!window.__vite_plugin_react_preamble_installed__) {
+      throw new Error(
+        "@vitejs/plugin-react can't detect preamble. Something is wrong. " +
+        "See https://github.com/vitejs/vite-plugin-react/pull/11#discussion_r430879201"
+      );
+    }
 
-  prevRefreshReg = window.$RefreshReg$;
-  prevRefreshSig = window.$RefreshSig$;
-  window.$RefreshReg$ = (type, id) => {
-    RefreshRuntime.register(type, __SOURCE__ + " " + id)
-  };
-  window.$RefreshSig$ = RefreshRuntime.createSignatureFunctionForTransform;
+    prevRefreshReg = window.$RefreshReg$;
+    prevRefreshSig = window.$RefreshSig$;
+    window.$RefreshReg$ = (type, id) => {
+      RefreshRuntime.register(type, __SOURCE__ + " " + id)
+    };
+    window.$RefreshSig$ = RefreshRuntime.createSignatureFunctionForTransform;
+  }
 }`.replace(/\n+/g, '')
 
 const footer = `


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR fixes the issue below and improves #181.
Also the issue is mentioned in https://github.com/vitejs/vite/issues/5396#issuecomment-2050127910

Define some stubs in Web Worker which is required by react-refresh to avoid the error: `Uncaught ReferenceError: $RefreshReg$ is not defined`.

#### Issue

First, create Worker.tsx with the following content

```tsx
function Worker() {
  return <></>;
}
```

Then, load Worker.tsx from App.tsx

```tsx
const worker = new Worker(new URL("./Worker.tsx", import.meta.url), {
  type: "module",
});
```

In that case, we got the error below

```
Uncaught ReferenceError: $RefreshReg$ is not defined
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

To avoid this error, @react-three/offscreen package, which renders React Three Fiber to OffscreenCanvas, shows the workaround to downgrade vite-plugin-react and disable all HMR.
This provides bad development experiences, so I hope that a new version will be released soon.

Reference:
https://github.com/pmndrs/react-three-offscreen?tab=readme-ov-file#vite


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite-plugin-react/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
