### PR TITLE
test: test SSR after HMR

### DIFF
--- a/playground/ssr-react/__tests__/ssr-react.spec.ts
+++ b/playground/ssr-react/__tests__/ssr-react.spec.ts
@@ -52,10 +52,15 @@ test('/', async () => {
 test('hmr', async () => {
   await untilBrowserLogAfter(() => page.goto(url), 'hydrated')
 
+  await untilUpdated(() => page.textContent('h1'), 'Home')
   editFile('src/pages/Home.jsx', (code) =>
     code.replace('<h1>Home', '<h1>changed'),
   )
   await untilUpdated(() => page.textContent('h1'), 'changed')
+
+  // verify the change also affects next SSR
+  const res = await page.reload()
+  expect(await res?.text()).toContain('<h1>changed')
 })
 
 test('client navigation', async () => {

--- a/playground/ssr-react/__tests__/ssr-react.spec.ts
+++ b/playground/ssr-react/__tests__/ssr-react.spec.ts
@@ -4,6 +4,7 @@ import { port } from './serve'
 import {
   browserLogs,
   editFile,
+  isBuild,
   page,
   untilBrowserLogAfter,
   untilUpdated,
@@ -49,7 +50,7 @@ test('/', async () => {
   expect(html).toMatch('Home')
 })
 
-test('hmr', async () => {
+test.skipIf(isBuild)('hmr', async () => {
   await untilBrowserLogAfter(() => page.goto(url), 'hydrated')
 
   await untilUpdated(() => page.textContent('h1'), 'Home')

--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["*.ts", "**/__test/*.ts", "**/vite.config.ts"],
+  "include": ["*.ts", "**/__tests__/*.ts", "**/vite.config.ts"],
   "exclude": ["**/dist/**"],
   "compilerOptions": {
     "target": "ES2020",

--- a/playground/vitest.config.e2e.ts
+++ b/playground/vitest.config.e2e.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'node:path'
 import { defineConfig } from 'vitest/config'
 
-const timeout = process.env.CI ? 20_000 : 5_000
+const timeout = process.env.PWDEBUG ? Infinity : process.env.CI ? 20_000 : 5_000
 
 export default defineConfig({
   resolve: {


### PR DESCRIPTION
### Description

I added a test to check `ssrLoadModule` correctly reflects the same change as client HMR. I verified this fails on `6.0.0-alpha.17` but passes on v5. cc @patak-dev @sheremet-va 

Technically this is purely a `ssrLoadModule` concern (probably I can write a similar failing test without React), but I think it's still nice to test it in the context of React SSR (for example, on RSC framework, it also requires framework side code to make sure server side module is invalidated correctly on top of `ssrLoadModule` or new module runner).

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite-plugin-react/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
