### PR TITLE
feat: add `async` option for streaming

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -47,6 +47,11 @@ export interface Options {
   babel?:
     | BabelOptions
     | ((id: string, options: { ssr?: boolean }) => BabelOptions)
+  /**
+   * Script to run as `async`
+   * We need this for streaming, otherwise script runs once streaming has finished
+   */
+  async?: boolean
 }
 
 export type BabelOptions = Omit<
@@ -305,7 +310,7 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
         return [
           {
             tag: 'script',
-            attrs: { type: 'module' },
+            attrs: { type: 'module', async: !!opts.async },
             children: preambleCode.replace(`__BASE__`, devBase),
           },
         ]


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Add `async` to options, so that the script will be executed as soon as it is available.
This allows our the client code to run ASAP, while the document is streaming.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite-plugin-react/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
