### PR TITLE
fix: add `react-dom` in `optimizeOps` to handle CJS script.

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -268,10 +268,12 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
     },
   }
 
-  // We can't add `react-dom` because the dependency is `react-dom/client`
-  // for React 18 while it's `react-dom` for React 17. We'd need to detect
-  // what React version the user has installed.
-  const dependencies = ['react', jsxImportDevRuntime, jsxImportRuntime]
+  const dependencies = [
+    'react',
+    'react-dom',
+    jsxImportDevRuntime,
+    jsxImportRuntime,
+  ]
   const staticBabelPlugins =
     typeof opts.babel === 'object' ? opts.babel?.plugins ?? [] : []
   if (hasCompilerWithDefaultRuntime(staticBabelPlugins)) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The inclusion of `react` introduced in [vite#9056](https://github.com/vitejs/vite/pull/9056) but not for `react-dom`. Since `react-dom` is a standalone package even in React 18, we should include it without problems to have consistent behavior.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
By merging this commit, CJS format js files like [react-dom/client.js](https://github.com/facebook/react/blob/main/packages/react-dom/npm/client.js) and [react-dom/index.js](https://github.com/facebook/react/blob/main/packages/react-dom/npm/index.js) will be enforced optimized, just like `react`'s [index.js](https://github.com/facebook/react/blob/main/packages/react/npm/index.js).

Optimization of these files will help not-well designed (import non-default exported modules `react` and `react-dom` directly) frameworks correctly import package **without developer's notice**, when using the development mode of vite, e.g. resolve [radix-ui/primitives#3114](https://github.com/radix-ui/primitives/issues/3114). More discussion of original inclusion can be seen at [vite#9052/comment](https://github.com/vitejs/vite/issues/9052#issuecomment-1182000942)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite-plugin-react/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
