### PR TITLE
feat: add `reactRefreshHost` option to support module federation HMR

### DIFF
--- a/packages/common/refresh-utils.ts
+++ b/packages/common/refresh-utils.ts
@@ -21,6 +21,7 @@ export function addRefreshWrapper<M extends { mappings: string }>(
   map: M | string | typeof avoidSourceMapOption,
   pluginName: string,
   id: string,
+  reactRefreshHost = '',
 ): { code: string; map: M | null | string } {
   const hasRefresh = refreshContentRE.test(code)
   const onlyReactComp = !hasRefresh && reactCompRE.test(code)
@@ -70,7 +71,8 @@ if (import.meta.hot && !inWebWorker) {
   }
 
   const sharedHead = removeLineBreaksIfNeeded(
-    `import * as RefreshRuntime from "${runtimePublicPath}";
+    `import * as RefreshRuntime from "${reactRefreshHost}${runtimePublicPath}";
+
 const inWebWorker = typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope;
 
 `,

--- a/packages/common/refresh-utils.ts
+++ b/packages/common/refresh-utils.ts
@@ -72,7 +72,6 @@ if (import.meta.hot && !inWebWorker) {
 
   const sharedHead = removeLineBreaksIfNeeded(
     `import * as RefreshRuntime from "${reactRefreshHost}${runtimePublicPath}";
-
 const inWebWorker = typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope;
 
 `,

--- a/packages/plugin-react-swc/CHANGELOG.md
+++ b/packages/plugin-react-swc/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Add option `reactRefreshHost`
+
+Add option `reactRefreshHost` to set React refresh runtime url prefix.
+This is useful in module federation context to enable HMR by setting the host url on a Vite config which is serving a remote app.
+See full discussion here: https://github.com/module-federation/vite/issues/183#issuecomment-2751825367
+
+```ts
+export default defineConfig({
+  plugins: [react({ reactRefreshHost: 'http://localhost:3000' })],
+})
+```
+
 ## 3.9.0-beta.2 (2025-04-09)
 
 ## 3.9.0-beta.0 (2025-04-09)

--- a/packages/plugin-react-swc/CHANGELOG.md
+++ b/packages/plugin-react-swc/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Add `reactRefreshHost` option
 
 Add `reactRefreshHost` option to set a React Fast Refresh runtime URL prefix.
-This is useful in a module federation context to enable HMR by specifying the host application URL in the vite config of a remote application.
+This is useful in a module federation context to enable HMR by specifying the host application URL in the Vite config of a remote application.
 See full discussion here: https://github.com/module-federation/vite/issues/183#issuecomment-2751825367
 
 ```ts

--- a/packages/plugin-react-swc/CHANGELOG.md
+++ b/packages/plugin-react-swc/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## Unreleased
 
-### Add option `reactRefreshHost`
+### Add `reactRefreshHost` option
 
-Add option `reactRefreshHost` to set React refresh runtime url prefix.
-This is useful in module federation context to enable HMR by setting the host url on a Vite config which is serving a remote app.
+Add `reactRefreshHost` option to set a React Fast Refresh runtime URL prefix.
+This is useful in a module federation context to enable HMR by specifying the host application URL in the vite config of a remote application.
 See full discussion here: https://github.com/module-federation/vite/issues/183#issuecomment-2751825367
 
 ```ts

--- a/packages/plugin-react-swc/README.md
+++ b/packages/plugin-react-swc/README.md
@@ -93,6 +93,16 @@ react({
 })
 ```
 
+### reactRefreshHost
+
+The `reactRefreshHost` option is only necessary in a module federation context. It allows HMR to work between a remote & host server. In your remote vite config you would add your host origin:
+
+```js
+react({ reactRefreshHost: 'http://localhost:3000' })
+```
+
+Under the hood this simply updates the react refresh url from "/@react-refresh" to "http://localhost:3000/@react-refresh" to ensure you get only one Fast Refresh runtime in the whole application.
+
 ### useAtYourOwnRisk_mutateSwcOptions
 
 The future of Vite is with OXC, and from the beginning this was a design choice to not exposed too many specialties from SWC so that Vite React users can move to another transformer later.

--- a/packages/plugin-react-swc/README.md
+++ b/packages/plugin-react-swc/README.md
@@ -95,7 +95,7 @@ react({
 
 ### reactRefreshHost
 
-The `reactRefreshHost` option is only necessary in a module federation context. It enables HMR to work between a remote & host application. In your remote vite config, you would add your host origin:
+The `reactRefreshHost` option is only necessary in a module federation context. It enables HMR to work between a remote & host application. In your remote Vite config, you would add your host origin:
 
 ```js
 react({ reactRefreshHost: 'http://localhost:3000' })

--- a/packages/plugin-react-swc/README.md
+++ b/packages/plugin-react-swc/README.md
@@ -95,13 +95,13 @@ react({
 
 ### reactRefreshHost
 
-The `reactRefreshHost` option is only necessary in a module federation context. It allows HMR to work between a remote & host server. In your remote vite config you would add your host origin:
+The `reactRefreshHost` option is only necessary in a module federation context. It enables HMR to work between a remote & host application. In your remote vite config, you would add your host origin:
 
 ```js
 react({ reactRefreshHost: 'http://localhost:3000' })
 ```
 
-Under the hood this simply updates the react refresh url from "/@react-refresh" to "http://localhost:3000/@react-refresh" to ensure you get only one Fast Refresh runtime in the whole application. Note that if you define `base` you need to include that in the url provided like: `http://localhost:3000/{base}`.
+Under the hood, this simply updates the React Fash Refresh runtime URL from `/@react-refresh` to `http://localhost:3000/@react-refresh` to ensure there is only one Refresh runtime across the whole application. Note that if you define `base` option in the host application, you need to include it in the option, like: `http://localhost:3000/{base}`.
 
 ### useAtYourOwnRisk_mutateSwcOptions
 

--- a/packages/plugin-react-swc/README.md
+++ b/packages/plugin-react-swc/README.md
@@ -101,7 +101,7 @@ The `reactRefreshHost` option is only necessary in a module federation context. 
 react({ reactRefreshHost: 'http://localhost:3000' })
 ```
 
-Under the hood this simply updates the react refresh url from "/@react-refresh" to "http://localhost:3000/@react-refresh" to ensure you get only one Fast Refresh runtime in the whole application.
+Under the hood this simply updates the react refresh url from "/@react-refresh" to "http://localhost:3000/@react-refresh" to ensure you get only one Fast Refresh runtime in the whole application. Note that if you define `base` you need to include that in the url provided like: `http://localhost:3000/{base}`.
 
 ### useAtYourOwnRisk_mutateSwcOptions
 

--- a/packages/plugin-react-swc/src/index.ts
+++ b/packages/plugin-react-swc/src/index.ts
@@ -59,6 +59,14 @@ type Options = {
    */
   parserConfig?: (id: string) => ParserConfig | undefined
   /**
+   * React refresh runtime url prefix.
+   * Useful in module federation context to enable HMR by
+   * setting the host url on a vite config which is serving a remote app.
+   * @example
+   * reactRefreshHost: 'http://localhost:3000'
+   */
+  reactRefreshHost?: string
+  /**
    * The future of Vite is with OXC, and from the beginning this was a design choice
    * to not exposed too many specialties from SWC so that Vite React users can move to
    * another transformer later.
@@ -78,6 +86,7 @@ const react = (_options?: Options): PluginOption[] => {
       : undefined,
     devTarget: _options?.devTarget ?? 'es2020',
     parserConfig: _options?.parserConfig,
+    reactRefreshHost: _options?.reactRefreshHost,
     useAtYourOwnRisk_mutateSwcOptions:
       _options?.useAtYourOwnRisk_mutateSwcOptions,
   }
@@ -152,6 +161,7 @@ const react = (_options?: Options): PluginOption[] => {
           result.map!,
           '@vitejs/plugin-react-swc',
           id,
+          options.reactRefreshHost,
         )
       },
     },

--- a/packages/plugin-react-swc/src/index.ts
+++ b/packages/plugin-react-swc/src/index.ts
@@ -59,9 +59,9 @@ type Options = {
    */
   parserConfig?: (id: string) => ParserConfig | undefined
   /**
-   * React refresh runtime url prefix.
-   * Useful in module federation context to enable HMR by
-   * setting the host url on a vite config which is serving a remote app.
+   * React Fast Refresh runtime URL prefix.
+   * Useful in a module federation context to enable HMR by specifying
+   * the host application URL in a Vite config of a remote application.
    * @example
    * reactRefreshHost: 'http://localhost:3000'
    */

--- a/packages/plugin-react/CHANGELOG.md
+++ b/packages/plugin-react/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Add option `reactRefreshHost`
+
+Add option `reactRefreshHost` to set React refresh runtime url prefix.
+This is useful in module federation context to enable HMR by setting the host url on a Vite config which is serving a remote app.
+See full discussion here: https://github.com/module-federation/vite/issues/183#issuecomment-2751825367
+
+```ts
+export default defineConfig({
+  plugins: [react({ reactRefreshHost: 'http://localhost:3000' })],
+})
+```
+
 ## 4.4.0-beta.1 (2025-04-09)
 
 ## 4.4.0-beta.0 (2025-04-09)

--- a/packages/plugin-react/CHANGELOG.md
+++ b/packages/plugin-react/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Add `reactRefreshHost` option
 
 Add `reactRefreshHost` option to set a React Fast Refresh runtime URL prefix.
-This is useful in a module federation context to enable HMR by specifying the host application URL in the vite config of a remote application.
+This is useful in a module federation context to enable HMR by specifying the host application URL in the Vite config of a remote application.
 See full discussion here: https://github.com/module-federation/vite/issues/183#issuecomment-2751825367
 
 ```ts

--- a/packages/plugin-react/CHANGELOG.md
+++ b/packages/plugin-react/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## Unreleased
 
-### Add option `reactRefreshHost`
+### Add `reactRefreshHost` option
 
-Add option `reactRefreshHost` to set React refresh runtime url prefix.
-This is useful in module federation context to enable HMR by setting the host url on a Vite config which is serving a remote app.
+Add `reactRefreshHost` option to set a React Fast Refresh runtime URL prefix.
+This is useful in a module federation context to enable HMR by specifying the host application URL in the vite config of a remote application.
 See full discussion here: https://github.com/module-federation/vite/issues/183#issuecomment-2751825367
 
 ```ts

--- a/packages/plugin-react/README.md
+++ b/packages/plugin-react/README.md
@@ -96,7 +96,7 @@ Here's the [complete list of Babel parser plugins](https://babeljs.io/docs/en/ba
 
 ### reactRefreshHost
 
-The `reactRefreshHost` option is only necessary in a module federation context. It enables HMR to work between a remote & host application. In your remote vite config, you would add your host origin:
+The `reactRefreshHost` option is only necessary in a module federation context. It enables HMR to work between a remote & host application. In your remote Vite config, you would add your host origin:
 
 ```js
 react({ reactRefreshHost: 'http://localhost:3000' })

--- a/packages/plugin-react/README.md
+++ b/packages/plugin-react/README.md
@@ -96,13 +96,13 @@ Here's the [complete list of Babel parser plugins](https://babeljs.io/docs/en/ba
 
 ### reactRefreshHost
 
-The `reactRefreshHost` option is only necessary in a module federation context. It allows HMR to work between a remote & host server. In your remote vite config you would add your host origin:
+The `reactRefreshHost` option is only necessary in a module federation context. It enables HMR to work between a remote & host application. In your remote vite config, you would add your host origin:
 
 ```js
 react({ reactRefreshHost: 'http://localhost:3000' })
 ```
 
-Under the hood this simply updates the react refresh url from "/@react-refresh" to "http://localhost:3000/@react-refresh" to ensure you get only one Fast Refresh runtime in the whole application. Note that if you define `base` you need to include that in the url provided like: `http://localhost:3000/{base}`.
+Under the hood, this simply updates the React Fash Refresh runtime URL from `/@react-refresh` to `http://localhost:3000/@react-refresh` to ensure there is only one Refresh runtime across the whole application. Note that if you define `base` option in the host application, you need to include it in the option, like: `http://localhost:3000/{base}`.
 
 ## Middleware mode
 

--- a/packages/plugin-react/README.md
+++ b/packages/plugin-react/README.md
@@ -102,7 +102,7 @@ The `reactRefreshHost` option is only necessary in a module federation context. 
 react({ reactRefreshHost: 'http://localhost:3000' })
 ```
 
-Under the hood this simply updates the react refresh url from "/@react-refresh" to "http://localhost:3000/@react-refresh" to ensure you get only one Fast Refresh runtime in the whole application.
+Under the hood this simply updates the react refresh url from "/@react-refresh" to "http://localhost:3000/@react-refresh" to ensure you get only one Fast Refresh runtime in the whole application. Note that if you define `base` you need to include that in the url provided like: `http://localhost:3000/{base}`.
 
 ## Middleware mode
 

--- a/packages/plugin-react/README.md
+++ b/packages/plugin-react/README.md
@@ -94,6 +94,16 @@ This option does not enable _code transformation_. That is handled by esbuild.
 
 Here's the [complete list of Babel parser plugins](https://babeljs.io/docs/en/babel-parser#ecmascript-proposalshttpsgithubcombabelproposals).
 
+### reactRefreshHost
+
+The `reactRefreshHost` option is only necessary in a module federation context. It allows HMR to work between a remote & host server. In your remote vite config you would add your host origin:
+
+```js
+react({ reactRefreshHost: 'http://localhost:3000' })
+```
+
+Under the hood this simply updates the react refresh url from "/@react-refresh" to "http://localhost:3000/@react-refresh" to ensure you get only one Fast Refresh runtime in the whole application.
+
 ## Middleware mode
 
 In [middleware mode](https://vite.dev/config/server-options.html#server-middlewaremode), you should make sure your entry `index.html` file is transformed by Vite. Here's an example for an Express server:

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -271,7 +271,7 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
           result.map!,
           '@vitejs/plugin-react',
           id,
-          opts.reactRefreshHost
+          opts.reactRefreshHost,
         )
       }
     },

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -50,9 +50,9 @@ export interface Options {
     | BabelOptions
     | ((id: string, options: { ssr?: boolean }) => BabelOptions)
   /**
-   * React refresh runtime url prefix.
-   * Useful in module federation context to enable HMR by
-   * setting the host url on a vite config which is serving a remote app.
+   * React Fast Refresh runtime URL prefix.
+   * Useful in a module federation context to enable HMR by specifying
+   * the host application URL in the Vite config of a remote application.
    * @example
    * reactRefreshHost: 'http://localhost:3000'
    */

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -49,6 +49,14 @@ export interface Options {
   babel?:
     | BabelOptions
     | ((id: string, options: { ssr?: boolean }) => BabelOptions)
+  /**
+   * React refresh runtime url prefix.
+   * Useful in module federation context to enable HMR by
+   * setting the host url on a vite config which is serving a remote app.
+   * @example
+   * reactRefreshHost: 'http://localhost:3000'
+   */
+  reactRefreshHost?: string
 }
 
 export type BabelOptions = Omit<
@@ -263,6 +271,7 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
           result.map!,
           '@vitejs/plugin-react',
           id,
+          opts.reactRefreshHost
         )
       }
     },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This resolves HMR not working in a module federation context when using the `@module-federation/vite` plugin.

This PR simply adds a new option `reactRefreshPrefix` in a backwards compat way to allow prefixing the react-refresh url which by default is: `/@react-refresh`

The reason this works is the following example:

1. host vite server on port 3000
2. remote vite server on port 4000
3. save file in remote server
4. react-refresh triggers on remote server port 4000 but does not propagate to the host server

Allowing dev to set prefix in the plugin will force the react-refresh plugin from remote files to point at the host react-refresh module:

```
react({ reactRefreshPrefix: 'http://localhost:3000' })
```

The react refresh url becomes `http://localhost:3000/@react-refresh`.

https://github.com/user-attachments/assets/b53a5772-5002-4924-8311-28d00969f221



<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

https://github.com/module-federation/vite/issues/183#issuecomment-2751825367

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite-plugin-react/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
