### PR TITLE
chore: fix refresh runtime path in dev

### DIFF
--- a/packages/plugin-react-oxc/build.config.ts
+++ b/packages/plugin-react-oxc/build.config.ts
@@ -8,4 +8,7 @@ export default defineBuildConfig({
   rollup: {
     inlineDependencies: true,
   },
+  replace: {
+    'globalThis.__IS_BUILD__': 'true',
+  },
 })

--- a/packages/plugin-react-oxc/src/build.d.ts
+++ b/packages/plugin-react-oxc/src/build.d.ts
@@ -1,0 +1,7 @@
+declare global {
+  /** replaced by unbuild only in build */
+  // eslint-disable-next-line no-var --- top level var has to be var
+  var __IS_BUILD__: boolean | void
+}
+
+export {}

--- a/packages/plugin-react-oxc/src/index.ts
+++ b/packages/plugin-react-oxc/src/index.ts
@@ -12,6 +12,11 @@ import {
 
 const _dirname = dirname(fileURLToPath(import.meta.url))
 
+const refreshRuntimePath = globalThis.__IS_BUILD__
+  ? join(_dirname, 'refresh-runtime.js')
+  : // eslint-disable-next-line n/no-unsupported-features/node-builtins -- only used in dev
+    fileURLToPath(import.meta.resolve('@vitejs/react-common/refresh-runtime'))
+
 export interface Options {
   include?: string | RegExp | Array<string | RegExp>
   exclude?: string | RegExp | Array<string | RegExp>
@@ -88,10 +93,7 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
     load: {
       filter: { id: exactRegex(runtimePublicPath) },
       handler(_id) {
-        return readFileSync(
-          join(_dirname, 'refresh-runtime.js'),
-          'utf-8',
-        ).replace(
+        return readFileSync(refreshRuntimePath, 'utf-8').replace(
           /__README_URL__/g,
           'https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-react-oxc',
         )

--- a/packages/plugin-react/build.config.ts
+++ b/packages/plugin-react/build.config.ts
@@ -9,4 +9,7 @@ export default defineBuildConfig({
     emitCJS: true,
     inlineDependencies: true,
   },
+  replace: {
+    'globalThis.__IS_BUILD__': 'true',
+  },
 })

--- a/packages/plugin-react/src/build.d.ts
+++ b/packages/plugin-react/src/build.d.ts
@@ -1,0 +1,7 @@
+declare global {
+  /** replaced by unbuild only in build */
+  // eslint-disable-next-line no-var --- top level var has to be var
+  var __IS_BUILD__: boolean | void
+}
+
+export {}

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -15,6 +15,11 @@ import {
 
 const _dirname = dirname(fileURLToPath(import.meta.url))
 
+const refreshRuntimePath = globalThis.__IS_BUILD__
+  ? join(_dirname, 'refresh-runtime.js')
+  : // eslint-disable-next-line n/no-unsupported-features/node-builtins -- only used in dev
+    fileURLToPath(import.meta.resolve('@vitejs/react-common/refresh-runtime'))
+
 // lazy load babel since it's not used during build if plugins are not used
 let babel: typeof babelCore | undefined
 async function loadBabel() {
@@ -297,10 +302,7 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
     },
     load(id) {
       if (id === runtimePublicPath) {
-        return readFileSync(
-          join(_dirname, 'refresh-runtime.js'),
-          'utf-8',
-        ).replace(
+        return readFileSync(refreshRuntimePath, 'utf-8').replace(
           /__README_URL__/g,
           'https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-react',
         )


### PR DESCRIPTION
### Description

fixes the `pnpm dev` behavior mentioned in https://github.com/vitejs/vite-plugin-react/pull/439#discussion_r2033211124

This way, we don't need to copy the runtime file when the runtime file is updated.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
