### PR TITLE
ci(plugin-swc): bump version number in package.json when release

### DIFF
--- a/packages/plugin-react-swc/package.json
+++ b/packages/plugin-react-swc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitejs/plugin-react-swc",
-  "version": "3.8.1",
+  "version": "3.9.0-beta.0",
   "license": "MIT",
   "author": "Arnaud Barré (https://github.com/ArnaudBarre)",
   "description": "Speed up your Vite dev server with SWC",

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -25,6 +25,14 @@ release({
     )
   },
   generateChangelog: async (pkgName, version) => {
+    if (pkgName === 'plugin-react-swc') {
+      console.log(colors.cyan('\nUpdating package.json version...'))
+      const pkgJsonPath = `packages/${pkgName}/package.json`
+      const pkg = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'))
+      pkg.version = version
+      writeFileSync(pkgJsonPath, `${JSON.stringify(pkg, null, 2)}\n`)
+    }
+
     const changelog = readFileSync(`packages/${pkgName}/CHANGELOG.md`, 'utf-8')
     console.log(colors.cyan('\nUpdating CHANGELOG.md...'))
     const date = new Date().toISOString().slice(0, 10)


### PR DESCRIPTION
### Description

Added this part of code which was missing in this repo.
https://github.com/vitejs/vite-plugin-react-swc/blob/4c919ddff99e2dcdbaa93cdfb03b4360c1cbd7d4/scripts/release.ts#L23-L26

refs #423
refs 458783b1b293b934e004a3e0681c42bc3cc019da

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
