### PR TITLE
chore: update release-scripts and clean up

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@eslint/js": "^9.22.0",
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^22.13.15",
-    "@vitejs/release-scripts": "^1.3.2",
+    "@vitejs/release-scripts": "^1.5.0",
     "eslint": "^9.22.0",
     "eslint-plugin-import-x": "^4.8.0",
     "eslint-plugin-n": "^17.16.2",

--- a/packages/plugin-react-swc/package.json
+++ b/packages/plugin-react-swc/package.json
@@ -17,8 +17,7 @@
   "scripts": {
     "dev": "tsx scripts/bundle.ts --dev",
     "build": "tsx scripts/bundle.ts",
-    "test": "playwright test",
-    "release": "pnpm build && tsx scripts/release.ts"
+    "test": "playwright test"
   },
   "repository": {
     "type": "git",
@@ -40,7 +39,6 @@
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^22.13.15",
     "@vitejs/react-common": "workspace:*",
-    "@vitejs/release-scripts": "^1.3.3",
     "esbuild": "^0.25.1",
     "fs-extra": "^11.3.0",
     "picocolors": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,8 +26,8 @@ importers:
         specifier: ^22.13.15
         version: 22.13.15
       '@vitejs/release-scripts':
-        specifier: ^1.3.2
-        version: 1.4.0
+        specifier: ^1.5.0
+        version: 1.5.0
       eslint:
         specifier: ^9.22.0
         version: 9.23.0(jiti@2.4.2)
@@ -1939,6 +1939,9 @@ packages:
 
   '@vitejs/release-scripts@1.4.0':
     resolution: {integrity: sha512-NpPniB3UxEsWf9fX8SlZA96vv3tqkd9IFW23pBHVylAW18BsV8J9f/iukbvilCU+nyhtCQ9xsf7K/7p2wSro3Q==}
+
+  '@vitejs/release-scripts@1.5.0':
+    resolution: {integrity: sha512-rZQdM5AneNJHzDOTUaQOOifauH6MkGTSI+GH8bKKrimBaa5BtvpnE1iz43fJ4QDO7RdGxAlxWnPQAVlFhGM1cQ==}
 
   '@vitest/expect@3.0.5':
     resolution: {integrity: sha512-nNIOqupgZ4v5jWuQx2DSlHLEs7Q4Oh/7AYwNyE+k0UQzG7tSmjPXShUikn1mpNGzYEN2jJbTvLejwShMitovBA==}
@@ -5120,6 +5123,15 @@ snapshots:
       valibot: 1.0.0(typescript@5.8.2)
 
   '@vitejs/release-scripts@1.4.0':
+    dependencies:
+      execa: 8.0.1
+      mri: 1.2.0
+      picocolors: 1.1.1
+      prompts: 2.4.2
+      publint: 0.3.9
+      semver: 7.7.1
+
+  '@vitejs/release-scripts@1.5.0':
     dependencies:
       execa: 8.0.1
       mri: 1.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,9 +138,6 @@ importers:
       '@vitejs/react-common':
         specifier: workspace:*
         version: link:../common
-      '@vitejs/release-scripts':
-        specifier: ^1.3.3
-        version: 1.4.0
       esbuild:
         specifier: ^0.25.1
         version: 0.25.2
@@ -1936,9 +1933,6 @@ packages:
     resolution: {integrity: sha512-/9crJgPptVsGCL6X+JPDQyaJwkalSZ/52WuF8DiRUxJgcmpNdzYRfZ+gqMEP8W3CTVfuMWPqqvIgfwJ97f9Etw==}
     peerDependencies:
       valibot: ^1.0.0
-
-  '@vitejs/release-scripts@1.4.0':
-    resolution: {integrity: sha512-NpPniB3UxEsWf9fX8SlZA96vv3tqkd9IFW23pBHVylAW18BsV8J9f/iukbvilCU+nyhtCQ9xsf7K/7p2wSro3Q==}
 
   '@vitejs/release-scripts@1.5.0':
     resolution: {integrity: sha512-rZQdM5AneNJHzDOTUaQOOifauH6MkGTSI+GH8bKKrimBaa5BtvpnE1iz43fJ4QDO7RdGxAlxWnPQAVlFhGM1cQ==}
@@ -5121,15 +5115,6 @@ snapshots:
   '@valibot/to-json-schema@1.0.0(valibot@1.0.0(typescript@5.8.2))':
     dependencies:
       valibot: 1.0.0(typescript@5.8.2)
-
-  '@vitejs/release-scripts@1.4.0':
-    dependencies:
-      execa: 8.0.1
-      mri: 1.2.0
-      picocolors: 1.1.1
-      prompts: 2.4.2
-      publint: 0.3.9
-      semver: 7.7.1
 
   '@vitejs/release-scripts@1.5.0':
     dependencies:

--- a/scripts/publishCI.ts
+++ b/scripts/publishCI.ts
@@ -1,7 +1,6 @@
 import { publish } from '@vitejs/release-scripts'
 
 publish({
-  defaultPackage: 'plugin-react',
   provenance: true,
   getPkgDir(pkg) {
     if (pkg === 'plugin-react-swc') {


### PR DESCRIPTION
### Description

- update release-scripts to pull in https://github.com/vitejs/release-scripts/pull/69, https://github.com/vitejs/release-scripts/pull/70
- remove `defaultPackage` option
- remove release-scripts from swc package: the top-level script should be used

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
