### PR TITLE
test(react): wait for hmr update to reduce flakyness

### DIFF
--- a/playground/react/__tests__/react.spec.ts
+++ b/playground/react/__tests__/react.spec.ts
@@ -46,8 +46,12 @@ test.runIf(isServe)('should not invalidate when code is invalid', async () => {
   // if import.meta.invalidate happened, the old page won't be shown because the page is reloaded
   expect(await page.textContent('h1')).toMatch('Hello Vite + React')
 
-  editFile('App.jsx', (code) =>
-    code.replace('<div className="App"}>', '<div className="App">'),
+  await untilBrowserLogAfter(
+    () =>
+      editFile('App.jsx', (code) =>
+        code.replace('<div className="App"}>', '<div className="App">'),
+      ),
+    '[vite] hot updated: /App.jsx',
   )
 })
 


### PR DESCRIPTION
### Description

The following test failed some times in the following condition
https://github.com/vitejs/vite-plugin-react/blob/ce0de3e82f6ad801f6760a5f0bc556bc7f4acf27/playground/react/__tests__/react.spec.ts#L74-L94

- these edits were executed fast enough to be processed in a single update:
https://github.com/vitejs/vite-plugin-react/blob/a758bfe550cc2249b423ed23d996e28d4adb1a23/playground/react/__tests__/react.spec.ts#L49-L51
https://github.com/vitejs/vite-plugin-react/blob/a758bfe550cc2249b423ed23d996e28d4adb1a23/playground/react/__tests__/react.spec.ts#L73-L75

In that case, `allExportsAreComponentsOrUnchanged` probably becomes `true` because of `prevExports[key] === nextExports[key]`, and `import.meta.hot.invalidate` won't be called.
https://github.com/vitejs/vite-plugin-react/blob/a758bfe550cc2249b423ed23d996e28d4adb1a23/packages/common/refresh-runtime.js#L615


---

This PR fixes that flaky fail by waiting for the update to be processed.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
