### PR TITLE
fix(react): fix package.json `types`

### DIFF
--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -22,7 +22,7 @@
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/index.d.mts",
   "exports": {
     ".": {
       "import": "./dist/index.mjs",


### PR DESCRIPTION
### Description

- Closes https://github.com/vitejs/vite-plugin-react/issues/460

This `types` field is only used by (mostly deprecated) `moduleResolution: "node"`. `index.d.ts` was same as `index.d.mts` previously, but `unbuild` 3.5.0 changed something and it's now `index.d.cts` for some reason. Making a quick fix to just point to `index.d.mts` to preserve old ts behavior.

Technically this should be reported and fixed on `unbuild`, but this `types` fields are only for back compat for ancient config, so   quick fix on our side seems fine.

I locally confirmed the repro is fixed with local override.