### PR TITLE
fix(common): silence "use server" directive build warning

### DIFF
--- a/packages/common/warning.ts
+++ b/packages/common/warning.ts
@@ -7,7 +7,8 @@ export const silenceUseClientWarning = (
     onwarn(warning, defaultHandler) {
       if (
         warning.code === 'MODULE_LEVEL_DIRECTIVE' &&
-        warning.message.includes('use client')
+        (warning.message.includes('use client') ||
+          warning.message.includes('use server'))
       ) {
         return
       }


### PR DESCRIPTION
### Description

This is just a minor convenience for RSC framework. Currently people still need an additional plugin to silence `use server` even if they use react plugin in the framework.