### PR TITLE
fix(plugin-swc): skip HMR preamble in Vitest browser mode

### DIFF
--- a/packages/plugin-react-swc/CHANGELOG.md
+++ b/packages/plugin-react-swc/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Skip HMR preamble in Vitest browser mode
+
+This was causing annoying `Sourcemap for "/@react-refresh" points to missing source files` and is unnecessary in test mode.
+
 ## 3.9.0 (2025-04-15)
 
 ### Make compatible with rolldown-vite

--- a/packages/plugin-react-swc/src/index.ts
+++ b/packages/plugin-react-swc/src/index.ts
@@ -132,13 +132,17 @@ const react = (_options?: Options): PluginOption[] => {
           )
         }
       },
-      transformIndexHtml: (_, config) => [
-        {
-          tag: 'script',
-          attrs: { type: 'module' },
-          children: getPreambleCode(config.server!.config.base),
-        },
-      ],
+      transformIndexHtml: (_, config) => {
+        if (!hmrDisabled) {
+          return [
+            {
+              tag: 'script',
+              attrs: { type: 'module' },
+              children: getPreambleCode(config.server!.config.base),
+            },
+          ]
+        }
+      },
       async transform(code, _id, transformOptions) {
         const id = _id.split('?')[0]
         const refresh = !transformOptions?.ssr && !hmrDisabled


### PR DESCRIPTION
Fixes #474

This aligns with the two other plugins