### PR TITLE
chore: fix changelog log on release command

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -2,6 +2,8 @@ import { readFileSync, writeFileSync } from 'node:fs'
 import { release } from '@vitejs/release-scripts'
 import colors from 'picocolors'
 
+const nextH2RE = /^## /gm
+
 release({
   repo: 'vite-plugin-react',
   packages: ['plugin-react', 'plugin-react-swc', 'plugin-react-oxc'],
@@ -18,11 +20,9 @@ release({
       throw new Error("Can't find '## Unreleased' section in CHANGELOG.md")
     }
     const index = changelog.indexOf('## Unreleased') + 13
-    console.log(
-      colors.dim(
-        changelog.slice(index, changelog.indexOf('## ', index)).trim(),
-      ),
-    )
+    nextH2RE.lastIndex = index
+    const nextH2Pos = nextH2RE.exec(changelog)?.index
+    console.log(colors.dim(changelog.slice(index, nextH2Pos).trim()))
   },
   generateChangelog: async (pkgName, version) => {
     if (pkgName === 'plugin-react-swc') {


### PR DESCRIPTION
### Description

The changelog log feature of `pnpm release` was not working when the changelog includes h3 titles.

**before**
```
√ Select package » plugin-react
#
```

**after**
```
√ Select package » plugin-react
### Add `filter` for rolldown-vite [#470](https://github.com/vitejs/vite-plugin-react/pull/470)

Added `filter` so that it is more performant when running this plugin with rolldown-powered version of Vite.

### Skip HMR for JSX files with hooks [#480](https://github.com/vitejs/vite-plugin-react/pull/480)

This removes the HMR warning for hooks with JSX.
```

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
