### PR TITLE
fix: use `optimizeDeps.rollupOptions` for rolldown-vite

### DIFF
--- a/packages/plugin-react-swc/CHANGELOG.md
+++ b/packages/plugin-react-swc/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Use `optimizeDeps.rollupOptions` instead of `optimizeDeps.esbuildOptions` for rolldown-vite [#489](https://github.com/vitejs/vite-plugin-react/pull/489)
+
+This suppresses the warning about `optimizeDeps.esbuildOptions` being deprecated in rolldown-vite.
+
 ## 3.10.1 (2025-06-03)
 
 ### Add explicit semicolon in preambleCode [#485](https://github.com/vitejs/vite-plugin-react/pull/485)

--- a/packages/plugin-react-swc/src/index.ts
+++ b/packages/plugin-react-swc/src/index.ts
@@ -12,6 +12,7 @@ import {
   transform,
 } from '@swc/core'
 import type { PluginOption } from 'vite'
+import * as vite from 'vite'
 import {
   addRefreshWrapper,
   getPreambleCode,
@@ -124,7 +125,9 @@ const react = (_options?: Options): PluginOption[] => {
         oxc: false,
         optimizeDeps: {
           include: [`${options.jsxImportSource}/jsx-dev-runtime`],
-          esbuildOptions: { jsx: 'automatic' },
+          ...('rolldownVersion' in vite
+            ? { rollupOptions: { jsx: { mode: 'automatic' } } }
+            : { esbuildOptions: { jsx: 'automatic' } }),
         },
       }),
       configResolved(config) {

--- a/packages/plugin-react/CHANGELOG.md
+++ b/packages/plugin-react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Use `optimizeDeps.rollupOptions` instead of `optimizeDeps.esbuildOptions` for rolldown-vite [#489](https://github.com/vitejs/vite-plugin-react/pull/489)
+
+This suppresses the warning about `optimizeDeps.esbuildOptions` being deprecated in rolldown-vite.
+
 ## 4.5.1 (2025-06-03)
 
 ### Add explicit semicolon in preambleCode [#485](https://github.com/vitejs/vite-plugin-react/pull/485)

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -157,7 +157,10 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
             jsx: 'automatic',
             jsxImportSource: opts.jsxImportSource,
           },
-          optimizeDeps: { esbuildOptions: { jsx: 'automatic' } },
+          optimizeDeps:
+            'rolldownVersion' in vite
+              ? { rollupOptions: { jsx: { mode: 'automatic' } } }
+              : { esbuildOptions: { jsx: 'automatic' } },
         }
       }
     },


### PR DESCRIPTION
### Description

So that the warning is not output.

refs https://github.com/vitejs/rolldown-vite/issues/207

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
