### PR TITLE
feat: swcCacheDir option

### DIFF
--- a/packages/plugin-react-swc/README.md
+++ b/packages/plugin-react-swc/README.md
@@ -125,6 +125,14 @@ If set, disables the recommendation to use `@vitejs/plugin-react-oxc` (which is 
 react({ disableOxcRecommendation: true })
 ```
 
+### swcCacheDir
+
+Specify the location where SWC stores its intermediate cache files.
+
+```js
+react({ swcCacheDir: 'node_modules/.vite/swc' })
+```
+
 ## Consistent components exports
 
 For React refresh to work correctly, your file should only export React components. The best explanation I've read is the one from the [Gatsby docs](https://www.gatsbyjs.com/docs/reference/local-development/fast-refresh/#how-it-works).

--- a/packages/plugin-react-swc/src/index.ts
+++ b/packages/plugin-react-swc/src/index.ts
@@ -49,7 +49,7 @@ type Options = {
   plugins?: [string, Record<string, any>][]
   /**
    * Specify the location where SWC stores its intermediate cache files.
-   * @default '.swc'
+   * @default 'node_modules/.vite/swc'
    */
   swcCacheDir?: string
   /**
@@ -93,7 +93,7 @@ const react = (_options?: Options): PluginOption[] => {
   const options = {
     jsxImportSource: _options?.jsxImportSource ?? 'react',
     tsDecorators: _options?.tsDecorators,
-    swcCacheDir: _options?.swcCacheDir,
+    swcCacheDir: _options?.swcCacheDir ?? 'node_modules/.vite/swc',
     plugins: _options?.plugins
       ? _options?.plugins.map((el): typeof el => [resolve(el[0]), el[1]])
       : undefined,

--- a/packages/plugin-react-swc/src/index.ts
+++ b/packages/plugin-react-swc/src/index.ts
@@ -48,6 +48,11 @@ type Options = {
    */
   plugins?: [string, Record<string, any>][]
   /**
+   * Specify the location where SWC stores its intermediate cache files.
+   * @default '.swc'
+   */
+  swcCacheDir?: string
+  /**
    * Set the target for SWC in dev. This can avoid to down-transpile private class method for example.
    * For production target, see https://vite.dev/config/build-options.html#build-target
    * @default "es2020"
@@ -88,6 +93,7 @@ const react = (_options?: Options): PluginOption[] => {
   const options = {
     jsxImportSource: _options?.jsxImportSource ?? 'react',
     tsDecorators: _options?.tsDecorators,
+    swcCacheDir: _options?.swcCacheDir,
     plugins: _options?.plugins
       ? _options?.plugins.map((el): typeof el => [resolve(el[0]), el[1]])
       : undefined,
@@ -264,7 +270,7 @@ const transformWithOptions = async (
       jsc: {
         target,
         parser,
-        experimental: { plugins: options.plugins },
+        experimental: { plugins: options.plugins, cacheRoot: options.swcCacheDir },
         transform: {
           useDefineForClassFields: true,
           react: reactConfig,


### PR DESCRIPTION
### Description

When using this plugin swc creates an .swc older in the cwd. It would be great to allow customizing it especially for meta-frameworks built on top of vite.