### PR TITLE
fix(oxc): disable refresh transform when `server.hmr: false`

### DIFF
--- a/packages/plugin-react-oxc/src/index.ts
+++ b/packages/plugin-react-oxc/src/index.ts
@@ -55,7 +55,7 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
           jsx: {
             runtime: 'automatic',
             importSource: jsxImportSource,
-            refresh: !process.env.VITEST && command === 'serve',
+            refresh: command === 'serve',
             development: command === 'serve',
           },
           jsxRefreshInclude: include,
@@ -78,6 +78,22 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
           '@vitejs/plugin-react-oxc requires rolldown-vite to be used. ' +
             'See https://vitejs.dev/guide/rolldown for more details about rolldown-vite.',
         )
+      }
+    },
+  }
+
+  const viteConfigPost: Plugin = {
+    name: 'vite:react-oxc:config-psot',
+    enforce: 'post',
+    config(userConfig) {
+      if (userConfig.server?.hmr === false) {
+        return {
+          oxc: {
+            jsx: {
+              refresh: false,
+            },
+          },
+        }
       }
     },
   }
@@ -148,5 +164,5 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
     },
   }
 
-  return [viteConfig, viteRefreshRuntime, viteRefreshWrapper]
+  return [viteConfig, viteConfigPost, viteRefreshRuntime, viteRefreshWrapper]
 }

--- a/packages/plugin-react-oxc/src/index.ts
+++ b/packages/plugin-react-oxc/src/index.ts
@@ -51,18 +51,16 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
       return {
         // @ts-expect-error rolldown-vite Vite type incompatibility
         build: silenceUseClientWarning(userConfig) as BuildOptions,
-        oxc: process.env.VITEST
-          ? undefined
-          : {
-              jsx: {
-                runtime: 'automatic',
-                importSource: jsxImportSource,
-                refresh: command === 'serve',
-                development: command === 'serve',
-              },
-              jsxRefreshInclude: include,
-              jsxRefreshExclude: exclude,
-            },
+        oxc: {
+          jsx: {
+            runtime: 'automatic',
+            importSource: jsxImportSource,
+            refresh: !process.env.VITEST && command === 'serve',
+            development: command === 'serve',
+          },
+          jsxRefreshInclude: include,
+          jsxRefreshExclude: exclude,
+        },
         optimizeDeps: {
           include: [
             'react',

--- a/packages/plugin-react-oxc/src/index.ts
+++ b/packages/plugin-react-oxc/src/index.ts
@@ -83,7 +83,7 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
   }
 
   const viteConfigPost: Plugin = {
-    name: 'vite:react-oxc:config-psot',
+    name: 'vite:react-oxc:config-post',
     enforce: 'post',
     config(userConfig) {
       if (userConfig.server?.hmr === false) {

--- a/packages/plugin-react-oxc/src/index.ts
+++ b/packages/plugin-react-oxc/src/index.ts
@@ -51,16 +51,18 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
       return {
         // @ts-expect-error rolldown-vite Vite type incompatibility
         build: silenceUseClientWarning(userConfig) as BuildOptions,
-        oxc: {
-          jsx: {
-            runtime: 'automatic',
-            importSource: jsxImportSource,
-            refresh: command === 'serve',
-            development: command === 'serve',
-          },
-          jsxRefreshInclude: include,
-          jsxRefreshExclude: exclude,
-        },
+        oxc: process.env.VITEST
+          ? undefined
+          : {
+              jsx: {
+                runtime: 'automatic',
+                importSource: jsxImportSource,
+                refresh: command === 'serve',
+                development: command === 'serve',
+              },
+              jsxRefreshInclude: include,
+              jsxRefreshExclude: exclude,
+            },
         optimizeDeps: {
           include: [
             'react',

--- a/playground/hmr-false/__tests__/hmr-false.spec.ts
+++ b/playground/hmr-false/__tests__/hmr-false.spec.ts
@@ -1,0 +1,8 @@
+import { expect, test } from 'vitest'
+import { page } from '~utils'
+
+test('basic', async () => {
+  expect(await page.textContent('button')).toMatch('count is 0')
+  expect(await page.click('button'))
+  expect(await page.textContent('button')).toMatch('count is 1')
+})

--- a/playground/hmr-false/__tests__/oxc/hmr-false.spec.ts
+++ b/playground/hmr-false/__tests__/oxc/hmr-false.spec.ts
@@ -1,0 +1,1 @@
+import '../hmr-false.spec'

--- a/playground/hmr-false/index.html
+++ b/playground/hmr-false/index.html
@@ -1,0 +1,2 @@
+<div id="app"></div>
+<script type="module" src="./src/main.tsx"></script>

--- a/playground/hmr-false/package.json
+++ b/playground/hmr-false/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@vitejs/test-react-hmr-false",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "debug": "node --inspect-brk vite",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.6",
+    "@types/react-dom": "^19.1.6",
+    "@vitejs/plugin-react": "workspace:*"
+  }
+}

--- a/playground/hmr-false/src/App.tsx
+++ b/playground/hmr-false/src/App.tsx
@@ -1,0 +1,13 @@
+import { useState } from 'react'
+
+export default function App() {
+  const [count, setCount] = useState(0)
+
+  return (
+    <>
+      <button onClick={() => setCount((count) => count + 1)}>
+        count is {count}
+      </button>
+    </>
+  )
+}

--- a/playground/hmr-false/src/main.tsx
+++ b/playground/hmr-false/src/main.tsx
@@ -1,0 +1,4 @@
+import ReactDOM from 'react-dom/client'
+import App from './App.jsx'
+
+ReactDOM.createRoot(document.getElementById('app')!).render(<App />)

--- a/playground/hmr-false/tsconfig.json
+++ b/playground/hmr-false/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "include": ["src"],
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/playground/hmr-false/vite.config.ts
+++ b/playground/hmr-false/vite.config.ts
@@ -1,0 +1,9 @@
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  server: {
+    hmr: false,
+  },
+  plugins: [react()],
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -521,6 +521,25 @@ importers:
         specifier: ^5.8.3
         version: 5.8.3
 
+  playground/hmr-false:
+    dependencies:
+      react:
+        specifier: ^19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.1.0(react@19.1.0)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.1.6
+        version: 19.1.6
+      '@types/react-dom':
+        specifier: ^19.1.6
+        version: 19.1.6(@types/react@19.1.6)
+      '@vitejs/plugin-react':
+        specifier: workspace:*
+        version: link:../../packages/plugin-react
+
   playground/hook-with-jsx:
     dependencies:
       react:


### PR DESCRIPTION
### Description

- Closes https://github.com/vitejs/vite-plugin-react/issues/500

~I think another approach is to configure `oxc` instead of `esbuild` on Vitest side when `rolldown-vite` is detected. Probably it makes more sense since we should migrate from `esbuild` to `oxc` eventually anyways.~

~(Btw tests are failing because `process.env.VITEST` is true during `test-serve` e2e :upside_down_face:)~

So, technically this is not Vitest specific issue. The same error would happen when `server.hmr: false`.
