### PR TITLE
chore(rsc): fix links

### DIFF
--- a/packages/plugin-rsc/examples/basic/README.md
+++ b/packages/plugin-rsc/examples/basic/README.md
@@ -1,9 +1,9 @@
 # rsc basic
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/hi-ogawa/vite-plugins/tree/main/packages/rsc/examples/basic)
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/vitejs/vite-plugin-react/tree/main/packages/plugin-rsc/examples/basic)
 
 https://vite-rsc-basic.hiro18181.workers.dev
 
 ```sh
-npx giget gh:hi-ogawa/vite-plugins/packages/rsc/examples/basic my-app
+npx giget gh:vitejs/vite-plugin-react/packages/plugin-rsc/examples/basic my-app
 ```

--- a/packages/plugin-rsc/examples/react-router/README.md
+++ b/packages/plugin-rsc/examples/react-router/README.md
@@ -10,12 +10,12 @@ Vite RSC example based on demo made by React router team with Parcel:
 
 See also [`rsc-movies`](https://github.com/hi-ogawa/rsc-movies/).
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/hi-ogawa/vite-plugins/tree/main/packages/rsc/examples/react-router?file=src%2Froutes%2Froot.tsx)
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/vitejs/vite-plugin-react/tree/main/packages/plugin-rsc/examples/react-router?file=src%2Froutes%2Froot.tsx)
 
 Or try it locally by:
 
 ```sh
-npx giget gh:hi-ogawa/vite-plugins/packages/rsc/examples/react-router my-app
+npx giget gh:vitejs/vite-plugin-react/packages/plugin-rsc/examples/react-router my-app
 cd my-app
 npm i
 npm run dev

--- a/packages/plugin-rsc/examples/starter-cf-single/README.md
+++ b/packages/plugin-rsc/examples/starter-cf-single/README.md
@@ -2,9 +2,9 @@
 
 https://vite-rsc-starter.hiro18181.workers.dev
 
-[examples/starter](https://github.com/hi-ogawa/vite-plugins/tree/main/packages/rsc/examples/starter) integrated with [`@cloudflare/vite-plugin`](https://github.com/cloudflare/workers-sdk/tree/main/packages/vite-plugin-cloudflare).
+[examples/starter](https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-rsc/examples/starter) integrated with [`@cloudflare/vite-plugin`](https://github.com/cloudflare/workers-sdk/tree/main/packages/vite-plugin-cloudflare).
 
-The difference from [examples/react-router](https://github.com/hi-ogawa/vite-plugins/tree/main/packages/rsc/examples/react-router) is that this doesn't require two workers.
+The difference from [examples/react-router](https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-rsc/examples/react-router) is that this doesn't require two workers.
 
 - RSC environment always runs on Cloudflare Workers.
 - During development, SSR environment runs as Vite's deafult Node environment.

--- a/packages/plugin-rsc/examples/starter/README.md
+++ b/packages/plugin-rsc/examples/starter/README.md
@@ -1,8 +1,8 @@
 # Vite + RSC
 
-This example shows how to setup a React application with [Server Component](https://react.dev/reference/rsc/server-components) features on Vite using [`@vitejs/plugin-rsc`](https://github.com/hi-ogawa/vite-plugins/tree/main/packages/rsc).
+This example shows how to setup a React application with [Server Component](https://react.dev/reference/rsc/server-components) features on Vite using [`@vitejs/plugin-rsc`](https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-rsc).
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/hi-ogawa/vite-plugins/tree/main/packages/rsc/examples/starter)
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/vitejs/vite-plugin-react/tree/main/packages/plugin-rsc/examples/starter)
 
 ```sh
 # run dev server
@@ -15,7 +15,7 @@ npm run preview
 
 ## API usages
 
-See [`@vitejs/plugin-rsc`](https://github.com/hi-ogawa/vite-plugins/tree/main/packages/rsc) for the documentation.
+See [`@vitejs/plugin-rsc`](https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-rsc) for the documentation.
 
 - [`vite.config.ts`](./vite.config.ts)
   - `@higoawa/vite-rsc/plugin`

--- a/packages/plugin-rsc/examples/starter/package.json
+++ b/packages/plugin-rsc/examples/starter/package.json
@@ -18,6 +18,7 @@
     "@types/react": "latest",
     "@types/react-dom": "latest",
     "@vitejs/plugin-react": "latest",
+    "vite": "^7.0.2",
     "vite-plugin-inspect": "latest"
   }
 }

--- a/packages/plugin-rsc/package.json
+++ b/packages/plugin-rsc/package.json
@@ -34,8 +34,7 @@
     "tsc": "tsc -b ./tsconfig.json ./e2e/tsconfig.json ./examples/*/tsconfig.json",
     "tsc-dev": "pnpm tsc --watch --preserveWatchOutput",
     "dev": "tsdown --sourcemap --watch src",
-    "build": "tsdown",
-    "prepack": "tsdown --clean"
+    "build": "tsdown"
   },
   "dependencies": {
     "@mjackson/node-fetch-server": "^0.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -665,6 +665,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: latest
         version: 4.6.0(vite@7.0.2(@types/node@22.16.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))
+      vite:
+        specifier: ^7.0.2
+        version: 7.0.2(@types/node@22.16.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1)
       vite-plugin-inspect:
         specifier: latest
         version: 11.3.0(vite@7.0.2(@types/node@22.16.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))


### PR DESCRIPTION
### Description

This fixes links to point to new repo.

Also `examples/starter` was missing `vite` dependency, so I added it to make it self-contained.