### PR TITLE
chore(rsc): fix example deps

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -5,3 +5,5 @@ hoist-pattern[]=eslint-import-resolver-*
 strict-peer-dependencies=false
 shell-emulator=true
 auto-install-peers=false
+link-workspace-packages=true
+prefer-workspace-packages=true

--- a/package.json
+++ b/package.json
@@ -72,9 +72,6 @@
     ]
   },
   "pnpm": {
-    "overrides": {
-      "@vitejs/plugin-rsc": "workspace:*"
-    },
     "packageExtensions": {
       "generouted": {
         "peerDependencies": {

--- a/packages/plugin-rsc/examples/basic/package.json
+++ b/packages/plugin-rsc/examples/basic/package.json
@@ -27,6 +27,7 @@
     "@vitejs/test-dep-server-in-server": "file:./test-dep/server-in-server",
     "tailwindcss": "^4.1.4",
     "vite": "^7.0.2",
-    "vite-plugin-inspect": "^11.2.0"
+    "vite-plugin-inspect": "^11.2.0",
+    "wrangler": "^4.22.0"
   }
 }

--- a/packages/plugin-rsc/examples/basic/package.json
+++ b/packages/plugin-rsc/examples/basic/package.json
@@ -13,13 +13,13 @@
   },
   "dependencies": {
     "@vitejs/plugin-rsc": "latest",
-    "react": "latest",
-    "react-dom": "latest"
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.4",
-    "@types/react": "latest",
-    "@types/react-dom": "latest",
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "latest",
     "@vitejs/test-dep-client-in-server": "file:./test-dep/client-in-server",
     "@vitejs/test-dep-client-in-server2": "file:./test-dep/client-in-server2",

--- a/packages/plugin-rsc/examples/react-router/package.json
+++ b/packages/plugin-rsc/examples/react-router/package.json
@@ -14,8 +14,8 @@
   },
   "dependencies": {
     "@vitejs/plugin-rsc": "latest",
-    "react": "latest",
-    "react-dom": "latest",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "react-router": "0.0.0-experimental-23decd7bc"
   },
   "devDependencies": {
@@ -23,8 +23,8 @@
     "@react-router/dev": "0.0.0-experimental-23decd7bc",
     "@tailwindcss/typography": "^0.5.16",
     "@tailwindcss/vite": "^4.1.4",
-    "@types/react": "latest",
-    "@types/react-dom": "latest",
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "latest",
     "tailwindcss": "^4.1.4",
     "vite": "^7.0.2",

--- a/packages/plugin-rsc/examples/ssg/package.json
+++ b/packages/plugin-rsc/examples/ssg/package.json
@@ -11,14 +11,14 @@
   },
   "dependencies": {
     "@vitejs/plugin-rsc": "latest",
-    "react": "latest",
-    "react-dom": "latest"
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
   },
   "devDependencies": {
     "@mdx-js/rollup": "^3.1.0",
-    "@types/react": "latest",
-    "@types/react-dom": "latest",
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "latest",
-    "vite-plugin-inspect": "latest"
+    "vite-plugin-inspect": "^11.2.0"
   }
 }

--- a/packages/plugin-rsc/examples/starter-cf-single/package.json
+++ b/packages/plugin-rsc/examples/starter-cf-single/package.json
@@ -12,13 +12,13 @@
   },
   "dependencies": {
     "@vitejs/plugin-rsc": "latest",
-    "react": "latest",
-    "react-dom": "latest"
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.8.0",
-    "@types/react": "latest",
-    "@types/react-dom": "latest",
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "latest"
   }
 }

--- a/packages/plugin-rsc/examples/starter/package.json
+++ b/packages/plugin-rsc/examples/starter/package.json
@@ -11,14 +11,14 @@
   },
   "dependencies": {
     "@vitejs/plugin-rsc": "latest",
-    "react": "latest",
-    "react-dom": "latest"
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
   },
   "devDependencies": {
-    "@types/react": "latest",
-    "@types/react-dom": "latest",
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "latest",
     "vite": "^7.0.2",
-    "vite-plugin-inspect": "latest"
+    "vite-plugin-inspect": "^11.2.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -554,6 +554,9 @@ importers:
       vite-plugin-inspect:
         specifier: ^11.2.0
         version: 11.3.0(vite@7.0.2(@types/node@22.16.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))
+      wrangler:
+        specifier: ^4.22.0
+        version: 4.23.0
 
   packages/plugin-rsc/examples/react-router:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,9 +10,6 @@ catalogs:
       specifier: npm:rolldown-vite@^6.3.21
       version: 6.3.21
 
-overrides:
-  '@vitejs/plugin-rsc': workspace:*
-
 packageExtensionsChecksum: sha256-S82yCctxnlOTNFuHWCyTFRo/B6Y3jque/4DnsDO4WZA=
 
 importers:
@@ -515,7 +512,7 @@ importers:
   packages/plugin-rsc/examples/basic:
     dependencies:
       '@vitejs/plugin-rsc':
-        specifier: workspace:*
+        specifier: latest
         version: link:../..
       react:
         specifier: latest
@@ -561,7 +558,7 @@ importers:
   packages/plugin-rsc/examples/react-router:
     dependencies:
       '@vitejs/plugin-rsc':
-        specifier: workspace:*
+        specifier: latest
         version: link:../..
       react:
         specifier: latest
@@ -610,7 +607,7 @@ importers:
   packages/plugin-rsc/examples/ssg:
     dependencies:
       '@vitejs/plugin-rsc':
-        specifier: workspace:*
+        specifier: latest
         version: link:../..
       react:
         specifier: latest
@@ -638,7 +635,7 @@ importers:
   packages/plugin-rsc/examples/starter:
     dependencies:
       '@vitejs/plugin-rsc':
-        specifier: workspace:*
+        specifier: latest
         version: link:../..
       react:
         specifier: latest
@@ -666,7 +663,7 @@ importers:
   packages/plugin-rsc/examples/starter-cf-single:
     dependencies:
       '@vitejs/plugin-rsc':
-        specifier: workspace:*
+        specifier: latest
         version: link:../..
       react:
         specifier: latest

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -515,20 +515,20 @@ importers:
         specifier: latest
         version: link:../..
       react:
-        specifier: latest
+        specifier: ^19.1.0
         version: 19.1.0
       react-dom:
-        specifier: latest
+        specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.1.4
         version: 4.1.11(vite@7.0.2(@types/node@22.16.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))
       '@types/react':
-        specifier: latest
+        specifier: ^19.1.8
         version: 19.1.8
       '@types/react-dom':
-        specifier: latest
+        specifier: ^19.1.6
         version: 19.1.6(@types/react@19.1.8)
       '@vitejs/plugin-react':
         specifier: latest
@@ -561,10 +561,10 @@ importers:
         specifier: latest
         version: link:../..
       react:
-        specifier: latest
+        specifier: ^19.1.0
         version: 19.1.0
       react-dom:
-        specifier: latest
+        specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
       react-router:
         specifier: 0.0.0-experimental-23decd7bc
@@ -583,10 +583,10 @@ importers:
         specifier: ^4.1.4
         version: 4.1.11(vite@7.0.2(@types/node@22.16.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))
       '@types/react':
-        specifier: latest
+        specifier: ^19.1.8
         version: 19.1.8
       '@types/react-dom':
-        specifier: latest
+        specifier: ^19.1.6
         version: 19.1.6(@types/react@19.1.8)
       '@vitejs/plugin-react':
         specifier: latest
@@ -610,26 +610,26 @@ importers:
         specifier: latest
         version: link:../..
       react:
-        specifier: latest
+        specifier: ^19.1.0
         version: 19.1.0
       react-dom:
-        specifier: latest
+        specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
     devDependencies:
       '@mdx-js/rollup':
         specifier: ^3.1.0
         version: 3.1.0(rollup@4.44.1)
       '@types/react':
-        specifier: latest
+        specifier: ^19.1.8
         version: 19.1.8
       '@types/react-dom':
-        specifier: latest
+        specifier: ^19.1.6
         version: 19.1.6(@types/react@19.1.8)
       '@vitejs/plugin-react':
         specifier: latest
         version: 4.6.0(vite@7.0.2(@types/node@22.16.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))
       vite-plugin-inspect:
-        specifier: latest
+        specifier: ^11.2.0
         version: 11.3.0(vite@7.0.2(@types/node@22.16.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))
 
   packages/plugin-rsc/examples/starter:
@@ -638,17 +638,17 @@ importers:
         specifier: latest
         version: link:../..
       react:
-        specifier: latest
+        specifier: ^19.1.0
         version: 19.1.0
       react-dom:
-        specifier: latest
+        specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
     devDependencies:
       '@types/react':
-        specifier: latest
+        specifier: ^19.1.8
         version: 19.1.8
       '@types/react-dom':
-        specifier: latest
+        specifier: ^19.1.6
         version: 19.1.6(@types/react@19.1.8)
       '@vitejs/plugin-react':
         specifier: latest
@@ -657,7 +657,7 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2(@types/node@22.16.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1)
       vite-plugin-inspect:
-        specifier: latest
+        specifier: ^11.2.0
         version: 11.3.0(vite@7.0.2(@types/node@22.16.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))
 
   packages/plugin-rsc/examples/starter-cf-single:
@@ -666,20 +666,20 @@ importers:
         specifier: latest
         version: link:../..
       react:
-        specifier: latest
+        specifier: ^19.1.0
         version: 19.1.0
       react-dom:
-        specifier: latest
+        specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.8.0
         version: 1.9.0(rollup@4.44.1)(vite@7.0.2(@types/node@22.16.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))(workerd@1.20250617.0)(wrangler@4.23.0)
       '@types/react':
-        specifier: latest
+        specifier: ^19.1.8
         version: 19.1.8
       '@types/react-dom':
-        specifier: latest
+        specifier: ^19.1.6
         version: 19.1.6(@types/react@19.1.8)
       '@vitejs/plugin-react':
         specifier: latest
@@ -7495,7 +7495,7 @@ snapshots:
 
   '@types/hoist-non-react-statics@3.3.6':
     dependencies:
-      '@types/react': 19.1.8
+      '@types/react': 18.3.20
       hoist-non-react-statics: 3.3.2
 
   '@types/json-schema@7.0.15': {}


### PR DESCRIPTION
### Description

Some examples are intended to be self-contained and they should be able to run simply by copying the directory e.g. for stackblitz demo, create-vite. For this, I cannot use `workspace:*` for workspace packages, but when developing locally, they should point to `workspace:*`. Pnpm provides `link-workspace-packages=true` and `prefer-workspace-packages=true`, so I used this instead of adding `overrides` each package.

I also updated `latest` dependencies with a proper version except workspace packages. For now, I kept `@vitejs/plugin-rsc` and `@vitejs/plugin-react` as `latest`, but maybe later we can adopt bumping templates version similar to create-vite https://github.com/vitejs/vite/blob/2e8050e4cd8835673baf07375b7db35128144222/scripts/releaseUtils.ts#L53