### PR TITLE
test(rsc): fix flaky server restart test

### DIFF
--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -12,10 +12,10 @@ test.describe('dev-default', () => {
   defineTest(f)
 })
 
-test.describe('dev-initial-ssr', () => {
+test.describe('dev-initial', () => {
   const f = useFixture({ root: 'examples/basic', mode: 'dev' })
 
-  // verifies css is collected on clean server startup
+  // verify css is collected properly on server startup (i.e. empty module graph)
   testNoJs('style', async ({ page }) => {
     await page.goto(f.url('./'))
     await expect(page.locator('.test-style-client')).toHaveCSS(

--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -12,6 +12,33 @@ test.describe('dev-default', () => {
   defineTest(f)
 })
 
+test.describe('dev-initial-ssr', () => {
+  const f = useFixture({ root: 'examples/basic', mode: 'dev' })
+
+  // verifies css is collected on clean server startup
+  testNoJs('style', async ({ page }) => {
+    await page.goto(f.url('./'))
+    await expect(page.locator('.test-style-client')).toHaveCSS(
+      'color',
+      'rgb(255, 165, 0)',
+    )
+    await expect(page.locator('.test-style-server')).toHaveCSS(
+      'color',
+      'rgb(255, 165, 0)',
+    )
+    await expect(page.locator('.test-tw-client')).toHaveCSS(
+      'color',
+      // blue-500
+      'rgb(0, 0, 255)',
+    )
+    await expect(page.locator('.test-tw-server')).toHaveCSS(
+      'color',
+      // red-500
+      'rgb(255, 0, 0)',
+    )
+  })
+})
+
 test.describe('build-default', () => {
   const f = useFixture({ root: 'examples/basic', mode: 'build' })
   defineTest(f)
@@ -655,15 +682,6 @@ function defineTest(f: Fixture) {
         'color',
         'rgb(255, 0, 0)',
       )
-    })
-
-    testNoJs('no FOUC after server restart @nojs', async ({ page }) => {
-      const res = await page.request.get(f.url('/__test_restart'))
-      expect(await res.text()).toBe('ok')
-      await new Promise((r) => setTimeout(r, 100))
-      await page.goto(f.url('./'))
-      await testCss(page)
-      await testTailwind(page)
     })
   })
 

--- a/packages/plugin-rsc/examples/basic/vite.config.ts
+++ b/packages/plugin-rsc/examples/basic/vite.config.ts
@@ -46,23 +46,6 @@ export default defineConfig({
     // avoid ecosystem CI fail due to vite-plugin-inspect compatibility
     !process.env.ECOSYSTEM_CI && inspect(),
     {
-      // test server restart scenario on e2e
-      name: 'test-api',
-      configureServer(server) {
-        server.middlewares.use((req, res, next) => {
-          const url = new URL(req.url!, 'http://localhost')
-          if (url.pathname === '/__test_restart') {
-            setTimeout(() => {
-              server.restart()
-            }, 10)
-            res.end('ok')
-            return
-          }
-          next()
-        })
-      },
-    },
-    {
       name: 'test-client-reference-tree-shaking',
       enforce: 'post',
       writeBundle(_options, bundle) {


### PR DESCRIPTION
### Description

This test is to verify css collection on intiail server startup. I was using programmatic server restart, but after I refactored e2e (https://github.com/hi-ogawa/vite-plugins/pull/1109), this approach is not necessary and this can be replaced with a fresh `useFixture`.