### PR TITLE
fix: return `Plugin[]` instead of `PluginOption[]`

### DIFF
--- a/packages/plugin-react-oxc/CHANGELOG.md
+++ b/packages/plugin-react-oxc/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### Return `Plugin[]` instead of `PluginOption[]`
+
 ## 0.2.3 (2025-06-16)
 
 ### Disable refresh transform when `server.hmr: false` is set [#502](https://github.com/vitejs/vite-plugin-react/pull/502)

--- a/packages/plugin-react-oxc/src/index.ts
+++ b/packages/plugin-react-oxc/src/index.ts
@@ -1,7 +1,7 @@
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { readFileSync } from 'node:fs'
-import type { BuildOptions, Plugin, PluginOption } from 'vite'
+import type { BuildOptions, Plugin } from 'vite'
 import {
   addRefreshWrapper,
   avoidSourceMapOption,
@@ -30,7 +30,7 @@ export interface Options {
 
 const defaultIncludeRE = /\.[tj]sx?(?:$|\?)/
 
-export default function viteReact(opts: Options = {}): PluginOption[] {
+export default function viteReact(opts: Options = {}): Plugin[] {
   const include = opts.include ?? defaultIncludeRE
   const exclude = [
     ...(Array.isArray(opts.exclude)

--- a/packages/plugin-react-swc/CHANGELOG.md
+++ b/packages/plugin-react-swc/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### Return `Plugin[]` instead of `PluginOption[]`
+
 ## 3.10.2 (2025-06-10)
 
 ### Suggest `@vitejs/plugin-react-oxc` if rolldown-vite is detected [#491](https://github.com/vitejs/vite-plugin-react/pull/491)

--- a/packages/plugin-react-swc/src/index.ts
+++ b/packages/plugin-react-swc/src/index.ts
@@ -11,7 +11,7 @@ import {
   type Options as SWCOptions,
   transform,
 } from '@swc/core'
-import type { PluginOption } from 'vite'
+import type { Plugin } from 'vite'
 import {
   addRefreshWrapper,
   getPreambleCode,
@@ -83,7 +83,7 @@ type Options = {
   disableOxcRecommendation?: boolean
 }
 
-const react = (_options?: Options): PluginOption[] => {
+const react = (_options?: Options): Plugin[] => {
   let hmrDisabled = false
   const options = {
     jsxImportSource: _options?.jsxImportSource ?? 'react',

--- a/packages/plugin-react/CHANGELOG.md
+++ b/packages/plugin-react/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Return `Plugin[]` instead of `PluginOption[]`
+
+The return type has changed from `react(): PluginOption[]` to more specialized type `react(): Plugin[]`. This allows for type-safe manipulation of plugins, for example:
+
+```tsx
+// previously this causes type errors
+react({ babel: { plugins: ['babel-plugin-react-compiler'] } })
+  .map(p => ({ ...p, applyToEnvironment: e => e.name === 'client' }))
+```
+
 ## 4.6.0 (2025-06-23)
 
 ### Add raw Rolldown support

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -5,7 +5,7 @@ import type * as babelCore from '@babel/core'
 import type { ParserOptions, TransformOptions } from '@babel/core'
 import { createFilter } from 'vite'
 import * as vite from 'vite'
-import type { Plugin, PluginOption, ResolvedConfig } from 'vite'
+import type { Plugin, ResolvedConfig } from 'vite'
 import {
   addRefreshWrapper,
   getPreambleCode,
@@ -109,7 +109,7 @@ export type ViteReactPluginApi = {
 const defaultIncludeRE = /\.[tj]sx?$/
 const tsRE = /\.tsx?$/
 
-export default function viteReact(opts: Options = {}): PluginOption[] {
+export default function viteReact(opts: Options = {}): Plugin[] {
   const include = opts.include ?? defaultIncludeRE
   const exclude = opts.exclude
   const filter = createFilter(include, exclude)

--- a/packages/plugin-rsc/examples/basic/vite.config.ts
+++ b/packages/plugin-rsc/examples/basic/vite.config.ts
@@ -23,12 +23,12 @@ export default defineConfig({
   plugins: [
     tailwindcss(),
     process.env.TEST_REACT_COMPILER
-      ? (react({
+      ? react({
           babel: { plugins: ['babel-plugin-react-compiler'] },
         }).map((p) => ({
           ...p,
-          applyToEnvironment: (e: any) => e.name === 'client',
-        })) as any)
+          applyToEnvironment: (e) => e.name === 'client',
+        }))
       : react(),
     vitePluginUseCache(),
     rsc({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -532,7 +532,7 @@ importers:
         version: 19.1.6(@types/react@19.1.8)
       '@vitejs/plugin-react':
         specifier: latest
-        version: 4.6.0(vite@7.0.2(@types/node@22.16.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))
+        version: link:../../../plugin-react
       '@vitejs/test-dep-client-in-server':
         specifier: file:./test-dep/client-in-server
         version: file:packages/plugin-rsc/examples/basic/test-dep/client-in-server(react@19.1.0)


### PR DESCRIPTION
### Description

- Related https://github.com/vitejs/vite-plugin-react/pull/529

This makes plugin return types to be more specialized so that users can do this without type error:

```js
 react({ babel: { plugins: ['babel-plugin-react-compiler'] } })
   .map(p => ({ ...p, applyToEnvironment: e => e.name === 'client' }))
```
