### PR TITLE
chore: renovate ignoreDeps react-router

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -43,5 +43,9 @@
     "kill-port", // `kill-port:^2.0.0 has perf issues (#8392)
 
     "prettier", // waiting for stable choice on ternaries
+
+    // plugin-rsc
+    "react-router",
+    "@react-router/dev",
   ],
 }


### PR DESCRIPTION
### Description

- related https://github.com/vitejs/vite-plugin-react/pull/540

React router RSC is only released as experimental, so they need to be updated manually.