### PR TITLE
chore: fix rsc release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - if: steps.tag.outputs.isAlpha == 'false'
+      - if: steps.tag.outputs.isAlpha == 'false' && steps.tag.outputs.pkgName != 'plugin-rsc'
         uses: ArnaudBarre/github-release@4fa6eafe8e2449c7c1c5a91ae50de4ee34db0b40 # v1.5.0
         with:
           path: packages/${{ steps.tag.outputs.pkgName }}/CHANGELOG.md

--- a/packages/plugin-rsc/package.json
+++ b/packages/plugin-rsc/package.json
@@ -34,7 +34,8 @@
     "tsc": "tsc -b ./tsconfig.json ./e2e/tsconfig.json ./examples/*/tsconfig.json",
     "tsc-dev": "pnpm tsc --watch --preserveWatchOutput",
     "dev": "tsdown --sourcemap --watch src",
-    "build": "tsdown"
+    "build": "tsdown",
+    "prepack": "tsdown"
   },
   "dependencies": {
     "@mjackson/node-fetch-server": "^0.7.0",


### PR DESCRIPTION
### Description

I had `prepack` when I did `0.4.10-alpha.1`, but removed later as I thought it was redundant on new release workflow. But it turned out it's still needed.