### PR TITLE
test(rsc): serial e2e

### DIFF
--- a/.github/workflows/ci-rsc.yml
+++ b/.github/workflows/ci-rsc.yml
@@ -37,14 +37,12 @@ jobs:
       matrix:
         shardIndex: [1, 2]
         shardTotal: [2]
-        config:
+        include:
           - { os: ubuntu-latest, browser: chromium }
-          - { os: macos-latest, browser: chromium }
-          - { os: windows-latest, browser: chromium }
           - { os: ubuntu-latest, browser: firefox }
+          - { os: macos-latest, browser: chromium }
           - { os: macos-latest, browser: webkit }
-        os: ${{ matrix.config.os }}
-        browser: ${{ matrix.config.browser }}
+          - { os: windows-latest, browser: chromium }
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-rsc.yml
+++ b/.github/workflows/ci-rsc.yml
@@ -31,19 +31,20 @@ jobs:
       - run: pnpm -C packages/plugin-rsc test
 
   test-e2e:
-    name: test-rsc (${{ matrix.os }} - ${{ matrix.browser }} - ${{ matrix.shared }}/${{ matrix.shardTotal }})
+    name: test-rsc (${{ matrix.os }} - ${{ matrix.browser }} - ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        shared: [1, 2]
+        shardIndex: [1, 2]
         shardTotal: [2]
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        browser: [chromium]
-        include:
-          - os: ubuntu-latest
-            browser: firefox
-          - os: macos-latest
-            browser: webkit
+        config:
+          - { os: ubuntu-latest, browser: chromium }
+          - { os: macos-latest, browser: chromium }
+          - { os: windows-latest, browser: chromium }
+          - { os: ubuntu-latest, browser: firefox }
+          - { os: macos-latest, browser: webkit }
+        os: ${{ matrix.config.os }}
+        browser: ${{ matrix.config.browser }}
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -54,12 +55,12 @@ jobs:
       - run: pnpm i
       - run: pnpm build
       - run: pnpm -C packages/plugin-rsc exec playwright install ${{ matrix.browser }}
-      - run: pnpm -C packages/plugin-rsc test-e2e-ci --project=${{ matrix.browser }} --shard=${{ matrix.shared }}/${{ matrix.shardTotal }}
+      - run: pnpm -C packages/plugin-rsc test-e2e-ci --project=${{ matrix.browser }} --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
         env:
           TEST_ISOLATED: true
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-${{ matrix.os }}-${{ matrix.browser }}-${{ matrix.shared }}
+          name: test-results-${{ matrix.os }}-${{ matrix.browser }}-${{ matrix.shardIndex }}
           path: |
             packages/plugin-rsc/test-results

--- a/.github/workflows/ci-rsc.yml
+++ b/.github/workflows/ci-rsc.yml
@@ -31,7 +31,7 @@ jobs:
       - run: pnpm -C packages/plugin-rsc test
 
   test-e2e:
-    name: test-rsc (${{ matrix.os }} / ${{ matrix.browser }})
+    name: test-rsc (${{ matrix.os }} - ${{ matrix.browser }} - ${{ matrix.shared }}/${{ matrix.shardTotal }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/ci-rsc.yml
+++ b/.github/workflows/ci-rsc.yml
@@ -37,12 +37,13 @@ jobs:
       matrix:
         shardIndex: [1, 2]
         shardTotal: [2]
-        include:
-          - { os: ubuntu-latest, browser: chromium }
-          - { os: ubuntu-latest, browser: firefox }
-          - { os: macos-latest, browser: chromium }
-          - { os: macos-latest, browser: webkit }
-          - { os: windows-latest, browser: chromium }
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        browser: [chromium, firefox, webkit]
+        exclude:
+          - { os: ubuntu-latest, browser: webkit }
+          - { os: macos-latest, browser: firefox }
+          - { os: windows-latest, browser: firefox }
+          - { os: windows-latest, browser: webkit }
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-rsc.yml
+++ b/.github/workflows/ci-rsc.yml
@@ -34,8 +34,9 @@ jobs:
     name: test-rsc (${{ matrix.os }} / ${{ matrix.browser }})
     runs-on: ${{ matrix.os }}
     strategy:
-      # TODO: shard?
       matrix:
+        shared: [1, 2]
+        shardTotal: [2]
         os: [ubuntu-latest, macos-latest, windows-latest]
         browser: [chromium]
         include:
@@ -53,12 +54,12 @@ jobs:
       - run: pnpm i
       - run: pnpm build
       - run: pnpm -C packages/plugin-rsc exec playwright install ${{ matrix.browser }}
-      - run: pnpm -C packages/plugin-rsc test-e2e-ci --project=${{ matrix.browser }}
+      - run: pnpm -C packages/plugin-rsc test-e2e-ci --project=${{ matrix.browser }} --shard=${{ matrix.shared }}/${{ matrix.shardTotal }}
         env:
           TEST_ISOLATED: true
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-${{ matrix.os }}-${{ matrix.browser }}
+          name: test-results-${{ matrix.os }}-${{ matrix.browser }}-${{ matrix.shared }}
           path: |
             packages/plugin-rsc/test-results

--- a/.github/workflows/ci-rsc.yml
+++ b/.github/workflows/ci-rsc.yml
@@ -31,19 +31,18 @@ jobs:
       - run: pnpm -C packages/plugin-rsc test
 
   test-e2e:
-    name: test-rsc (${{ matrix.os }} - ${{ matrix.browser }} - ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
+    name: test-rsc (${{ matrix.os }} / ${{ matrix.browser }})
     runs-on: ${{ matrix.os }}
     strategy:
+      # TODO: shard?
       matrix:
-        shardIndex: [1, 2]
-        shardTotal: [2]
         os: [ubuntu-latest, macos-latest, windows-latest]
-        browser: [chromium, firefox, webkit]
-        exclude:
-          - { os: ubuntu-latest, browser: webkit }
-          - { os: macos-latest, browser: firefox }
-          - { os: windows-latest, browser: firefox }
-          - { os: windows-latest, browser: webkit }
+        browser: [chromium]
+        include:
+          - os: ubuntu-latest
+            browser: firefox
+          - os: macos-latest
+            browser: webkit
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -54,12 +53,12 @@ jobs:
       - run: pnpm i
       - run: pnpm build
       - run: pnpm -C packages/plugin-rsc exec playwright install ${{ matrix.browser }}
-      - run: pnpm -C packages/plugin-rsc test-e2e-ci --project=${{ matrix.browser }} --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+      - run: pnpm -C packages/plugin-rsc test-e2e-ci --project=${{ matrix.browser }}
         env:
           TEST_ISOLATED: true
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-results-${{ matrix.os }}-${{ matrix.browser }}-${{ matrix.shardIndex }}
+          name: test-results-${{ matrix.os }}-${{ matrix.browser }}
           path: |
             packages/plugin-rsc/test-results

--- a/packages/plugin-rsc/playwright.config.ts
+++ b/packages/plugin-rsc/playwright.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
       use: devices['Desktop Safari'],
     },
   ],
+  workers: 1,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   reporter: ['list', process.env.CI && 'github']

--- a/packages/plugin-rsc/playwright.config.ts
+++ b/packages/plugin-rsc/playwright.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
     },
   ],
   workers: 1,
+  fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   reporter: ['list', process.env.CI && 'github']

--- a/packages/plugin-rsc/playwright.config.ts
+++ b/packages/plugin-rsc/playwright.config.ts
@@ -27,7 +27,6 @@ export default defineConfig({
     },
   ],
   workers: 1,
-  fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   reporter: ['list', process.env.CI && 'github']


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

It looks like multiple workers makes it flaky, so making it `workers: 1` for now. Since the bottleneck is `basic.test.ts` which is entirely sequential anyway, so test time doesn't increase much (and actually some flaky os/browser is now faster because there's no retry)

Currently, shard is not helping since they can only split by test files. This is also because `basic.test.ts`  is the bottleneck. We can split that out in the future.
