### PR TITLE
chore(rsc): tweak cloudflare setting on rolldown-vite

### DIFF
--- a/packages/plugin-rsc/examples/starter-cf-single/vite.config.ts
+++ b/packages/plugin-rsc/examples/starter-cf-single/vite.config.ts
@@ -35,12 +35,6 @@ export default defineConfig({
           platform: 'neutral',
         },
       },
-      optimizeDeps: {
-        // @ts-ignore rolldown
-        rollupOptions: {
-          platform: 'neutral',
-        },
-      },
     },
     ssr: {
       keepProcessEnv: false,


### PR DESCRIPTION
### Description

I noticed Rolldown-vite copies `optimizeDeps.esbuildOptions.platform` to `optimizeDeps.rollupOptions.platform`, so this is not necessary.
