### PR TITLE
chore(rsc): update readme

### DIFF
--- a/packages/plugin-rsc/README.md
+++ b/packages/plugin-rsc/README.md
@@ -130,7 +130,7 @@ export default defineConfig({
 - [`entry.rsc.tsx`](./examples/starter/src/framework/entry.rsc.tsx)
 
 ```tsx
-import * as ReactServer from '@vitejs/plugin-rsc/rsc' // re-export of react-server-dom/server.edge
+import * as ReactServer from '@vitejs/plugin-rsc/rsc' // re-export of react-server-dom/server.edge and client.edge
 
 // the plugin assumes `rsc` entry having default export of request handler
 export default async function handler(request: Request): Promise<Response> {

--- a/packages/plugin-rsc/README.md
+++ b/packages/plugin-rsc/README.md
@@ -214,7 +214,7 @@ main();
 
 ### `@vitejs/plugin-rsc/rsc`
 
-This module re-exports RSC runtime API provided by `react-server-dom/server.edge` adn `react-server-dom/client.edge` such as:
+This module re-exports RSC runtime API provided by `react-server-dom/server.edge` and `react-server-dom/client.edge` such as:
 
 - `renderToReadableStream`: RSC serialization (React VDOM -> RSC stream)
 - `createFromReadableStream`: RSC deserialization (RSC stream -> React VDOM). This is also available on rsc environment itself. For example, it allows saving serailized RSC and deserializing it for later use.

--- a/packages/plugin-rsc/README.md
+++ b/packages/plugin-rsc/README.md
@@ -214,11 +214,12 @@ main();
 
 ### `@vitejs/plugin-rsc/rsc`
 
-This module re-exports RSC runtime API provided by `react-server-dom/server.edge`
+This module re-exports RSC runtime API provided by `react-server-dom/server.edge` adn `react-server-dom/client.edge` such as:
 
 - `renderToReadableStream`: RSC serialization (React VDOM -> RSC stream)
 - `createFromReadableStream`: RSC deserialization (RSC stream -> React VDOM). This is also available on rsc environment itself. For example, it allows saving serailized RSC and deserializing it for later use.
-- `decodeAction/decodeReply/loadServerAction`: server function related...
+- `decodeAction/decodeReply/decodeFormState/loadServerAction/createTemporaryReferenceSet`
+- `encodeReply/createClientTemporaryReferenceSet`
 
 ### `@vitejs/plugin-rsc/ssr`
 


### PR DESCRIPTION
### Description

Mentioning that `client.edge` is also re-exported from `@vitejs/plugin-rsc/rsc`, which is necessary to implement Next.js `"use cache"` like caching semantics. See https://github.com/hi-ogawa/vite-plugins/pull/1089 for more context.