### PR TITLE
chore: overrides `@types/estree` to fix type duplicates

### DIFF
--- a/.github/workflows/ci-rsc.yml
+++ b/.github/workflows/ci-rsc.yml
@@ -58,7 +58,7 @@ jobs:
       - name: install rolldown
         if: ${{ matrix.rolldown }}
         run: |
-          echo 'overrides: { vite: "npm:rolldown-vite@latest" }' >> pnpm-workspace.yaml
+          sed -i '/^overrides:/a\  vite: "npm:rolldown-vite@latest"' pnpm-workspace.yaml
           pnpm i --no-frozen-lockfile
       - run: pnpm -C packages/plugin-rsc exec playwright install ${{ matrix.browser }}
       - run: pnpm -C packages/plugin-rsc test-e2e-ci --project=${{ matrix.browser }}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ catalogs:
       specifier: npm:rolldown-vite@^7.0.5
       version: 7.0.5
 
+overrides:
+  '@types/estree': ^1.0.8
+
 importers:
 
   .:
@@ -2753,9 +2756,6 @@ packages:
 
   '@types/estree-jsx@1.0.3':
     resolution: {integrity: sha512-pvQ+TKeRHeiUGRhvYwRrQ/ISnohKkSJR14fT2yqyZ4e9K5vqc7hrtY2Y1Dw0ZwAzQ6DQsxsaCUuSIIi8v0Cq6w==}
-
-  '@types/estree@1.0.6':
-    resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -7276,8 +7276,6 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
-  '@types/estree@1.0.6': {}
-
   '@types/estree@1.0.8': {}
 
   '@types/fs-extra@11.0.4':
@@ -9805,7 +9803,7 @@ snapshots:
 
   rollup@4.37.0:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.8
     optionalDependencies:
       '@rollup/rollup-android-arm-eabi': 4.37.0
       '@rollup/rollup-android-arm64': 4.37.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,6 @@ packages:
 catalogs:
   rolldown-vite:
     vite: npm:rolldown-vite@^7.0.5
+
+overrides:
+  '@types/estree': ^1.0.8


### PR DESCRIPTION
### Description

This probably fixes https://github.com/vitejs/vite-ecosystem-ci/actions/runs/16160767110/job/45611916056. I'm actually not exactly sure why ecosystem ci is failing, but I know that there's a general issue that `@types/estree` can mismatch easily since `rollup` pins the exact version https://github.com/rollup/rollup/blob/9cebb0b6d9f03d11f53a8c3e7e9e3a79f567e3c6/package.json#L114. If that became different from the one in this repo, then typecheck is destined to fail anyways, so fixing this by overrides for now.