### PR TITLE
test(rsc): fix ssr modulepreload link test

### DIFF
--- a/packages/plugin-rsc/e2e/react-router.test.ts
+++ b/packages/plugin-rsc/e2e/react-router.test.ts
@@ -1,5 +1,4 @@
 import { createHash } from 'node:crypto'
-import path from 'node:path'
 import { expect, test } from '@playwright/test'
 import { type Fixture, useFixture } from './fixture'
 import { expectNoReload, testNoJs, waitForHydration } from './helper'

--- a/packages/plugin-rsc/e2e/react-router.test.ts
+++ b/packages/plugin-rsc/e2e/react-router.test.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import { expect, test } from '@playwright/test'
 import { type Fixture, useFixture } from './fixture'
 import { expectNoReload, testNoJs, waitForHydration } from './helper'
+import { readFileSync } from 'node:fs'
 
 test.describe('dev-default', () => {
   const f = useFixture({ root: 'examples/react-router', mode: 'dev' })
@@ -74,8 +75,11 @@ function defineTest(f: Fixture) {
         .evaluateAll((elements) =>
           elements.map((el) => el.getAttribute('href')),
         )
-      const { default: manifest } = await import(
-        path.resolve(f.root, 'dist/ssr/__vite_rsc_assets_manifest.js')
+      const manifest = JSON.parse(
+        readFileSync(
+          f.root + '/dist/ssr/__vite_rsc_assets_manifest.js',
+          'utf-8',
+        ).slice('export default '.length),
       )
       const hashString = (v: string) =>
         createHash('sha256').update(v).digest().toString('hex').slice(0, 12)


### PR DESCRIPTION
### Description

`__vite_rsc_assets_manifest.js` shouldn't be `import`-ed during the test since the module will be cached inside playwright worker but the content can change between different test variants (e.g. build-default and build-cloudflare). This was making rolldown run to fail on first run (then retry always succeeds since playwright recreate a worker) https://github.com/vitejs/vite-plugin-react/actions/runs/16235033401/job/45843973297#step:9:681

I already did this for `basic.test.ts` https://github.com/vitejs/vite-plugin-react/blob/b2b9276b6e9142637f85e0184e4ddc6ef28e787a/packages/plugin-rsc/e2e/basic.test.ts#L236-L241, but `react-router.test.ts` still had the old one.