### PR TITLE
chore: replace `build --app` with `build` in examples

### DIFF
--- a/packages/plugin-rsc/examples/basic/package.json
+++ b/packages/plugin-rsc/examples/basic/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build --app",
+    "build": "vite build",
     "preview": "vite preview",
     "cf-build": "CF_BUILD=1 pnpm build",
     "cf-preview": "wrangler dev",

--- a/packages/plugin-rsc/examples/react-router/package.json
+++ b/packages/plugin-rsc/examples/react-router/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build --app",
+    "build": "vite build",
     "preview": "vite preview",
     "cf-dev": "vite -c ./cf/vite.config.ts",
     "cf-build": "vite -c ./cf/vite.config.ts build",

--- a/playground/ssr-react/package.json
+++ b/playground/ssr-react/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build --app",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "dependencies": {


### PR DESCRIPTION
### Description

I had `--app` flags in some examples but this is unnecessary.
