### PR TITLE
fix(rsc): await handler to avoid unhandled rejection

### DIFF
--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -303,7 +303,9 @@ export default function vitePluginRsc(
                 `[vite-rsc] failed to resolve server handler '${source}'`,
               )
               const mod = await environment.runner.import(resolved.id)
-              createRequestListener(mod.default)(req, res)
+              // ensure catching rejected promise
+              // https://github.com/mjackson/remix-the-web/blob/b5aa2ae24558f5d926af576482caf6e9b35461dc/packages/node-fetch-server/src/lib/request-listener.ts#L87
+              await createRequestListener(mod.default)(req, res)
             } catch (e) {
               next(e)
             }
@@ -336,7 +338,7 @@ export default function vitePluginRsc(
         return () => {
           server.middlewares.use(async (req, res, next) => {
             try {
-              handler(req, res)
+              await handler(req, res)
             } catch (e) {
               next(e)
             }


### PR DESCRIPTION
### Description

- Related https://github.com/vitejs/vite-plugin-react/pull/573

`@mjackson/node-fetch-server`'s request handler is typed as `void`, but internally it can reject when response stream is broken for whatever reason (e.g. when `ReadableStream/TransformStream`'s `transform`, `flush`, `pull`, etc... throws).
https://github.com/mjackson/remix-the-web/blob/b5aa2ae24558f5d926af576482caf6e9b35461dc/packages/node-fetch-server/src/lib/request-listener.ts#L87

I was comparing with `@hono/node-server` (which is currently used by Waku) and this one swallows any stream errors internally, so the same won't happen. https://github.com/honojs/node-server/blob/cb52c36d1d5d5b68416c807ce4b231c8bc549e29/src/utils.ts#L20-L28. This difference might somehow affects this issue https://github.com/wakujs/waku/issues/1521.

---

Okay, this is likely irrelevant for Waku.

I cannot reproduce any crash externally, but this can happen if there's a "bug" in stream handling e.g.

```js
    responseStream = responseStream.pipeThrough(
      new TransformStream({
        flush() {
          throw new Error("boom")
        }
      }),
    );
```

```
⚠️⚠️⚠️ unhandledRejection ⚠️⚠️⚠️ Error: boom
    at Object.flush (/home/hiroshi/code/others/vite-plugin-react/packages/plugin-rsc/src/extra/ssr.tsx:50:17)
    at invokePromiseCallback (node:internal/webstreams/util:172:10)
    at Object.<anonymous> (node:internal/webstreams/util:177:23)
    at transformStreamDefaultSinkCloseAlgorithm (node:internal/webstreams/transformstream:621:43)
    at node:internal/webstreams/transformstream:379:11
    at writableStreamDefaultControllerProcessClose (node:internal/webstreams/writablestream:1162:28)
    at writableStreamDefaultControllerAdvanceQueueIfNeeded (node:internal/webstreams/writablestream:1251:5)
    at writableStreamDefaultControllerClose (node:internal/webstreams/writablestream:1218:3)
    at writableStreamClose (node:internal/webstreams/writablestream:722:3)
    at writableStreamDefaultWriterClose (node:internal/webstreams/writablestream:1091:10)
```