### PR TITLE
fix(rsc): ensure trailing slash of `BASE_URL`

### DIFF
--- a/packages/plugin-rsc/src/browser.ts
+++ b/packages/plugin-rsc/src/browser.ts
@@ -10,7 +10,9 @@ function initialize(): void {
     load: async (id) => {
       if (!import.meta.env.__vite_rsc_build__) {
         // @ts-ignore
-        return __vite_rsc_raw_import__(import.meta.env.BASE_URL + id.slice(1))
+        return __vite_rsc_raw_import__(
+          withTrailingSlash(import.meta.env.BASE_URL) + id.slice(1),
+        )
       } else {
         const import_ = clientReferences.default[id]
         if (!import_) {
@@ -20,4 +22,12 @@ function initialize(): void {
       }
     },
   })
+}
+
+// https://github.com/vitejs/vite/blob/27a192fc95036dbdb6e615a4201b858eb64aa075/packages/vite/src/shared/utils.ts#L48-L53
+function withTrailingSlash(path: string): string {
+  if (path[path.length - 1] !== '/') {
+    return `${path}/`
+  }
+  return path
 }

--- a/packages/plugin-rsc/src/browser.ts
+++ b/packages/plugin-rsc/src/browser.ts
@@ -24,6 +24,7 @@ function initialize(): void {
   })
 }
 
+// Vite normalizes `config.base` to have trailing slash, but not for `import.meta.env.BASE_URL`.
 // https://github.com/vitejs/vite/blob/27a192fc95036dbdb6e615a4201b858eb64aa075/packages/vite/src/shared/utils.ts#L48-L53
 function withTrailingSlash(path: string): string {
   if (path[path.length - 1] !== '/') {


### PR DESCRIPTION
### Description

- Closes https://github.com/vitejs/vite-plugin-react/issues/582

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

No tests are added. Manually tested by tweaking https://github.com/vitejs/vite-plugin-react/blob/ed59bbeea74a198ea2a3e550106c999e0bd1ad9e/packages/plugin-rsc/examples/basic/vite.config.ts#L21