### PR TITLE
chore(rsc): deprecate `@vitejs/plugin-rsc/extra` API

### DIFF
--- a/packages/plugin-rsc/README.md
+++ b/packages/plugin-rsc/README.md
@@ -419,7 +419,10 @@ export default defineConfig({
 })
 ```
 
-## Higher level API
+## High level API
+
+> [!NOTE]
+> High level API is deprecated. Please write on your own `@vitejs/plugin-rsc/{rsc,ssr,browser}` integration.
 
 This is a wrapper of `react-server-dom` API and helper API to setup a minimal RSC app without writing own framework code like [`./examples/starter/src/framework`](./examples/starter/src/framework/). See [`./examples/basic`](./examples/basic/) for how this API is used.
 

--- a/packages/plugin-rsc/src/extra/browser.tsx
+++ b/packages/plugin-rsc/src/extra/browser.tsx
@@ -11,6 +11,9 @@ import {
 } from '../browser'
 import type { RscPayload } from './rsc'
 
+/**
+ * @deprecated Use `@vitejs/plugin-rsc/browser` API instead.
+ */
 export async function hydrate(): Promise<void> {
   const callServer: CallServerCallback = async (id, args) => {
     const url = new URL(window.location.href)
@@ -71,6 +74,9 @@ export async function hydrate(): Promise<void> {
   }
 }
 
+/**
+ * @deprecated Use `@vitejs/plugin-rsc/browser` API instead.
+ */
 export async function fetchRSC(
   request: string | URL | Request,
 ): Promise<RscPayload['root']> {

--- a/packages/plugin-rsc/src/extra/rsc.tsx
+++ b/packages/plugin-rsc/src/extra/rsc.tsx
@@ -14,6 +14,9 @@ export type RscPayload = {
   returnValue?: unknown
 }
 
+/**
+ * @deprecated Use `@vitejs/plugin-rsc/rsc` API instead.
+ */
 export async function renderRequest(
   request: Request,
   root: React.ReactNode,

--- a/packages/plugin-rsc/src/extra/ssr.tsx
+++ b/packages/plugin-rsc/src/extra/ssr.tsx
@@ -5,6 +5,9 @@ import { injectRSCPayload } from 'rsc-html-stream/server'
 import { createFromReadableStream } from '../ssr'
 import type { RscPayload } from './rsc'
 
+/**
+ * @deprecated Use `@vitejs/plugin-rsc/ssr` API instead.
+ */
 export async function renderHtml(
   rscStream: ReadableStream<Uint8Array>,
   options?: {


### PR DESCRIPTION
### Description

The high level API cannot be flexible and designing such layer is out of the scope of this plugin. React router and Waku only use `@vitejs/plugin-rsc/{ssr,rsc,browser}` API.