### PR TITLE
test(rsc): add more basic tests to starter

### DIFF
--- a/packages/plugin-rsc/e2e/starter.test.ts
+++ b/packages/plugin-rsc/e2e/starter.test.ts
@@ -141,4 +141,23 @@ function defineTest(f: Fixture, variant?: 'no-ssr') {
       0,
     )
   })
+
+  test('css @js', async ({ page }) => {
+    await page.goto(f.url())
+    await waitForHydration(page)
+    await expect(page.locator('.read-the-docs')).toHaveCSS(
+      'color',
+      'rgb(136, 136, 136)',
+    )
+  })
+
+  testNoJs('css @nojs', async ({ page }) => {
+    test.skip(variant === 'no-ssr')
+
+    await page.goto(f.url())
+    await expect(page.locator('.read-the-docs')).toHaveCSS(
+      'color',
+      'rgb(136, 136, 136)',
+    )
+  })
 }

--- a/packages/plugin-rsc/e2e/starter.test.ts
+++ b/packages/plugin-rsc/e2e/starter.test.ts
@@ -151,13 +151,15 @@ function defineTest(f: Fixture, variant?: 'no-ssr') {
     )
   })
 
-  testNoJs('css @nojs', async ({ page }) => {
+  test.describe(() => {
     test.skip(variant === 'no-ssr')
 
-    await page.goto(f.url())
-    await expect(page.locator('.read-the-docs')).toHaveCSS(
-      'color',
-      'rgb(136, 136, 136)',
-    )
+    testNoJs('css @nojs', async ({ page }) => {
+      await page.goto(f.url())
+      await expect(page.locator('.read-the-docs')).toHaveCSS(
+        'color',
+        'rgb(136, 136, 136)',
+      )
+    })
   })
 }

--- a/packages/plugin-rsc/e2e/starter.test.ts
+++ b/packages/plugin-rsc/e2e/starter.test.ts
@@ -117,15 +117,14 @@ function defineTest(f: Fixture, variant?: 'no-ssr') {
       await page.goto(f.url())
       await waitForHydration(page)
       await using _ = await expectNoReload(page)
+      await expect(page.getByText('Vite + RSC')).toBeVisible()
       const editor = f.createEditor('src/root.tsx')
-      editor.edit((s) => s.replace('Server Counter', 'Server [edit] Counter'))
-      await expect(
-        page.getByRole('button', { name: 'Server [edit] Counter: 0' }),
-      ).toBeVisible()
+      editor.edit((s) =>
+        s.replace('<h1>Vite + RSC</h1>', '<h1>Vite x RSC</h1>'),
+      )
+      await expect(page.getByText('Vite x RSC')).toBeVisible()
       editor.reset()
-      await expect(
-        page.getByRole('button', { name: 'Server Counter: 0' }),
-      ).toBeVisible()
+      await expect(page.getByText('Vite + RSC')).toBeVisible()
     })
   })
 

--- a/packages/plugin-rsc/e2e/starter.test.ts
+++ b/packages/plugin-rsc/e2e/starter.test.ts
@@ -110,6 +110,25 @@ function defineTest(f: Fixture, variant?: 'no-ssr') {
     await page.getByRole('button', { name: 'Client Counter: 0' }).click()
   })
 
+  test.describe(() => {
+    test.skip(f.mode === 'build')
+
+    test('server hmr', async ({ page }) => {
+      await page.goto(f.url())
+      await waitForHydration(page)
+      await using _ = await expectNoReload(page)
+      const editor = f.createEditor('src/root.tsx')
+      editor.edit((s) => s.replace('Server Counter', 'Server [edit] Counter'))
+      await expect(
+        page.getByRole('button', { name: 'Server [edit] Counter: 0' }),
+      ).toBeVisible()
+      editor.reset()
+      await expect(
+        page.getByRole('button', { name: 'Server Counter: 0' }),
+      ).toBeVisible()
+    })
+  })
+
   test('image assets', async ({ page }) => {
     await page.goto(f.url())
     await waitForHydration(page)


### PR DESCRIPTION
### Description

The idea is to eventually move "variant tests" (e.g. custom base, react compiler etc...) from `basic.test.ts` to more smaller `starter.test.ts` to reduce overall test time as running full-fledged `basic.test.ts` for each variants seem to be overkill. But currently `starter.test.ts`'s coverage is too small, so this PR starts with copying equivalent tests from `basic.test.ts` to `starter.test.ts`.
