### PR TITLE
test(rsc): refactor variant tests

### DIFF
--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -72,39 +72,6 @@ test.describe('build-base', () => {
   defineTest(f)
 })
 
-test.describe('dev-react-compiler', () => {
-  const f = useFixture({
-    root: 'examples/basic',
-    mode: 'dev',
-    cliOptions: {
-      env: {
-        TEST_REACT_COMPILER: 'true',
-      },
-    },
-  })
-  defineTest(f)
-
-  test('verify react compiler', async ({ page }) => {
-    await page.goto(f.url())
-    await waitForHydration(page)
-    const res = await page.request.get(f.url('src/routes/client.tsx'))
-    expect(await res.text()).toContain('react.memo_cache_sentinel')
-  })
-})
-
-test.describe('build-react-compiler', () => {
-  const f = useFixture({
-    root: 'examples/basic',
-    mode: 'build',
-    cliOptions: {
-      env: {
-        TEST_REACT_COMPILER: 'true',
-      },
-    },
-  })
-  defineTest(f)
-})
-
 test.describe(() => {
   // disabled by default
   if (process.env.TEST_ISOLATED !== 'true') return

--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -46,32 +46,6 @@ test.describe('build-default', () => {
   defineTest(f)
 })
 
-test.describe('dev-base', () => {
-  const f = useFixture({
-    root: 'examples/basic',
-    mode: 'dev',
-    cliOptions: {
-      env: {
-        TEST_BASE: 'true',
-      },
-    },
-  })
-  defineTest(f)
-})
-
-test.describe('build-base', () => {
-  const f = useFixture({
-    root: 'examples/basic',
-    mode: 'build',
-    cliOptions: {
-      env: {
-        TEST_BASE: 'true',
-      },
-    },
-  })
-  defineTest(f)
-})
-
 test.describe(() => {
   // disabled by default
   if (process.env.TEST_ISOLATED !== 'true') return

--- a/packages/plugin-rsc/e2e/fixture.ts
+++ b/packages/plugin-rsc/e2e/fixture.ts
@@ -193,7 +193,36 @@ function editFileJson(filepath: string, edit: (s: string) => string) {
   )
 }
 
+// inspired by
+//   https://github.com/remix-run/react-router/blob/433872f6ab098eaf946cc6c9cf80abf137420ad2/integration/helpers/vite.ts#L239
+// for syntax highlighting of /* js */, use this extension
+//   https://github.com/mjbvz/vscode-comment-tagged-templates
 export async function setupInlineFixture(options: {
   src: string
   dest: string
-}) {}
+  files?: Record<string, string>
+}) {
+  fs.rmSync(options.dest, { recursive: true, force: true })
+  fs.mkdirSync(options.dest, { recursive: true })
+
+  // copy src
+  fs.cpSync(options.src, options.dest, {
+    recursive: true,
+    filter: (src) => !src.includes('node_modules') && !src.includes('dist'),
+  })
+
+  // write additional files
+  if (options.files) {
+    for (const [filename, contents] of Object.entries(options.files)) {
+      let filepath = path.join(options.dest, filename)
+      fs.mkdirSync(path.dirname(filepath), { recursive: true })
+      // strip indent
+      const indent = contents.match(/^\s*/)?.[0] ?? ''
+      const strippedContents = contents
+        .split('\n')
+        .map((line) => line.replace(new RegExp(`^${indent}`), ''))
+        .join('\n')
+      fs.writeFileSync(filepath, strippedContents)
+    }
+  }
+}

--- a/packages/plugin-rsc/e2e/fixture.ts
+++ b/packages/plugin-rsc/e2e/fixture.ts
@@ -192,3 +192,8 @@ function editFileJson(filepath: string, edit: (s: string) => string) {
     ),
   )
 }
+
+export async function setupInlineFixture(options: {
+  src: string
+  dest: string
+}) {}

--- a/packages/plugin-rsc/e2e/starter.test.ts
+++ b/packages/plugin-rsc/e2e/starter.test.ts
@@ -141,4 +141,23 @@ function defineTest(f: Fixture, variant?: 'no-ssr') {
       0,
     )
   })
+
+  test('css @js', async ({ page }) => {
+    await page.goto(f.url())
+    await waitForHydration(page)
+    await expect(page.locator('.read-the-docs')).toHaveCSS(
+      'color',
+      'rgb(136, 136, 136)',
+    )
+  })
+
+  testNoJs('css @nojs', async ({ page }) => {
+    test.skip(variant === 'no-ssr')
+
+    await page.goto(f.url())
+    await expect(page.locator('.read-the-docs')).toHaveCSS(
+      'color',
+      'rgb(136, 136, 136)',
+    )
+  })
 }

--- a/packages/plugin-rsc/e2e/starter.test.ts
+++ b/packages/plugin-rsc/e2e/starter.test.ts
@@ -151,13 +151,15 @@ function defineTest(f: Fixture, variant?: 'no-ssr') {
     )
   })
 
-  testNoJs('css @nojs', async ({ page }) => {
+  test.describe(() => {
     test.skip(variant === 'no-ssr')
 
-    await page.goto(f.url())
-    await expect(page.locator('.read-the-docs')).toHaveCSS(
-      'color',
-      'rgb(136, 136, 136)',
-    )
+    testNoJs('css @nojs', async ({ page }) => {
+      await page.goto(f.url())
+      await expect(page.locator('.read-the-docs')).toHaveCSS(
+        'color',
+        'rgb(136, 136, 136)',
+      )
+    })
   })
 }

--- a/packages/plugin-rsc/e2e/starter.test.ts
+++ b/packages/plugin-rsc/e2e/starter.test.ts
@@ -117,15 +117,14 @@ function defineTest(f: Fixture, variant?: 'no-ssr') {
       await page.goto(f.url())
       await waitForHydration(page)
       await using _ = await expectNoReload(page)
+      await expect(page.getByText('Vite + RSC')).toBeVisible()
       const editor = f.createEditor('src/root.tsx')
-      editor.edit((s) => s.replace('Server Counter', 'Server [edit] Counter'))
-      await expect(
-        page.getByRole('button', { name: 'Server [edit] Counter: 0' }),
-      ).toBeVisible()
+      editor.edit((s) =>
+        s.replace('<h1>Vite + RSC</h1>', '<h1>Vite x RSC</h1>'),
+      )
+      await expect(page.getByText('Vite x RSC')).toBeVisible()
       editor.reset()
-      await expect(
-        page.getByRole('button', { name: 'Server Counter: 0' }),
-      ).toBeVisible()
+      await expect(page.getByText('Vite + RSC')).toBeVisible()
     })
   })
 

--- a/packages/plugin-rsc/e2e/starter.test.ts
+++ b/packages/plugin-rsc/e2e/starter.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test'
-import { type Fixture, useFixture } from './fixture'
+import { setupInlineFixture, type Fixture, useFixture } from './fixture'
 import {
   expectNoReload,
   testNoJs,
@@ -39,6 +39,27 @@ test.describe('build-no-ssr', () => {
 
   test('no ssr build', () => {
     expect(fs.existsSync(path.join(f.root, 'dist/ssr'))).toBe(false)
+  })
+})
+
+test.describe(() => {
+  const root = 'temp/starter-react-compiler'
+
+  test.beforeAll(async () => {
+    await setupInlineFixture({
+      src: 'examples/starter',
+      dest: root,
+    })
+  })
+
+  test.describe('dev-react-compiler', () => {
+    const f = useFixture({ root, mode: 'dev' })
+    defineTest(f)
+  })
+
+  test.describe('build-react-compiler', () => {
+    const f = useFixture({ root, mode: 'build' })
+    defineTest(f)
   })
 })
 

--- a/packages/plugin-rsc/e2e/starter.test.ts
+++ b/packages/plugin-rsc/e2e/starter.test.ts
@@ -43,7 +43,7 @@ test.describe('build-no-ssr', () => {
 })
 
 test.describe(() => {
-  const root = 'examples/e2e/temp/starter-react-compiler'
+  const root = 'examples/e2e/temp/react-compiler'
 
   test.beforeAll(async () => {
     await setupInlineFixture({

--- a/packages/plugin-rsc/e2e/starter.test.ts
+++ b/packages/plugin-rsc/e2e/starter.test.ts
@@ -95,6 +95,54 @@ test.describe(() => {
   })
 })
 
+test.describe(() => {
+  const root = 'examples/e2e/temp/base'
+
+  test.beforeAll(async () => {
+    await setupInlineFixture({
+      src: 'examples/starter',
+      dest: root,
+      files: {
+        'vite.config.ts': /* js */ `
+          import rsc from '@vitejs/plugin-rsc'
+          import react from '@vitejs/plugin-react'
+          import { defineConfig } from 'vite'
+
+          export default defineConfig({
+            base: '/custom-base/',
+            plugins: [
+              react(),
+              rsc({
+                entries: {
+                  client: './src/framework/entry.browser.tsx',
+                  ssr: './src/framework/entry.ssr.tsx',
+                  rsc: './src/framework/entry.rsc.tsx',
+                }
+              }),
+            ],
+          })
+        `,
+      },
+    })
+  })
+
+  test.describe('dev-base', () => {
+    const f = useFixture({ root, mode: 'dev' })
+    defineTest({
+      ...f,
+      url: (url) => new URL(url ?? './', f.url('./custom-base/')).href,
+    })
+  })
+
+  test.describe('build-base', () => {
+    const f = useFixture({ root, mode: 'build' })
+    defineTest({
+      ...f,
+      url: (url) => new URL(url ?? './', f.url('./custom-base/')).href,
+    })
+  })
+})
+
 function defineTest(f: Fixture, variant?: 'no-ssr') {
   const waitForHydration: typeof waitForHydration_ = (page) =>
     waitForHydration_(page, variant === 'no-ssr' ? '#root' : 'body')

--- a/packages/plugin-rsc/e2e/starter.test.ts
+++ b/packages/plugin-rsc/e2e/starter.test.ts
@@ -110,6 +110,25 @@ function defineTest(f: Fixture, variant?: 'no-ssr') {
     await page.getByRole('button', { name: 'Client Counter: 0' }).click()
   })
 
+  test.describe(() => {
+    test.skip(f.mode === 'build')
+
+    test('server hmr', async ({ page }) => {
+      await page.goto(f.url())
+      await waitForHydration(page)
+      await using _ = await expectNoReload(page)
+      const editor = f.createEditor('src/root.tsx')
+      editor.edit((s) => s.replace('Server Counter', 'Server [edit] Counter'))
+      await expect(
+        page.getByRole('button', { name: 'Server [edit] Counter: 0' }),
+      ).toBeVisible()
+      editor.reset()
+      await expect(
+        page.getByRole('button', { name: 'Server Counter: 0' }),
+      ).toBeVisible()
+    })
+  })
+
   test('image assets', async ({ page }) => {
     await page.goto(f.url())
     await waitForHydration(page)

--- a/packages/plugin-rsc/examples/basic/package.json
+++ b/packages/plugin-rsc/examples/basic/package.json
@@ -25,7 +25,6 @@
     "@vitejs/test-dep-client-in-server2": "file:./test-dep/client-in-server2",
     "@vitejs/test-dep-server-in-client": "file:./test-dep/server-in-client",
     "@vitejs/test-dep-server-in-server": "file:./test-dep/server-in-server",
-    "babel-plugin-react-compiler": "19.1.0-rc.2",
     "tailwindcss": "^4.1.11",
     "vite": "^7.0.4",
     "vite-plugin-inspect": "^11.3.0",

--- a/packages/plugin-rsc/examples/basic/vite.config.ts
+++ b/packages/plugin-rsc/examples/basic/vite.config.ts
@@ -11,14 +11,7 @@ export default defineConfig({
   clearScreen: false,
   plugins: [
     tailwindcss(),
-    process.env.TEST_REACT_COMPILER
-      ? react({
-          babel: { plugins: ['babel-plugin-react-compiler'] },
-        }).map((p) => ({
-          ...p,
-          applyToEnvironment: (e) => e.name === 'client',
-        }))
-      : react(),
+    react(),
     vitePluginUseCache(),
     rsc({
       entries: {

--- a/packages/plugin-rsc/examples/basic/vite.config.ts
+++ b/packages/plugin-rsc/examples/basic/vite.config.ts
@@ -7,7 +7,6 @@ import inspect from 'vite-plugin-inspect'
 import path from 'node:path'
 
 export default defineConfig({
-  base: process.env.TEST_BASE ? '/custom-base/' : undefined,
   clearScreen: false,
   plugins: [
     tailwindcss(),

--- a/packages/plugin-rsc/examples/e2e/package.json
+++ b/packages/plugin-rsc/examples/e2e/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@vitejs/plugin-rsc-examples-e2e-temp",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@vitejs/plugin-rsc": "latest",
+    "@vitejs/plugin-react": "latest",
+    "babel-plugin-react-compiler": "19.1.0-rc.2"
+  }
+}

--- a/packages/plugin-rsc/examples/e2e/package.json
+++ b/packages/plugin-rsc/examples/e2e/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@vitejs/plugin-rsc-examples-e2e-temp",
+  "name": "@vitejs/plugin-rsc-examples-e2e",
   "private": true,
   "type": "module",
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -542,9 +542,6 @@ importers:
       '@vitejs/test-dep-server-in-server':
         specifier: file:./test-dep/server-in-server
         version: file:packages/plugin-rsc/examples/basic/test-dep/server-in-server(react@19.1.0)
-      babel-plugin-react-compiler:
-        specifier: 19.1.0-rc.2
-        version: 19.1.0-rc.2
       tailwindcss:
         specifier: ^4.1.11
         version: 4.1.11

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -558,6 +558,18 @@ importers:
         specifier: ^4.24.3
         version: 4.24.3
 
+  packages/plugin-rsc/examples/e2e:
+    devDependencies:
+      '@vitejs/plugin-react':
+        specifier: latest
+        version: link:../../../plugin-react
+      '@vitejs/plugin-rsc':
+        specifier: latest
+        version: link:../..
+      babel-plugin-react-compiler:
+        specifier: 19.1.0-rc.2
+        version: 19.1.0-rc.2
+
   packages/plugin-rsc/examples/no-ssr:
     dependencies:
       '@vitejs/plugin-rsc':
@@ -7741,7 +7753,7 @@ snapshots:
 
   babel-plugin-react-compiler@19.1.0-rc.2:
     dependencies:
-      '@babel/types': 7.27.7
+      '@babel/types': 7.28.0
 
   bail@2.0.2: {}
 


### PR DESCRIPTION
### Description

Inspired by React Router's integration test ([example](https://github.com/remix-run/react-router/blob/433872f6ab098eaf946cc6c9cf80abf137420ad2/integration/rsc/rsc-test.ts#L110-L123)), this PR setups more scale-able approach of testing different scenarios based on small number of templates.

The file structure looks like this:

- `examples/e2e/temp`
  - This is a base directory of test project. For example, this PR uses `examples/e2e/temp/react-compiler`, which is setup by `setupInlineFixture` utility. It uses `examples/starter` as a base project and additionally it replaces `vite.config.ts` to setup react compiler plugin.
  - This whole directory is ignored, but each test project is run-able locally e.g. by 
    `pnpm -C packages/plugin-rsc/examples/e2e/temp/react-compiler dev`
- `examples/e2e/package.json`
  - The dependencies for `temp` projects are listed here. For example, it has `babel-plugin-react-compiler` for the test above.

I likely do more iterations, but for now, this PR migrates custom base test and react-compiler test to this system. This allows cutting down test times since they only test based on `examples/starter` and not the huge `examples/basic`.