### PR TITLE
feat(rsc): add `frameworkPackages` option to control server external

### DIFF
--- a/packages/plugin-rsc/examples/basic/vite.config.ts
+++ b/packages/plugin-rsc/examples/basic/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
         ssr: './src/framework/entry.ssr.tsx',
         rsc: './src/server.tsx',
       },
+      frameworkPackages: ['react'],
       // disable auto css injection to manually test `loadCss` feature.
       rscCssTransform: false,
       ignoredPackageWarnings: [/@vitejs\/test-dep-/],

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -112,7 +112,7 @@ export type RscPluginOptions = {
   keepUseCientProxy?: boolean
 
   /**
-   * The packages which depends on `frameworkPackages` will be added to `noExternal`
+   * The packages which depend on `frameworkPackages` will be automatically added to `noExternal`.
    * @default ["react"]
    */
   frameworkPackages?: string[]
@@ -129,10 +129,14 @@ export default function vitePluginRsc(
 
         // crawl packages with "react" in "peerDependencies" to bundle react deps on server
         // see https://github.com/svitejs/vitefu/blob/d8d82fa121e3b2215ba437107093c77bde51b63b/src/index.js#L95-L101
+        const frameworkPackages = rscPluginOptions.frameworkPackages || [
+          'react',
+        ]
         const result = await crawlFrameworkPkgs({
           root: process.cwd(),
           isBuild: env.command === 'build',
           isFrameworkPkgByJson(pkgJson) {
+            // these are added by default
             if ([PKG_NAME, 'react-dom'].includes(pkgJson.name)) {
               return false
             }
@@ -140,8 +144,7 @@ export default function vitePluginRsc(
               ...pkgJson['dependencies'],
               ...pkgJson['peerDependencies'],
             }
-            Object.keys(deps)
-            return 'react' in deps
+            return frameworkPackages.some((name) => name in deps)
           },
         })
         const noExternal = [

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -110,6 +110,12 @@ export type RscPluginOptions = {
 
   /** Escape hatch for Waku's `allowServer` */
   keepUseCientProxy?: boolean
+
+  /**
+   * The packages which depends on `frameworkPackages` will be added to `noExternal`
+   * @default ["react"]
+   */
+  frameworkPackages?: string[]
 }
 
 export default function vitePluginRsc(
@@ -128,10 +134,14 @@ export default function vitePluginRsc(
           isBuild: env.command === 'build',
           isFrameworkPkgByJson(pkgJson) {
             if ([PKG_NAME, 'react-dom'].includes(pkgJson.name)) {
-              return
+              return false
             }
-            const deps = pkgJson['peerDependencies']
-            return deps && 'react' in deps
+            const deps = {
+              ...pkgJson['dependencies'],
+              ...pkgJson['peerDependencies'],
+            }
+            Object.keys(deps)
+            return 'react' in deps
           },
         })
         const noExternal = [

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -136,7 +136,7 @@ export default function vitePluginRsc(
           root: process.cwd(),
           isBuild: env.command === 'build',
           isFrameworkPkgByJson(pkgJson) {
-            // these are added by default
+            // these are added by default and don't need to crawl further
             if ([PKG_NAME, 'react-dom'].includes(pkgJson.name)) {
               return false
             }


### PR DESCRIPTION
### Description

Related
- https://github.com/wakujs/waku/pull/1493
- https://github.com/wakujs/waku/pull/1552

Currently rsc plugin automatically `noExternal`-ize dependencies with `react` in peerDependencies (i.e. 3rd party react package) to ensure all react import goes through Vite transform pipelines. This can be extended to support higher level framework such as `waku`, which has its own ecosystem package `waku-jotai` and we want to allow automatically `noExternal`izing them in the same way.

TODO
- [x] test (just trivial one)
- [x] doc (just jsdoc)
