### PR TITLE
ci: add workflow_dispatch to ci-rsc

### DIFF
--- a/.github/workflows/ci-rsc.yml
+++ b/.github/workflows/ci-rsc.yml
@@ -3,6 +3,7 @@ name: ci-rsc
 permissions: {}
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
### Description

This allows running ci-rsc manually even when `packages/plugin-rsc` hasn't changed.