### PR TITLE
fix(rsc): handle transform errors before server hmr

### DIFF
--- a/packages/plugin-rsc/e2e/syntax-error.test.ts
+++ b/packages/plugin-rsc/e2e/syntax-error.test.ts
@@ -152,9 +152,7 @@ test.describe(() => {
         ),
       )
       await page.goto(f.url())
-      await expect(page.locator('body')).toContainText(
-        'Transform failed with 1 error',
-      )
+      await expect(page.locator('body')).toContainText('src/client.tsx:15')
 
       // fix syntax error
       await page.waitForTimeout(200)
@@ -187,9 +185,7 @@ test.describe(() => {
         ),
       )
       await page.goto(f.url())
-      await expect(page.locator('body')).toContainText(
-        'Transform failed with 1 error',
-      )
+      await expect(page.locator('body')).toContainText('src/root.tsx:11')
 
       // fix syntax error
       await page.waitForTimeout(200)

--- a/packages/plugin-rsc/e2e/syntax-error.test.ts
+++ b/packages/plugin-rsc/e2e/syntax-error.test.ts
@@ -70,6 +70,7 @@ function defineSyntaxErrorTests(f: Fixture) {
   test('client syntax error triggers error overlay', async ({ page }) => {
     await page.goto(f.url())
     await waitForHydration(page)
+    await using _ = await expectNoReload(page)
 
     await expect(page.getByTestId('client-syntax-ready')).toBeVisible()
 
@@ -96,6 +97,7 @@ function defineSyntaxErrorTests(f: Fixture) {
   test('server syntax error triggers error overlay', async ({ page }) => {
     await page.goto(f.url())
     await waitForHydration(page)
+    await using _ = await expectNoReload(page)
 
     await expect(page.getByTestId('server-syntax-ready')).toBeVisible()
 

--- a/packages/plugin-rsc/e2e/syntax-error.test.ts
+++ b/packages/plugin-rsc/e2e/syntax-error.test.ts
@@ -1,0 +1,192 @@
+import { test, expect } from '@playwright/test'
+import { setupInlineFixture, type Fixture, useFixture } from './fixture'
+import { waitForHydration } from './helper'
+
+test.describe(() => {
+  const root = 'examples/e2e/temp/syntax-error'
+
+  test.beforeAll(async () => {
+    await setupInlineFixture({
+      src: 'examples/starter',
+      dest: root,
+      files: {
+        'src/root.tsx': /* tsx */ `
+          import { TestSyntaxErrorClient } from './client.tsx'
+          import { TestSyntaxErrorServer } from './server.tsx'
+
+          export function Root() {
+            return (
+              <html lang="en">
+                <head>
+                  <meta charSet="UTF-8" />
+                </head>
+                <body>
+                  <TestSyntaxErrorClient />
+                  <TestSyntaxErrorServer />
+                </body>
+              </html>
+            )
+          }
+        `,
+        'src/client.tsx': /* tsx */ `
+          "use client";
+          import { useState } from 'react'
+
+          export function TestSyntaxErrorClient() {
+            const [triggerError, setTriggerError] = useState(false)
+            
+            return (
+              <div data-testid="client-syntax-ready">
+                <button 
+                  onClick={() => setTriggerError(true)}
+                  data-testid="trigger-client-syntax-error"
+                >
+                  Trigger Client Syntax Error
+                </button>
+                {triggerError && <div>Client ready for syntax error</div>}
+              </div>
+            )
+          }
+        `,
+        'src/server.tsx': /* tsx */ `
+          export function TestSyntaxErrorServer() {
+            return (
+              <div data-testid="server-syntax-ready">
+                Server ready for syntax error testing
+              </div>
+            )
+          }
+        `,
+      },
+    })
+  })
+
+  function defineSyntaxErrorTests(f: Fixture) {
+    test('client syntax error triggers error overlay', async ({ page }) => {
+      await page.goto(f.url())
+      await waitForHydration(page)
+
+      await expect(page.getByTestId('client-syntax-ready')).toBeVisible()
+
+      // Edit client file to introduce syntax error
+      const editor = f.createEditor('src/client.tsx')
+      editor.edit((s) =>
+        s.replace(
+          'export function TestSyntaxErrorClient() {',
+          'export function TestSyntaxErrorClient() { const invalid = ;',
+        ),
+      )
+
+      // Should see error overlay
+      await expect(page.locator('vite-error-overlay')).toBeVisible({
+        timeout: 5000,
+      })
+
+      // Fix syntax error
+      editor.reset()
+
+      // Error overlay should disappear and page should work
+      await expect(page.locator('vite-error-overlay')).not.toBeVisible({
+        timeout: 5000,
+      })
+      await expect(page.getByTestId('client-syntax-ready')).toBeVisible()
+    })
+
+    test('server syntax error triggers error overlay', async ({ page }) => {
+      await page.goto(f.url())
+      await waitForHydration(page)
+
+      await expect(page.getByTestId('server-syntax-ready')).toBeVisible()
+
+      // Edit server file to introduce syntax error
+      const editor = f.createEditor('src/server.tsx')
+      editor.edit((s) =>
+        s.replace(
+          'export function TestSyntaxErrorServer() {',
+          'export function TestSyntaxErrorServer() { const invalid = ;',
+        ),
+      )
+
+      // Should see error overlay
+      await expect(page.locator('vite-error-overlay')).toBeVisible({
+        timeout: 5000,
+      })
+
+      // Fix syntax error
+      editor.reset()
+
+      // Error overlay should disappear and server HMR should work
+      await expect(page.locator('vite-error-overlay')).not.toBeVisible({
+        timeout: 10000,
+      })
+      await expect(page.getByTestId('server-syntax-ready')).toBeVisible()
+    })
+
+    test('initial SSR with server component syntax error shows error page', async ({
+      page,
+    }) => {
+      // Edit server file to introduce syntax error before navigation
+      const editor = f.createEditor('src/server.tsx')
+      editor.edit((s) =>
+        s.replace(
+          'export function TestSyntaxErrorServer() {',
+          'export function TestSyntaxErrorServer() { const invalid = ;',
+        ),
+      )
+
+      // Navigate to page with syntax error
+      await page.goto(f.url())
+
+      // Should see error content (check for the actual error text visible in the output)
+      await expect(page.locator('body')).toContainText(
+        'Transform failed with 1 error',
+      )
+
+      // Fix syntax error
+      editor.reset()
+
+      // Wait a bit for file system changes to be detected
+      await page.waitForTimeout(100)
+
+      // Should work normally now
+      await page.goto(f.url())
+      await waitForHydration(page)
+      await expect(page.getByTestId('server-syntax-ready')).toBeVisible()
+    })
+
+    test('initial SSR with client component syntax error shows error page', async ({
+      page,
+    }) => {
+      // Edit client file to introduce syntax error before navigation
+      const editor = f.createEditor('src/client.tsx')
+      editor.edit((s) =>
+        s.replace(
+          'export function TestSyntaxErrorClient() {',
+          'export function TestSyntaxErrorClient() { const invalid = ;',
+        ),
+      )
+
+      // Navigate to page with syntax error
+      await page.goto(f.url())
+
+      // Should see error content (client syntax errors during SSR)
+      await expect(page.locator('body')).toContainText('Unexpected token')
+
+      // Fix syntax error
+      editor.reset()
+
+      // Wait a bit for file system changes to be detected
+      await page.waitForTimeout(100)
+
+      // Should work normally now
+      await page.goto(f.url())
+      await waitForHydration(page)
+      await expect(page.getByTestId('client-syntax-ready')).toBeVisible()
+    })
+  }
+
+  test.describe('dev', () => {
+    const f = useFixture({ root, mode: 'dev' })
+    defineSyntaxErrorTests(f)
+  })
+})

--- a/packages/plugin-rsc/e2e/syntax-error.test.ts
+++ b/packages/plugin-rsc/e2e/syntax-error.test.ts
@@ -72,8 +72,6 @@ function defineSyntaxErrorTests(f: Fixture) {
     await waitForHydration(page)
     await using _ = await expectNoReload(page)
 
-    await expect(page.getByTestId('client-syntax-ready')).toBeVisible()
-
     // Edit client file to introduce syntax error
     const editor = f.createEditor('src/client.tsx')
     editor.edit((s) =>
@@ -99,8 +97,6 @@ function defineSyntaxErrorTests(f: Fixture) {
     await waitForHydration(page)
     await using _ = await expectNoReload(page)
 
-    await expect(page.getByTestId('server-syntax-ready')).toBeVisible()
-
     // Set client state to verify it's preserved after server HMR
     await page.getByTestId('client-counter').click()
     await expect(page.getByTestId('client-counter')).toHaveText(
@@ -123,11 +119,10 @@ function defineSyntaxErrorTests(f: Fixture) {
     editor.reset()
 
     // Error overlay should disappear and server should work again
-    await expect(page.locator('vite-error-overlay')).not.toBeVisible({
-      timeout: 15000,
-    })
+    await expect(page.locator('vite-error-overlay')).not.toBeVisible()
     await expect(page.getByTestId('server-syntax-ready')).toBeVisible()
 
+    // TODO
     // Verify client state is preserved (no full reload happened)
     await expect(page.getByTestId('client-counter')).toHaveText(
       'Client Count: 1',

--- a/packages/plugin-rsc/e2e/syntax-error.test.ts
+++ b/packages/plugin-rsc/e2e/syntax-error.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test'
 import { setupInlineFixture, type Fixture, useFixture } from './fixture'
-import { waitForHydration } from './helper'
+import { waitForHydration, expectNoReload } from './helper'
 
 test.describe(() => {
   const root = 'examples/e2e/temp/syntax-error'
@@ -33,17 +33,16 @@ test.describe(() => {
           import { useState } from 'react'
 
           export function TestSyntaxErrorClient() {
-            const [triggerError, setTriggerError] = useState(false)
+            const [count, setCount] = useState(0)
             
             return (
               <div data-testid="client-syntax-ready">
                 <button 
-                  onClick={() => setTriggerError(true)}
-                  data-testid="trigger-client-syntax-error"
+                  onClick={() => setCount(count + 1)}
+                  data-testid="client-counter"
                 >
-                  Trigger Client Syntax Error
+                  Client Count: {count}
                 </button>
-                {triggerError && <div>Client ready for syntax error</div>}
               </div>
             )
           }
@@ -61,132 +60,124 @@ test.describe(() => {
     })
   })
 
-  function defineSyntaxErrorTests(f: Fixture) {
-    test('client syntax error triggers error overlay', async ({ page }) => {
-      await page.goto(f.url())
-      await waitForHydration(page)
-
-      await expect(page.getByTestId('client-syntax-ready')).toBeVisible()
-
-      // Edit client file to introduce syntax error
-      const editor = f.createEditor('src/client.tsx')
-      editor.edit((s) =>
-        s.replace(
-          'export function TestSyntaxErrorClient() {',
-          'export function TestSyntaxErrorClient() { const invalid = ;',
-        ),
-      )
-
-      // Should see error overlay
-      await expect(page.locator('vite-error-overlay')).toBeVisible({
-        timeout: 5000,
-      })
-
-      // Fix syntax error
-      editor.reset()
-
-      // Error overlay should disappear and page should work
-      await expect(page.locator('vite-error-overlay')).not.toBeVisible({
-        timeout: 5000,
-      })
-      await expect(page.getByTestId('client-syntax-ready')).toBeVisible()
-    })
-
-    test('server syntax error triggers error overlay', async ({ page }) => {
-      await page.goto(f.url())
-      await waitForHydration(page)
-
-      await expect(page.getByTestId('server-syntax-ready')).toBeVisible()
-
-      // Edit server file to introduce syntax error
-      const editor = f.createEditor('src/server.tsx')
-      editor.edit((s) =>
-        s.replace(
-          'export function TestSyntaxErrorServer() {',
-          'export function TestSyntaxErrorServer() { const invalid = ;',
-        ),
-      )
-
-      // Should see error overlay
-      await expect(page.locator('vite-error-overlay')).toBeVisible({
-        timeout: 5000,
-      })
-
-      // Fix syntax error
-      editor.reset()
-
-      // Error overlay should disappear and server HMR should work
-      await expect(page.locator('vite-error-overlay')).not.toBeVisible({
-        timeout: 10000,
-      })
-      await expect(page.getByTestId('server-syntax-ready')).toBeVisible()
-    })
-
-    test('initial SSR with server component syntax error shows error page', async ({
-      page,
-    }) => {
-      // Edit server file to introduce syntax error before navigation
-      const editor = f.createEditor('src/server.tsx')
-      editor.edit((s) =>
-        s.replace(
-          'export function TestSyntaxErrorServer() {',
-          'export function TestSyntaxErrorServer() { const invalid = ;',
-        ),
-      )
-
-      // Navigate to page with syntax error
-      await page.goto(f.url())
-
-      // Should see error content (check for the actual error text visible in the output)
-      await expect(page.locator('body')).toContainText(
-        'Transform failed with 1 error',
-      )
-
-      // Fix syntax error
-      editor.reset()
-
-      // Wait a bit for file system changes to be detected
-      await page.waitForTimeout(100)
-
-      // Should work normally now
-      await page.goto(f.url())
-      await waitForHydration(page)
-      await expect(page.getByTestId('server-syntax-ready')).toBeVisible()
-    })
-
-    test('initial SSR with client component syntax error shows error page', async ({
-      page,
-    }) => {
-      // Edit client file to introduce syntax error before navigation
-      const editor = f.createEditor('src/client.tsx')
-      editor.edit((s) =>
-        s.replace(
-          'export function TestSyntaxErrorClient() {',
-          'export function TestSyntaxErrorClient() { const invalid = ;',
-        ),
-      )
-
-      // Navigate to page with syntax error
-      await page.goto(f.url())
-
-      // Should see error content (client syntax errors during SSR)
-      await expect(page.locator('body')).toContainText('Unexpected token')
-
-      // Fix syntax error
-      editor.reset()
-
-      // Wait a bit for file system changes to be detected
-      await page.waitForTimeout(100)
-
-      // Should work normally now
-      await page.goto(f.url())
-      await waitForHydration(page)
-      await expect(page.getByTestId('client-syntax-ready')).toBeVisible()
-    })
-  }
-
   test.describe('dev', () => {
     const f = useFixture({ root, mode: 'dev' })
     defineSyntaxErrorTests(f)
   })
 })
+
+function defineSyntaxErrorTests(f: Fixture) {
+  test('client syntax error triggers error overlay', async ({ page }) => {
+    await page.goto(f.url())
+    await waitForHydration(page)
+
+    await expect(page.getByTestId('client-syntax-ready')).toBeVisible()
+
+    // Edit client file to introduce syntax error
+    const editor = f.createEditor('src/client.tsx')
+    editor.edit((s) =>
+      s.replace(
+        'export function TestSyntaxErrorClient() {',
+        'export function TestSyntaxErrorClient() { const invalid = ;',
+      ),
+    )
+
+    // Should see error overlay
+    await expect(page.locator('vite-error-overlay')).toBeVisible()
+
+    // Fix syntax error
+    editor.reset()
+
+    // Error overlay should disappear and page should work
+    await expect(page.locator('vite-error-overlay')).not.toBeVisible()
+    await expect(page.getByTestId('client-syntax-ready')).toBeVisible()
+  })
+
+  test('server syntax error triggers error overlay', async ({ page }) => {
+    await page.goto(f.url())
+    await waitForHydration(page)
+
+    await expect(page.getByTestId('server-syntax-ready')).toBeVisible()
+
+    // Edit server file to introduce syntax error
+    const editor = f.createEditor('src/server.tsx')
+    editor.edit((s) =>
+      s.replace(
+        'export function TestSyntaxErrorServer() {',
+        'export function TestSyntaxErrorServer() { const invalid = ;',
+      ),
+    )
+
+    // Should see error overlay
+    await expect(page.locator('vite-error-overlay')).toBeVisible()
+
+    // Fix syntax error
+    editor.reset()
+
+    // Error overlay should disappear and server should work again
+    await expect(page.locator('vite-error-overlay')).not.toBeVisible()
+    await expect(page.getByTestId('server-syntax-ready')).toBeVisible()
+  })
+
+  test('initial SSR with server component syntax error shows error page', async ({
+    page,
+  }) => {
+    // Edit server file to introduce syntax error before navigation
+    const editor = f.createEditor('src/server.tsx')
+    editor.edit((s) =>
+      s.replace(
+        'export function TestSyntaxErrorServer() {',
+        'export function TestSyntaxErrorServer() { const invalid = ;',
+      ),
+    )
+
+    // Navigate to page with syntax error
+    await page.goto(f.url())
+
+    // Should see error content
+    await expect(page.locator('body')).toContainText(
+      'Transform failed with 1 error',
+    )
+
+    // Fix syntax error
+    editor.reset()
+
+    // Should work normally now
+    await expect(async () => {
+      await page.goto(f.url())
+      await waitForHydration(page)
+      await expect(page.getByTestId('server-syntax-ready')).toBeVisible()
+    }).toPass({ timeout: 10000 })
+  })
+
+  test('initial SSR with client component syntax error shows error page', async ({
+    page,
+  }) => {
+    // Edit client file to introduce syntax error before navigation
+    const editor = f.createEditor('src/client.tsx')
+    editor.edit((s) =>
+      s.replace(
+        'export function TestSyntaxErrorClient() {',
+        'export function TestSyntaxErrorClient() { const invalid = ;',
+      ),
+    )
+
+    // Navigate to page with syntax error
+    await page.goto(f.url())
+
+    // Should see error content
+    await expect(page.locator('body')).toContainText(
+      'Transform failed with 1 error',
+    )
+
+    // Fix syntax error
+    editor.reset()
+
+    // Should work normally now
+    await expect(async () => {
+      await page.goto(f.url())
+      await waitForHydration(page)
+      await expect(page.getByTestId('client-syntax-ready')).toBeVisible()
+    }).toPass()
+  })
+}

--- a/packages/plugin-rsc/e2e/syntax-error.test.ts
+++ b/packages/plugin-rsc/e2e/syntax-error.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { setupInlineFixture, type Fixture, useFixture } from './fixture'
+import { setupInlineFixture, useFixture } from './fixture'
 import { waitForHydration, expectNoReload } from './helper'
 
 test.describe(() => {
@@ -12,7 +12,6 @@ test.describe(() => {
       files: {
         'src/root.tsx': /* tsx */ `
           import { TestSyntaxErrorClient } from './client.tsx'
-          import { TestSyntaxErrorServer } from './server.tsx'
 
           export function Root() {
             return (
@@ -22,7 +21,7 @@ test.describe(() => {
                 </head>
                 <body>
                   <TestSyntaxErrorClient />
-                  <TestSyntaxErrorServer />
+                  <div data-testid="server-content">server:ok</div>
                 </body>
               </html>
             )
@@ -43,15 +42,7 @@ test.describe(() => {
                 >
                   Client Count: {count}
                 </button>
-              </div>
-            )
-          }
-        `,
-        'src/server.tsx': /* tsx */ `
-          export function TestSyntaxErrorServer() {
-            return (
-              <div data-testid="server-syntax-ready">
-                Server ready for syntax error testing
+                <div data-testid="client-content">client:ok</div>
               </div>
             )
           }
@@ -60,126 +51,161 @@ test.describe(() => {
     })
   })
 
-  test.describe('dev', () => {
+  test.describe(() => {
     const f = useFixture({ root, mode: 'dev' })
-    defineSyntaxErrorTests(f)
+
+    test('client hmr', async ({ page }) => {
+      await page.goto(f.url())
+      await waitForHydration(page)
+      await using _ = await expectNoReload(page)
+      await expect(page.getByTestId('client-content')).toHaveText('client:ok')
+
+      // Set client state to verify preservation after HMR
+      await page.getByTestId('client-counter').click()
+      await expect(page.getByTestId('client-counter')).toHaveText(
+        'Client Count: 1',
+      )
+
+      // add syntax error
+      const editor = f.createEditor('src/client.tsx')
+      editor.edit((s) =>
+        s.replace(
+          '<div data-testid="client-content">client:ok</div>',
+          '<div data-testid="client-content">client:broken<</div>',
+        ),
+      )
+      await expect(page.locator('vite-error-overlay')).toBeVisible()
+
+      // fix syntax error
+      await page.waitForTimeout(200)
+      editor.edit((s) =>
+        s.replace(
+          '<div data-testid="client-content">client:broken<</div>',
+          '<div data-testid="client-content">client:fixed</div>',
+        ),
+      )
+      await expect(page.locator('vite-error-overlay')).not.toBeVisible()
+      await expect(page.getByTestId('client-syntax-ready')).toBeVisible()
+      await expect(page.getByTestId('client-content')).toHaveText(
+        'client:fixed',
+      )
+      await expect(page.getByTestId('client-counter')).toHaveText(
+        'Client Count: 1',
+      )
+    })
+  })
+
+  test.describe(() => {
+    const f = useFixture({ root, mode: 'dev' })
+
+    test('server hmr', async ({ page }) => {
+      await page.goto(f.url())
+      await waitForHydration(page)
+      await using _ = await expectNoReload(page)
+
+      await expect(page.getByTestId('server-content')).toHaveText('server:ok')
+
+      // Set client state to verify preservation during server HMR
+      await page.getByTestId('client-counter').click()
+      await expect(page.getByTestId('client-counter')).toHaveText(
+        'Client Count: 1',
+      )
+
+      // add syntax error
+      const editor = f.createEditor('src/root.tsx')
+      editor.edit((s) =>
+        s.replace(
+          '<div data-testid="server-content">server:ok</div>',
+          '<div data-testid="server-content">server:broken<</div>',
+        ),
+      )
+      await expect(page.locator('vite-error-overlay')).toBeVisible()
+
+      // fix syntax error
+      await page.waitForTimeout(200)
+      editor.edit((s) =>
+        s.replace(
+          '<div data-testid="server-content">server:broken<</div>',
+          '<div data-testid="server-content">server:fixed</div>',
+        ),
+      )
+      await expect(page.locator('vite-error-overlay')).not.toBeVisible()
+      await expect(page.getByTestId('server-content')).toHaveText(
+        'server:fixed',
+      )
+      await expect(page.getByTestId('client-counter')).toHaveText(
+        'Client Count: 1',
+      )
+    })
+  })
+
+  test.describe(() => {
+    const f = useFixture({ root, mode: 'dev' })
+
+    test('client ssr', async ({ page }) => {
+      // add syntax error
+      const editor = f.createEditor('src/client.tsx')
+      editor.edit((s) =>
+        s.replace(
+          '<div data-testid="client-content">client:ok</div>',
+          '<div data-testid="client-content">client:broken<</div>',
+        ),
+      )
+      await page.goto(f.url())
+      await expect(page.locator('body')).toContainText(
+        'Transform failed with 1 error',
+      )
+
+      // fix syntax error
+      await page.waitForTimeout(200)
+      editor.edit((s) =>
+        s.replace(
+          '<div data-testid="client-content">client:broken<</div>',
+          '<div data-testid="client-content">client:fixed</div>',
+        ),
+      )
+      await expect(async () => {
+        await page.goto(f.url())
+        await waitForHydration(page)
+        await expect(page.getByTestId('client-content')).toHaveText(
+          'client:fixed',
+        )
+      }).toPass()
+    })
+  })
+
+  test.describe(() => {
+    const f = useFixture({ root, mode: 'dev' })
+
+    test('server ssr', async ({ page }) => {
+      // add syntax error
+      const editor = f.createEditor('src/root.tsx')
+      editor.edit((s) =>
+        s.replace(
+          '<div data-testid="server-content">server:ok</div>',
+          '<div data-testid="server-content">server:broken<</div>',
+        ),
+      )
+      await page.goto(f.url())
+      await expect(page.locator('body')).toContainText(
+        'Transform failed with 1 error',
+      )
+
+      // fix syntax error
+      await page.waitForTimeout(200)
+      editor.edit((s) =>
+        s.replace(
+          '<div data-testid="server-content">server:broken<</div>',
+          '<div data-testid="server-content">server:fixed</div>',
+        ),
+      )
+      await expect(async () => {
+        await page.goto(f.url())
+        await waitForHydration(page)
+        await expect(page.getByTestId('server-content')).toHaveText(
+          'server:fixed',
+        )
+      }).toPass()
+    })
   })
 })
-
-function defineSyntaxErrorTests(f: Fixture) {
-  test('client syntax error triggers error overlay', async ({ page }) => {
-    await page.goto(f.url())
-    await waitForHydration(page)
-    await using _ = await expectNoReload(page)
-
-    await expect(page.getByTestId('client-syntax-ready')).toBeVisible()
-
-    // Set client state to verify preservation after HMR
-    await page.getByTestId('client-counter').click()
-    await expect(page.getByTestId('client-counter')).toHaveText(
-      'Client Count: 1',
-    )
-
-    // Introduce syntax error and verify error overlay
-    const editor = f.createEditor('src/client.tsx')
-    editor.edit((s) =>
-      s.replace(
-        'export function TestSyntaxErrorClient() {',
-        'export function TestSyntaxErrorClient() { const invalid = ;',
-      ),
-    )
-    await expect(page.locator('vite-error-overlay')).toBeVisible()
-
-    // Fix error and verify recovery with preserved client state
-    editor.reset()
-    await expect(page.locator('vite-error-overlay')).not.toBeVisible()
-    await expect(page.getByTestId('client-syntax-ready')).toBeVisible()
-    await expect(page.getByTestId('client-counter')).toHaveText(
-      'Client Count: 1',
-    )
-  })
-
-  test('server syntax error triggers error overlay', async ({ page }) => {
-    await page.goto(f.url())
-    await waitForHydration(page)
-    await using _ = await expectNoReload(page)
-
-    // Set client state to verify preservation during server HMR
-    await page.getByTestId('client-counter').click()
-    await expect(page.getByTestId('client-counter')).toHaveText(
-      'Client Count: 1',
-    )
-
-    // Introduce server syntax error and verify error overlay
-    const editor = f.createEditor('src/server.tsx')
-    editor.edit((s) =>
-      s.replace(
-        'export function TestSyntaxErrorServer() {',
-        'export function TestSyntaxErrorServer() { const invalid = ;',
-      ),
-    )
-    await expect(page.locator('vite-error-overlay')).toBeVisible()
-
-    // Fix error and verify recovery with preserved client state
-    editor.reset()
-    await expect(page.locator('vite-error-overlay')).not.toBeVisible()
-    await expect(page.getByTestId('server-syntax-ready')).toBeVisible()
-    await expect(page.getByTestId('client-counter')).toHaveText(
-      'Client Count: 1',
-    )
-  })
-
-  test('initial SSR with server component syntax error shows error page', async ({
-    page,
-  }) => {
-    // Introduce server syntax error and navigate to page
-    const editor = f.createEditor('src/server.tsx')
-    editor.edit((s) =>
-      s.replace(
-        'export function TestSyntaxErrorServer() {',
-        'export function TestSyntaxErrorServer() { const invalid = ;',
-      ),
-    )
-    await page.goto(f.url())
-    await expect(page.locator('body')).toContainText(
-      'Transform failed with 1 error',
-    )
-
-    // Fix error and verify recovery
-    editor.reset()
-    await expect(async () => {
-      await page.goto(f.url())
-      const bodyText = await page.locator('body').textContent()
-      if (bodyText?.includes('Transform failed with 1 error')) {
-        throw new Error('Still seeing error page')
-      }
-      await waitForHydration(page)
-      await expect(page.getByTestId('server-syntax-ready')).toBeVisible()
-    }).toPass({ timeout: 15000 })
-  })
-
-  test('initial SSR with client component syntax error shows error page', async ({
-    page,
-  }) => {
-    // Introduce client syntax error and navigate to page
-    const editor = f.createEditor('src/client.tsx')
-    editor.edit((s) =>
-      s.replace(
-        'export function TestSyntaxErrorClient() {',
-        'export function TestSyntaxErrorClient() { const invalid = ;',
-      ),
-    )
-    await page.goto(f.url())
-    await expect(page.locator('body')).toContainText(
-      'Transform failed with 1 error',
-    )
-
-    // Fix error and verify recovery
-    editor.reset()
-    await expect(async () => {
-      await page.goto(f.url())
-      await waitForHydration(page)
-      await expect(page.getByTestId('client-syntax-ready')).toBeVisible()
-    }).toPass()
-  })
-}

--- a/packages/plugin-rsc/e2e/syntax-error.test.ts
+++ b/packages/plugin-rsc/e2e/syntax-error.test.ts
@@ -72,6 +72,14 @@ function defineSyntaxErrorTests(f: Fixture) {
     await waitForHydration(page)
     await using _ = await expectNoReload(page)
 
+    await expect(page.getByTestId('client-syntax-ready')).toBeVisible()
+
+    // Set client state to verify it's preserved after client HMR
+    await page.getByTestId('client-counter').click()
+    await expect(page.getByTestId('client-counter')).toHaveText(
+      'Client Count: 1',
+    )
+
     // Edit client file to introduce syntax error
     const editor = f.createEditor('src/client.tsx')
     editor.edit((s) =>
@@ -90,6 +98,11 @@ function defineSyntaxErrorTests(f: Fixture) {
     // Error overlay should disappear and page should work
     await expect(page.locator('vite-error-overlay')).not.toBeVisible()
     await expect(page.getByTestId('client-syntax-ready')).toBeVisible()
+
+    // Verify client state is preserved (no full reload happened)
+    await expect(page.getByTestId('client-counter')).toHaveText(
+      'Client Count: 1',
+    )
   })
 
   test('server syntax error triggers error overlay', async ({ page }) => {
@@ -122,7 +135,6 @@ function defineSyntaxErrorTests(f: Fixture) {
     await expect(page.locator('vite-error-overlay')).not.toBeVisible()
     await expect(page.getByTestId('server-syntax-ready')).toBeVisible()
 
-    // TODO
     // Verify client state is preserved (no full reload happened)
     await expect(page.getByTestId('client-counter')).toHaveText(
       'Client Count: 1',

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -382,6 +382,12 @@ export default function vitePluginRsc(
 
         if (!isInsideClientBoundary(ctx.modules)) {
           if (this.environment.name === 'rsc') {
+            // transform js to surface syntax errors
+            for (const mod of ctx.modules) {
+              if (mod.type === 'js') {
+                await this.environment.transformRequest(mod.url)
+              }
+            }
             // server hmr
             ctx.server.environments.client.hot.send({
               type: 'custom',

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -396,11 +396,6 @@ export default function vitePluginRsc(
                 }
               }
             }
-            // send empty client updates to clear error overlay if any
-            ctx.server.environments.client.hot.send({
-              type: 'update',
-              updates: [],
-            })
             // server hmr
             ctx.server.environments.client.hot.send({
               type: 'custom',
@@ -792,6 +787,13 @@ window.__vite_plugin_react_preamble_installed__ = true;
         code += `
 const ssrCss = document.querySelectorAll("link[rel='stylesheet']");
 import.meta.hot.on("vite:beforeUpdate", () => ssrCss.forEach(node => node.remove()));
+`
+        // close error overlay after syntax error is fixed and hmr is triggered.
+        // https://github.com/vitejs/vite/blob/8033e5bf8d3ff43995d0620490ed8739c59171dd/packages/vite/src/client/client.ts#L318-L320
+        code += `
+import.meta.hot.on("rsc:update", () => {
+  document.querySelectorAll("vite-error-overlay").forEach((n) => n.close())
+});
 `
         return code
       },


### PR DESCRIPTION
### Description

- Closes https://github.com/vitejs/vite-plugin-react/issues/625

_summary_

- [x] Client already works. Client hmr catches syntax errors and triggers error overlay.
- [x] Avoid `rsc:update` when syntax errors by calling `transformRequest` during `hotUpdate`.
- [x] After the syntax error is fixed, next `hotUpdate` properly triggers server hmr (without full reload).
- [x] Send `transformRequest` error to client to trigger error overlay.
- [x] SSR with syntax error triggers Vite's error middleware with the same error overlay.

## todo

- [x] test 
  - [x] client
  - [x] server
  - [x] initial ssr
- [x] check waku hot-reload.spec.ts https://github.com/wakujs/waku/pull/1493