### PR TITLE
fix(rsc): add `getEntrySource` assertion error message

### DIFF
--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -869,12 +869,12 @@ function getEntrySource(
   name: string = 'index',
 ) {
   const input = config.build.rollupOptions.input
-  assert(input)
   assert(
     typeof input === 'object' &&
       !Array.isArray(input) &&
       name in input &&
       typeof input[name] === 'string',
+    `[vite-rsc:getEntrySource] expected 'build.rollupOptions.input' to be an object with a '${name}' property that is a string, but got ${JSON.stringify(input)}`,
   )
   return input[name]
 }


### PR DESCRIPTION
### Description

Extracted from https://github.com/vitejs/vite-plugin-react/pull/632

Probably still cryptic but better 

```
### before
assert(
    typeof input === 'object' &&
      !Array.isArray(input) &&
      name in input &&
      typeof input[name] === 'string')

### after
AssertionError [ERR_ASSERTION]: [vite-rsc:getEntrySource] expected 'build.rollupOptions.input' to be an object with a 'index' property that is a string, but got "/home/hiroshi/code/others/vite-plugin-react/packages/plugin-rsc/examples/react-router/cf/entry.ssr.tsx"
```