### PR TITLE
feat(rsc): show warning for non optimized cjs

### DIFF
--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto'
 import { readFileSync } from 'node:fs'
 import { type Page, expect, test } from '@playwright/test'
-import { type Fixture, setupInlineFixture, useFixture } from './fixture'
+import { type Fixture, useFixture } from './fixture'
 import {
   expectNoPageError,
   expectNoReload,

--- a/packages/plugin-rsc/examples/basic/vite.config.ts
+++ b/packages/plugin-rsc/examples/basic/vite.config.ts
@@ -154,7 +154,7 @@ export default { fetch: handler };
         // TODO: this should be somehow auto inferred or at least show a warning
         // to guide users to `optimizeDeps.include`
         include: [
-          // '@vitejs/test-dep-transitive-cjs > use-sync-external-store/shim/index.js',
+          '@vitejs/test-dep-transitive-cjs > use-sync-external-store/shim/index.js',
         ],
       },
     },

--- a/packages/plugin-rsc/examples/basic/vite.config.ts
+++ b/packages/plugin-rsc/examples/basic/vite.config.ts
@@ -154,7 +154,7 @@ export default { fetch: handler };
         // TODO: this should be somehow auto inferred or at least show a warning
         // to guide users to `optimizeDeps.include`
         include: [
-          '@vitejs/test-dep-transitive-cjs > use-sync-external-store/shim/index.js',
+          // '@vitejs/test-dep-transitive-cjs > use-sync-external-store/shim/index.js',
         ],
       },
     },

--- a/packages/plugin-rsc/examples/basic/vite.config.ts
+++ b/packages/plugin-rsc/examples/basic/vite.config.ts
@@ -151,8 +151,6 @@ export default { fetch: handler };
     },
     ssr: {
       optimizeDeps: {
-        // TODO: this should be somehow auto inferred or at least show a warning
-        // to guide users to `optimizeDeps.include`
         include: [
           '@vitejs/test-dep-transitive-cjs > use-sync-external-store/shim/index.js',
         ],

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -850,7 +850,7 @@ function detectNonOptimizedCjsPlugin(): Plugin {
       if (
         id.includes('/node_modules/') &&
         !id.startsWith(this.environment.config.cacheDir) &&
-        (code.includes('exports') || code.includes('require'))
+        /\b(require|exports)\b/.test(code)
       ) {
         id = parseIdQuery(id).filename
         let isEsm = id.endsWith('.mjs')

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -853,20 +853,17 @@ function detectNonOptimizedCjsPlugin(): Plugin {
         (code.includes('exports') || code.includes('require'))
       ) {
         id = parseIdQuery(id).filename
-        let isCjs = id.endsWith('.cjs')
-        if (!isCjs && id.endsWith('.js')) {
-          // check closest package.json
+        let isEsm = id.endsWith('.mjs')
+        if (id.endsWith('.js')) {
           const pkgJsonPath = await findClosestPkgJsonPath(path.dirname(id))
           if (pkgJsonPath) {
             const pkgJson = JSON.parse(
               fs.readFileSync(pkgJsonPath, 'utf-8'),
             ) as { type?: string }
-            isCjs = pkgJson.type !== 'module'
-          } else {
-            isCjs = true
+            isEsm = pkgJson.type === 'module'
           }
         }
-        if (isCjs) {
+        if (!isEsm) {
           this.warn(
             `[vite-rsc] found non-optimized CJS dependency in '${this.environment.name}' environment. ` +
               `It is recommended to manually add the dependency to 'environments.${this.environment.name}.optimizeDeps.include'.`,


### PR DESCRIPTION
### Description

- Related https://github.com/vitejs/vite-plugin-react/issues/610

Just a slight reassurance to avoid entirely cryptic `ReferenceError: module is not defined` server error.

Example when removing this line (explicit `include` example added by https://github.com/vitejs/vite-plugin-react/pull/611)

https://github.com/vitejs/vite-plugin-react/blob/94448463173f5bba479f01fe445f5b1ba604720d/packages/plugin-rsc/examples/basic/vite.config.ts#L157

```sh
7:14:05 PM [vite] (ssr) warning: [vite-rsc] found non-optimized CJS dependency in 'ssr' environment. It is recommended to manually add the dependency to 'environments.ssr.optimizeDeps.include'.
  Plugin: rsc:detect-non-optimized-cjs
  File: /home/hiroshi/code/others/vite-plugin-react/node_modules/.pnpm/use-sync-external-store@1.5.0_react@19.1.0/node_modules/use-sync-external-store/shim/index.js?v=5b54ec8a
```

<img width="902" height="272" alt="image" src="https://github.com/user-attachments/assets/cdcc8d34-b619-4b5d-992f-21f913bacbe8" />

---

TODO

- [ ] test
- [ ] option (enabled by default)
- [ ] transform cjs into esm on the fly (later)