### PR TITLE
fix(rsc): improve auto css heuristics

### DIFF
--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -322,11 +322,19 @@ function defineTest(f: Fixture) {
     await page.goto(f.url())
     await waitForHydration(page)
     await testCss(page)
+    await expect(page.locator('.test-dep-css-in-server')).toHaveCSS(
+      'color',
+      'rgb(255, 165, 0)',
+    )
   })
 
   testNoJs('css @nojs', async ({ page }) => {
     await page.goto(f.url())
     await testCss(page)
+    await expect(page.locator('.test-dep-css-in-server')).toHaveCSS(
+      'color',
+      'rgb(255, 165, 0)',
+    )
   })
 
   async function testCss(page: Page, color = 'rgb(255, 165, 0)') {

--- a/packages/plugin-rsc/examples/basic/package.json
+++ b/packages/plugin-rsc/examples/basic/package.json
@@ -26,6 +26,7 @@
     "@vitejs/test-dep-client-in-server2": "file:./test-dep/client-in-server2",
     "@vitejs/test-dep-server-in-client": "file:./test-dep/server-in-client",
     "@vitejs/test-dep-server-in-server": "file:./test-dep/server-in-server",
+    "@vitejs/test-dep-css-in-server": "file:./test-dep/css-in-server",
     "rsc-html-stream": "^0.0.7",
     "tailwindcss": "^4.1.11",
     "vite": "^7.0.5",

--- a/packages/plugin-rsc/examples/basic/src/routes/root.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/root.tsx
@@ -30,6 +30,7 @@ import { TestUseCache } from './use-cache/server'
 import { TestHydrationMismatch } from './hydration-mismatch/server'
 import { TestBrowserOnly } from './browser-only/client'
 import { TestTransitiveCjsClient } from './deps/transitive-cjs/client'
+import TestDepCssInServer from '@vitejs/test-dep-css-in-server/server'
 
 export function Root(props: { url: URL }) {
   return (
@@ -51,6 +52,7 @@ export function Root(props: { url: URL }) {
         <TestCssClientNoSsr url={props.url} />
         <TestTailwindClient />
         <TestTailwindServer />
+        <TestDepCssInServer />
         <TestHydrationMismatch url={props.url} />
         <TestHmrClientDep />
         <TestTemporaryReference />

--- a/packages/plugin-rsc/examples/basic/test-dep/css-in-server/package.json
+++ b/packages/plugin-rsc/examples/basic/test-dep/css-in-server/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@vitejs/test-dep-css-in-server",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./server": "./server.js"
+  },
+  "peerDependencies": {
+    "react": "*"
+  }
+}

--- a/packages/plugin-rsc/examples/basic/test-dep/css-in-server/server.css
+++ b/packages/plugin-rsc/examples/basic/test-dep/css-in-server/server.css
@@ -1,0 +1,3 @@
+.test-dep-css-in-server {
+  color: rgb(255, 165, 0);
+}

--- a/packages/plugin-rsc/examples/basic/test-dep/css-in-server/server.d.ts
+++ b/packages/plugin-rsc/examples/basic/test-dep/css-in-server/server.d.ts
@@ -1,0 +1,1 @@
+export default function TestDepCssInServer(): import('react').ReactNode

--- a/packages/plugin-rsc/examples/basic/test-dep/css-in-server/server.js
+++ b/packages/plugin-rsc/examples/basic/test-dep/css-in-server/server.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import './server.css'
+
+const h = React.createElement
+
+export default function TestDepCssInServer() {
+  return h(
+    'div',
+    { className: 'test-dep-css-in-server' },
+    `test-dep-css-in-server`,
+  )
+}

--- a/packages/plugin-rsc/examples/e2e/package.json
+++ b/packages/plugin-rsc/examples/e2e/package.json
@@ -3,8 +3,9 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@vitejs/plugin-rsc": "latest",
     "@vitejs/plugin-react": "latest",
-    "babel-plugin-react-compiler": "19.1.0-rc.2"
+    "@vitejs/plugin-rsc": "latest",
+    "babel-plugin-react-compiler": "19.1.0-rc.2",
+    "react-tweet": "^3.2.2"
   }
 }

--- a/packages/plugin-rsc/examples/e2e/package.json
+++ b/packages/plugin-rsc/examples/e2e/package.json
@@ -3,9 +3,8 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@vitejs/plugin-react": "latest",
     "@vitejs/plugin-rsc": "latest",
-    "babel-plugin-react-compiler": "19.1.0-rc.2",
-    "react-tweet": "^3.2.2"
+    "@vitejs/plugin-react": "latest",
+    "babel-plugin-react-compiler": "19.1.0-rc.2"
   }
 }

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1646,7 +1646,7 @@ export function vitePluginRscCss(
     id: string
     code: string
   }): false | TransformWrapExportFilter {
-    const { query } = parseIdQuery(id)
+    const { filename, query } = parseIdQuery(id)
     if ('vite-rsc-css-export' in query) {
       const value = query['vite-rsc-css-export']
       if (value) {
@@ -1658,11 +1658,11 @@ export function vitePluginRscCss(
 
     const options = rscCssOptions?.rscCssTransform
     if (options === false) return false
-    if (options?.filter && !options.filter(id)) return false
+    if (options?.filter && !options.filter(filename)) return false
     // https://github.com/vitejs/vite/blob/7979f9da555aa16bd221b32ea78ce8cb5292fac4/packages/vite/src/node/constants.ts#L95
     if (
       !/\.(css|less|sass|scss|styl|stylus|pcss|postcss|sss)\b/.test(code) ||
-      !/\.[tj]sx?$/.test(id)
+      !/\.[tj]sx?$/.test(filename)
     )
       return false
 

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1659,7 +1659,12 @@ export function vitePluginRscCss(
     const options = rscCssOptions?.rscCssTransform
     if (options === false) return false
     if (options?.filter && !options.filter(id)) return false
-    if (id.includes('/node_modules/') || !/\.[tj]sx$/.test(id)) return false
+    // https://github.com/vitejs/vite/blob/7979f9da555aa16bd221b32ea78ce8cb5292fac4/packages/vite/src/node/constants.ts#L95
+    if (
+      !/\.(css|less|sass|scss|styl|stylus|pcss|postcss|sss)\b/.test(code) ||
+      !/\.[tj]sx?$/.test(id)
+    )
+      return false
 
     // skip transform if no css imports
     const result = esModuleLexer.parse(code)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -533,6 +533,9 @@ importers:
       '@vitejs/test-dep-client-in-server2':
         specifier: file:./test-dep/client-in-server2
         version: file:packages/plugin-rsc/examples/basic/test-dep/client-in-server2(react@19.1.0)
+      '@vitejs/test-dep-css-in-server':
+        specifier: file:./test-dep/css-in-server
+        version: file:packages/plugin-rsc/examples/basic/test-dep/css-in-server(react@19.1.0)
       '@vitejs/test-dep-server-in-client':
         specifier: file:./test-dep/server-in-client
         version: file:packages/plugin-rsc/examples/basic/test-dep/server-in-client(react@19.1.0)
@@ -2570,6 +2573,11 @@ packages:
 
   '@vitejs/test-dep-client-in-server@file:packages/plugin-rsc/examples/basic/test-dep/client-in-server':
     resolution: {directory: packages/plugin-rsc/examples/basic/test-dep/client-in-server, type: directory}
+    peerDependencies:
+      react: '*'
+
+  '@vitejs/test-dep-css-in-server@file:packages/plugin-rsc/examples/basic/test-dep/css-in-server':
+    resolution: {directory: packages/plugin-rsc/examples/basic/test-dep/css-in-server, type: directory}
     peerDependencies:
       react: '*'
 
@@ -6314,6 +6322,10 @@ snapshots:
       react: 19.1.0
 
   '@vitejs/test-dep-client-in-server@file:packages/plugin-rsc/examples/basic/test-dep/client-in-server(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+
+  '@vitejs/test-dep-css-in-server@file:packages/plugin-rsc/examples/basic/test-dep/css-in-server(react@19.1.0)':
     dependencies:
       react: 19.1.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,7 +149,7 @@ importers:
         version: 1.0.0-beta.29
       '@swc/core':
         specifier: ^1.12.11
-        version: 1.12.11(@swc/helpers@0.5.17)
+        version: 1.12.11
     devDependencies:
       '@playwright/test':
         specifier: ^1.54.1
@@ -572,9 +572,6 @@ importers:
       babel-plugin-react-compiler:
         specifier: 19.1.0-rc.2
         version: 19.1.0-rc.2
-      react-tweet:
-        specifier: ^3.2.2
-        version: 3.2.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
   packages/plugin-rsc/examples/no-ssr:
     dependencies:
@@ -2391,9 +2388,6 @@ packages:
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
-  '@swc/helpers@0.5.17':
-    resolution: {integrity: sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==}
-
   '@swc/plugin-emotion@10.0.3':
     resolution: {integrity: sha512-YJVWKwvcggWUBz952/TKHLlF9aMhgxjzliuLB3xuXbM/r/xAV/whVUiH8zvrTJZmzj15xApRWX4EkXQmGkRt3g==}
 
@@ -3012,10 +3006,6 @@ packages:
   cli-truncate@4.0.0:
     resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
     engines: {node: '>=18'}
-
-  clsx@2.1.1:
-    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
-    engines: {node: '>=6'}
 
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
@@ -4667,12 +4657,6 @@ packages:
       react: ^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  react-tweet@3.2.2:
-    resolution: {integrity: sha512-hIkxAVPpN2RqWoDEbo3TTnN/pDcp9/Jb6pTgiA4EbXa9S+m2vHIvvZKHR+eS0PDIsYqe+zTmANRa5k6+/iwGog==}
-    peerDependencies:
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -5013,11 +4997,6 @@ packages:
     resolution: {integrity: sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==}
     engines: {node: '>=14.0.0'}
     hasBin: true
-
-  swr@2.3.4:
-    resolution: {integrity: sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==}
-    peerDependencies:
-      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   tailwindcss@4.1.11:
     resolution: {integrity: sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==}
@@ -6626,7 +6605,7 @@ snapshots:
   '@swc/core-win32-x64-msvc@1.12.11':
     optional: true
 
-  '@swc/core@1.12.11(@swc/helpers@0.5.17)':
+  '@swc/core@1.12.11':
     dependencies:
       '@swc/counter': 0.1.3
       '@swc/types': 0.1.23
@@ -6641,13 +6620,8 @@ snapshots:
       '@swc/core-win32-arm64-msvc': 1.12.11
       '@swc/core-win32-ia32-msvc': 1.12.11
       '@swc/core-win32-x64-msvc': 1.12.11
-      '@swc/helpers': 0.5.17
 
   '@swc/counter@0.1.3': {}
-
-  '@swc/helpers@0.5.17':
-    dependencies:
-      tslib: 2.8.1
 
   '@swc/plugin-emotion@10.0.3':
     dependencies:
@@ -7268,8 +7242,6 @@ snapshots:
     dependencies:
       slice-ansi: 5.0.0
       string-width: 7.0.0
-
-  clsx@2.1.1: {}
 
   collapse-white-space@2.1.0: {}
 
@@ -9140,14 +9112,6 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  react-tweet@3.2.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@swc/helpers': 0.5.17
-      clsx: 2.1.1
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      swr: 2.3.4(react@19.1.0)
-
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
@@ -9520,12 +9484,6 @@ snapshots:
       csso: 5.0.5
       picocolors: 1.1.1
 
-  swr@2.3.4(react@19.1.0):
-    dependencies:
-      dequal: 2.0.3
-      react: 19.1.0
-      use-sync-external-store: 1.5.0(react@19.1.0)
-
   tailwindcss@4.1.11: {}
 
   tapable@2.2.1: {}
@@ -9603,7 +9561,8 @@ snapshots:
 
   tslib@2.6.2: {}
 
-  tslib@2.8.1: {}
+  tslib@2.8.1:
+    optional: true
 
   tsx@4.20.3:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,7 +149,7 @@ importers:
         version: 1.0.0-beta.29
       '@swc/core':
         specifier: ^1.12.11
-        version: 1.12.11
+        version: 1.12.11(@swc/helpers@0.5.17)
     devDependencies:
       '@playwright/test':
         specifier: ^1.54.1
@@ -572,6 +572,9 @@ importers:
       babel-plugin-react-compiler:
         specifier: 19.1.0-rc.2
         version: 19.1.0-rc.2
+      react-tweet:
+        specifier: ^3.2.2
+        version: 3.2.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
   packages/plugin-rsc/examples/no-ssr:
     dependencies:
@@ -2388,6 +2391,9 @@ packages:
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
+  '@swc/helpers@0.5.17':
+    resolution: {integrity: sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==}
+
   '@swc/plugin-emotion@10.0.3':
     resolution: {integrity: sha512-YJVWKwvcggWUBz952/TKHLlF9aMhgxjzliuLB3xuXbM/r/xAV/whVUiH8zvrTJZmzj15xApRWX4EkXQmGkRt3g==}
 
@@ -3006,6 +3012,10 @@ packages:
   cli-truncate@4.0.0:
     resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
     engines: {node: '>=18'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
@@ -4657,6 +4667,12 @@ packages:
       react: ^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  react-tweet@3.2.2:
+    resolution: {integrity: sha512-hIkxAVPpN2RqWoDEbo3TTnN/pDcp9/Jb6pTgiA4EbXa9S+m2vHIvvZKHR+eS0PDIsYqe+zTmANRa5k6+/iwGog==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -4997,6 +5013,11 @@ packages:
     resolution: {integrity: sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  swr@2.3.4:
+    resolution: {integrity: sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   tailwindcss@4.1.11:
     resolution: {integrity: sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==}
@@ -6605,7 +6626,7 @@ snapshots:
   '@swc/core-win32-x64-msvc@1.12.11':
     optional: true
 
-  '@swc/core@1.12.11':
+  '@swc/core@1.12.11(@swc/helpers@0.5.17)':
     dependencies:
       '@swc/counter': 0.1.3
       '@swc/types': 0.1.23
@@ -6620,8 +6641,13 @@ snapshots:
       '@swc/core-win32-arm64-msvc': 1.12.11
       '@swc/core-win32-ia32-msvc': 1.12.11
       '@swc/core-win32-x64-msvc': 1.12.11
+      '@swc/helpers': 0.5.17
 
   '@swc/counter@0.1.3': {}
+
+  '@swc/helpers@0.5.17':
+    dependencies:
+      tslib: 2.8.1
 
   '@swc/plugin-emotion@10.0.3':
     dependencies:
@@ -7242,6 +7268,8 @@ snapshots:
     dependencies:
       slice-ansi: 5.0.0
       string-width: 7.0.0
+
+  clsx@2.1.1: {}
 
   collapse-white-space@2.1.0: {}
 
@@ -9112,6 +9140,14 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
+  react-tweet@3.2.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@swc/helpers': 0.5.17
+      clsx: 2.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      swr: 2.3.4(react@19.1.0)
+
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
@@ -9484,6 +9520,12 @@ snapshots:
       csso: 5.0.5
       picocolors: 1.1.1
 
+  swr@2.3.4(react@19.1.0):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.1.0
+      use-sync-external-store: 1.5.0(react@19.1.0)
+
   tailwindcss@4.1.11: {}
 
   tapable@2.2.1: {}
@@ -9561,8 +9603,7 @@ snapshots:
 
   tslib@2.6.2: {}
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   tsx@4.20.3:
     dependencies:


### PR DESCRIPTION
### Description

- Related https://github.com/vitejs/vite-plugin-react/issues/636

TODO
- [x] support css inside `node_modules` (e.g. `react-tweet`)
- [ ] show warning for non discovered case (e.g. `vanilla-extract`) https://github.com/pawelblaszczyk5/vite-rsc-experiments/blob/ef7cbd0e3b64047eb395c6433d1165bdb5d03be7/apps/vanilla-extract/src/root.tsx#L2
  - try it later.
  - probably detecting during build is possible.

---

I verified `react-tweet` works with zero config:

<details>

<img width="768" height="554" alt="image" src="https://github.com/user-attachments/assets/b39522c2-73af-4113-b27e-f485d734753d" />

</details>