### PR TITLE
fix(react): use development jsx transform for `NODE_ENV=development` build

### DIFF
--- a/packages/plugin-react/CHANGELOG.md
+++ b/packages/plugin-react/CHANGELOG.md
@@ -8,6 +8,8 @@ When used with rolldown-vite, this plugin now uses Oxc for react refresh transfo
 
 Since this behavior is what `@vitejs/plugin-react-oxc` did, `@vitejs/plugin-react-oxc` is now deprecated and the `disableOxcRecommendation` option is removed.
 
+Also, while `@vitejs/plugin-react-oxc` used the production JSX transform even for `NODE_ENV=development` build, `@vitejs/plugin-react` uses the development JSX transform for `NODE_ENV=development` build.
+
 ### Allow processing files in `node_modules`
 
 The default value of `exclude` options is now `[/\/node_modules\//]` to allow processing files in `node_modules` directory. It was previously `[]` and files in `node_modules` was always excluded regardless of the value of `exclude` option.

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -155,7 +155,6 @@ export default function viteReact(opts: Options = {}): Plugin[] {
                 runtime: 'automatic',
                 importSource: jsxImportSource,
                 refresh: command === 'serve',
-                development: command === 'serve',
               },
               jsxRefreshInclude: include,
               jsxRefreshExclude: exclude,

--- a/packages/plugin-rsc/e2e/starter.test.ts
+++ b/packages/plugin-rsc/e2e/starter.test.ts
@@ -2,7 +2,6 @@ import { expect, test } from '@playwright/test'
 import { useFixture } from './fixture'
 import { defineStarterTest } from './starter'
 import { waitForHydration } from './helper'
-import * as vite from 'vite'
 
 test.describe('dev-default', () => {
   const f = useFixture({ root: 'examples/starter', mode: 'dev' })

--- a/packages/plugin-rsc/e2e/starter.test.ts
+++ b/packages/plugin-rsc/e2e/starter.test.ts
@@ -25,8 +25,6 @@ test.describe('build-cloudflare', () => {
 })
 
 test.describe('dev-production', () => {
-  test.skip('rolldownVersion' in vite)
-
   const f = useFixture({
     root: 'examples/starter',
     mode: 'dev',
@@ -45,8 +43,6 @@ test.describe('dev-production', () => {
 })
 
 test.describe('build-development', () => {
-  test.skip('rolldownVersion' in vite)
-
   const f = useFixture({
     root: 'examples/starter',
     mode: 'build',

--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["*.ts", "**/__tests__/*.ts", "**/vite.config.ts"],
+  "include": ["*.ts", "**/__tests__/**/*", "**/vite.config.ts"],
   "exclude": ["**/dist/**"],
   "compilerOptions": {
     "target": "ES2023",


### PR DESCRIPTION
### Description

Removed `development: command === 'serve'` so that the development JSX transform is used for `NODE_ENV=development` build.

I didn't add a test case as I though it requires setting up a custom setup (otherwise the process.env change leaks to other tests) and this is a bit edge case one. But I'll add one if you have any ideas.

fixes #622

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
