### PR TITLE
fix(rsc): fix FOUC of lazy component css within client boundary

### DIFF
--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1495,6 +1495,8 @@ function collectAssetDepsInner(
     assert(v, `Not found '${k}' in the bundle`)
     if (v.type === 'chunk') {
       css.push(...(v.viteMetadata?.importedCss ?? []))
+      // TODO: for client references, aggressively collect to surface css at client boundary for SSR.
+      v.dynamicImports
       for (const k2 of v.imports) {
         // server external imports is not in bundle
         if (k2 in bundle) {


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

I haven't tested but such setup currently causes FOUC. We probably need to aggressively collect through dynamic imports or apply `transformRscCssExport` for client components too.