### PR TITLE
fix(rsc): avoid unnecessary server hmr due to tailwind module deps

### DIFF
--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -637,6 +637,24 @@ function defineTest(f: Fixture) {
         'rgb(255, 0, 0)',
       )
     })
+
+    test('tailwind no redundant server hmr', async ({ page }) => {
+      await page.goto(f.url())
+      await waitForHydration(page)
+      const logs: string[] = []
+      page.on('console', (msg) => {
+        if (msg.type() === 'log') {
+          logs.push(msg.text())
+        }
+      })
+      f.createEditor('src/routes/tailwind/unused.tsx').resave()
+      await page.waitForTimeout(200)
+      f.createEditor('src/routes/tailwind/server.tsx').resave()
+      await page.waitForTimeout(200)
+      expect(logs).toEqual([
+        expect.stringMatching(/\[vite-rsc:update\].*\/tailwind\/server.tsx/),
+      ])
+    })
   })
 
   test('temporary references @js', async ({ page }) => {

--- a/packages/plugin-rsc/e2e/fixture.ts
+++ b/packages/plugin-rsc/e2e/fixture.ts
@@ -142,6 +142,9 @@ export function useFixture(options: {
       reset(): void {
         fs.writeFileSync(filepath, originalFiles[filepath]!)
       },
+      resave(): void {
+        fs.writeFileSync(filepath, current)
+      },
     }
   }
 

--- a/packages/plugin-rsc/examples/basic/src/framework/entry.browser.tsx
+++ b/packages/plugin-rsc/examples/basic/src/framework/entry.browser.tsx
@@ -70,7 +70,8 @@ async function main() {
 
   // implement server HMR by trigering re-fetch/render of RSC upon server code change
   if (import.meta.hot) {
-    import.meta.hot.on('rsc:update', () => {
+    import.meta.hot.on('rsc:update', (e) => {
+      console.log('[vite-rsc:update]', e.file)
       fetchRscPayload()
     })
   }

--- a/packages/plugin-rsc/examples/basic/src/routes/tailwind/unused.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/tailwind/unused.tsx
@@ -1,1 +1,1 @@
-console.log('unused file text-[#f12345]')
+console.log(<div className="unused">unused</div>)

--- a/packages/plugin-rsc/examples/basic/src/routes/tailwind/unused.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/tailwind/unused.tsx
@@ -1,0 +1,1 @@
+console.log('unused file text-[#f12345]')

--- a/packages/plugin-rsc/examples/basic/src/styles.css
+++ b/packages/plugin-rsc/examples/basic/src/styles.css
@@ -1,4 +1,4 @@
-@import 'tailwindcss' source('./');
+@import 'tailwindcss';
 
 button {
   @apply bg-gray-100 mx-1 px-2 border hover:bg-gray-200 active:bg-gray-300;

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -400,12 +400,14 @@ export default function vitePluginRsc(
           if (this.environment.name === 'rsc') {
             // detect if this module is only created as css deps (e.g. tailwind)
             // (NOTE: this is not necessary since Vite 7.1.0-beta.0 https://github.com/vitejs/vite/pull/20391 )
-            if (
-              ctx.modules
-                .flatMap((m) => [...m.importers])
-                .every((m) => m.id && isCSSRequest(m.id))
-            ) {
-              return
+            if (ctx.modules.length === 1) {
+              const importers = [...ctx.modules[0]!.importers]
+              if (
+                importers.length > 0 &&
+                importers.every((m) => m.id && isCSSRequest(m.id))
+              ) {
+                return
+              }
             }
 
             // transform js to surface syntax errors

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -406,7 +406,7 @@ export default function vitePluginRsc(
                 importers.length > 0 &&
                 importers.every((m) => m.id && isCSSRequest(m.id))
               ) {
-                return
+                return []
               }
             }
 

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -398,6 +398,16 @@ export default function vitePluginRsc(
 
         if (!isInsideClientBoundary(ctx.modules)) {
           if (this.environment.name === 'rsc') {
+            // detect if this module is only created as css deps (e.g. tailwind)
+            // (NOTE: this is not necessary since Vite 7.1.0-beta.0 https://github.com/vitejs/vite/pull/20391 )
+            if (
+              ctx.modules
+                .flatMap((m) => [...m.importers])
+                .every((m) => m.id && isCSSRequest(m.id))
+            ) {
+              return
+            }
+
             // transform js to surface syntax errors
             for (const mod of ctx.modules) {
               if (mod.type === 'js') {
@@ -426,6 +436,7 @@ export default function vitePluginRsc(
             // Server files can be included in client module graph, for example,
             // when `addWatchFile` is used to track js files as style dependency (e.g. tailwind)
             // In this case, reload all importers (for css hmr), and return empty modules to avoid full-reload.
+            // (NOTE: this is not necessary since Vite 7.1.0-beta.0 https://github.com/vitejs/vite/pull/20391 )
             const env = ctx.server.environments.rsc!
             const mod = env.moduleGraph.getModuleById(ctx.file)
             if (mod) {


### PR DESCRIPTION
### Description

I noticed a redundant server hmr on Waku example where it uses tailwind and typegen. Any change causes an auto-generated type files `pages.gen.ts` to be updated and it's doubly causing server hmr refetch.

This won't be necessary after https://github.com/vitejs/vite/pull/20391 (7.1.0-beta.1), but a workaround on rsc plugin side is fairly simple, so let's include this for now.

Also we didn't have tests to verify there's no redundant server hmr. Let's add such tests.