### PR TITLE
test(rsc): test shared module hmr

### DIFF
--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -316,6 +316,14 @@ function defineTest(f: Fixture) {
       editor.reset()
       await expect(locator).toContainText('[dep: 1]')
     })
+
+    test('shared hmr', async ({ page }) => {
+      // TODO:
+      // modify src/routes/hmr-shared/shared1.tsx to confirm component hmr
+      // modify src/routes/hmr-shared/shared2.tsx to confirm non-comonent hmr
+      // modify src/routes/hmr-shared/aomic/shared.tsx to confirm server/client updates are not atomic
+      page
+    })
   })
 
   test('css @js', async ({ page }) => {

--- a/packages/plugin-rsc/examples/basic/src/routes/hmr-shared/atomic/client.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/hmr-shared/atomic/client.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import React from 'react'
+import { testShared } from './shared'
+
+export function TestClient({
+  testSharedFromServer,
+}: {
+  testSharedFromServer: string
+}) {
+  React.useEffect(() => {
+    console.log({ testShared, testSharedFromServer })
+    if (testShared !== testSharedFromServer) {
+      throw new Error(
+        `Mismatch: ${JSON.stringify({ testShared, testSharedFromServer })}`,
+      )
+    }
+  }, [testShared, testSharedFromServer])
+
+  return <>ok ({testShared})</>
+}

--- a/packages/plugin-rsc/examples/basic/src/routes/hmr-shared/atomic/error-boundary.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/hmr-shared/atomic/error-boundary.tsx
@@ -24,7 +24,7 @@ export default class ErrorBoundary extends React.Component<Props, State> {
     if (this.state.error) {
       return (
         <span>
-          ERROR
+          ErrorBoundary: {this.state.error.message}
           <button
             onClick={() => {
               this.setState({ error: null })

--- a/packages/plugin-rsc/examples/basic/src/routes/hmr-shared/atomic/error-boundary.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/hmr-shared/atomic/error-boundary.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import * as React from 'react'
+
+interface Props {
+  children?: React.ReactNode
+}
+
+interface State {
+  error: Error | null
+}
+
+export default class ErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = { error: null }
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    return { error }
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <span>
+          ERROR
+          <button
+            onClick={() => {
+              this.setState({ error: null })
+            }}
+          >
+            Reset
+          </button>
+        </span>
+      )
+    }
+    return this.props.children
+  }
+}

--- a/packages/plugin-rsc/examples/basic/src/routes/hmr-shared/atomic/server.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/hmr-shared/atomic/server.tsx
@@ -4,7 +4,7 @@ import { testShared } from './shared'
 
 export function TestHmrSharedAtomic() {
   return (
-    <div>
+    <div data-testid="test-hmr-shared-atomic">
       test-hmr-shared-atomic:{' '}
       <ErrorBoundary>
         <TestClient testSharedFromServer={testShared} />

--- a/packages/plugin-rsc/examples/basic/src/routes/hmr-shared/atomic/server.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/hmr-shared/atomic/server.tsx
@@ -1,0 +1,14 @@
+import { TestClient } from './client'
+import ErrorBoundary from './error-boundary'
+import { testShared } from './shared'
+
+export function TestHmrSharedAtomic() {
+  return (
+    <div>
+      test-hmr-shared-atomic:{' '}
+      <ErrorBoundary>
+        <TestClient testSharedFromServer={testShared} />
+      </ErrorBoundary>
+    </div>
+  )
+}

--- a/packages/plugin-rsc/examples/basic/src/routes/hmr-shared/atomic/shared.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/hmr-shared/atomic/shared.tsx
@@ -1,0 +1,1 @@
+export const testShared = 'test-shared'

--- a/packages/plugin-rsc/examples/basic/src/routes/hmr-shared/client.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/hmr-shared/client.tsx
@@ -5,7 +5,7 @@ import { testHmrSharedObject } from './shared2'
 
 export function TestHmrSharedClient() {
   return (
-    <div>
+    <div data-testid="test-hmr-shared-client">
       test-hmr-shared-client: (<TestHmrSharedComponent />,{' '}
       {testHmrSharedObject.value})
     </div>

--- a/packages/plugin-rsc/examples/basic/src/routes/hmr-shared/client.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/hmr-shared/client.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { TestHmrSharedComponent } from './shared1'
+import { testHmrSharedObject } from './shared2'
+
+export function TestHmrSharedClient() {
+  return (
+    <div>
+      test-hmr-shared-client: (<TestHmrSharedComponent />,{' '}
+      {testHmrSharedObject.value})
+    </div>
+  )
+}

--- a/packages/plugin-rsc/examples/basic/src/routes/hmr-shared/server.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/hmr-shared/server.tsx
@@ -3,7 +3,7 @@ import { testHmrSharedObject } from './shared2'
 
 export function TestHmrSharedServer() {
   return (
-    <div>
+    <div data-testid="test-hmr-shared-server">
       test-hmr-shared-server: (<TestHmrSharedComponent />,{' '}
       {testHmrSharedObject.value})
     </div>

--- a/packages/plugin-rsc/examples/basic/src/routes/hmr-shared/server.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/hmr-shared/server.tsx
@@ -1,0 +1,11 @@
+import { TestHmrSharedComponent } from './shared1'
+import { testHmrSharedObject } from './shared2'
+
+export function TestHmrSharedServer() {
+  return (
+    <div>
+      test-hmr-shared-server: (<TestHmrSharedComponent />,{' '}
+      {testHmrSharedObject.value})
+    </div>
+  )
+}

--- a/packages/plugin-rsc/examples/basic/src/routes/hmr-shared/shared1.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/hmr-shared/shared1.tsx
@@ -1,3 +1,3 @@
 export function TestHmrSharedComponent() {
-  return <>component</>
+  return <>shared1</>
 }

--- a/packages/plugin-rsc/examples/basic/src/routes/hmr-shared/shared1.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/hmr-shared/shared1.tsx
@@ -1,0 +1,3 @@
+export function TestHmrSharedComponent() {
+  return <>component</>
+}

--- a/packages/plugin-rsc/examples/basic/src/routes/hmr-shared/shared2.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/hmr-shared/shared2.tsx
@@ -1,3 +1,3 @@
 export const testHmrSharedObject = {
-  value: 'object',
+  value: 'shared2',
 }

--- a/packages/plugin-rsc/examples/basic/src/routes/hmr-shared/shared2.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/hmr-shared/shared2.tsx
@@ -1,0 +1,3 @@
+export const testHmrSharedObject = {
+  value: 'object',
+}

--- a/packages/plugin-rsc/examples/basic/src/routes/root.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/root.tsx
@@ -32,6 +32,8 @@ import { TestHydrationMismatch } from './hydration-mismatch/server'
 import { TestBrowserOnly } from './browser-only/client'
 import { TestTransitiveCjsClient } from './deps/transitive-cjs/client'
 import TestDepCssInServer from '@vitejs/test-dep-css-in-server/server'
+import { TestHmrSharedServer } from './hmr-shared/server'
+import { TestHmrSharedClient } from './hmr-shared/client'
 
 export function Root(props: { url: URL }) {
   return (
@@ -56,6 +58,8 @@ export function Root(props: { url: URL }) {
         <TestDepCssInServer />
         <TestHydrationMismatch url={props.url} />
         <TestHmrClientDep />
+        <TestHmrSharedServer />
+        <TestHmrSharedClient />
         <TestTemporaryReference />
         <TestServerActionError />
         <TestReplayConsoleLogs url={props.url} />

--- a/packages/plugin-rsc/examples/basic/src/routes/root.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/root.tsx
@@ -34,6 +34,7 @@ import { TestTransitiveCjsClient } from './deps/transitive-cjs/client'
 import TestDepCssInServer from '@vitejs/test-dep-css-in-server/server'
 import { TestHmrSharedServer } from './hmr-shared/server'
 import { TestHmrSharedClient } from './hmr-shared/client'
+import { TestHmrSharedAtomic } from './hmr-shared/atomic/server'
 
 export function Root(props: { url: URL }) {
   return (
@@ -60,6 +61,7 @@ export function Root(props: { url: URL }) {
         <TestHmrClientDep />
         <TestHmrSharedServer />
         <TestHmrSharedClient />
+        <TestHmrSharedAtomic />
         <TestTemporaryReference />
         <TestServerActionError />
         <TestReplayConsoleLogs url={props.url} />

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -429,7 +429,9 @@ export default function vitePluginRsc(
         const ids = ctx.modules.map((mod) => mod.id).filter((v) => v !== null)
         if (ids.length === 0) return
 
-        // TODO: what if shared component?
+        // a shared component/module will have `isInsideClientBoundary = false` on `rsc` environment
+        // and `isInsideClientBoundary = true` on `client` environment,
+        // which means both server hmr and client hmr will be triggered.
         function isInsideClientBoundary(mods: EnvironmentModuleNode[]) {
           const visited = new Set<string>()
           function recurse(mod: EnvironmentModuleNode): boolean {


### PR DESCRIPTION
### Description

- Related https://github.com/vitejs/vite-plugin-react/issues/666

It looks like shared module hmr is almost working perfectly except it cannot guarantee server hmr and client hmr re-renders at the same time atomically, so the example like  `src/routes/hmr-shared/atomic` breaks (simplified version of https://github.com/vitejs/vite-plugin-react/issues/666).

Next.js also has same behavior https://github.com/hi-ogawa/reproductions/tree/main/next-rsc-hmr-shared-module, so this may be considered as a rather edge case. 