### PR TITLE
ci: add `if-no-files-found: ignore` to `actions/upload-artifact`

### DIFF
--- a/.github/workflows/ci-rsc.yml
+++ b/.github/workflows/ci-rsc.yml
@@ -83,3 +83,4 @@ jobs:
           name: test-results-${{ matrix.os }}-${{ matrix.browser }}${{ matrix.rolldown == true && '-rolldown' || '' }}${{ matrix.react_version && format('-react-{0}', matrix.react_version) || '' }}
           path: |
             packages/plugin-rsc/test-results
+          if-no-files-found: ignore


### PR DESCRIPTION
### Description

This is to silence noisy CI annotations like in https://github.com/vitejs/vite-plugin-react/actions/runs/16714528668

> [test-rsc (ubuntu-latest / chromium) (rolldown)](https://github.com/vitejs/vite-plugin-react/actions/runs/16714528668/job/47305398484#step:11:13)
> No files were found with the provided path: packages/plugin-rsc/test-results. No artifacts will be uploaded.

<img width="1180" height="951" alt="image" src="https://github.com/user-attachments/assets/3ff56bbe-9e91-4966-b84e-24409e92988b" />
