### PR TITLE
fix(rsc): optimize `use-sync-external-store`

### DIFF
--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -52,7 +52,7 @@ test.describe('dev-non-optimized-cjs', () => {
     const editor = f.createEditor('vite.config.ts')
     editor.edit((s) =>
       s.replace(
-        `'@vitejs/test-dep-transitive-cjs > use-sync-external-store/shim/index.js',`,
+        `include: ['@vitejs/test-dep-transitive-cjs > @vitejs/test-dep-cjs'],`,
         ``,
       ),
     )
@@ -941,9 +941,10 @@ function defineTest(f: Fixture) {
   test('transitive cjs dep', async ({ page }) => {
     await page.goto(f.url())
     await waitForHydration(page)
-    await expect(page.getByTestId('transitive-cjs-client')).toHaveText(
-      'ok:browser',
-    )
+    await expect(page.getByTestId('transitive-cjs-client')).toHaveText('ok')
+    await expect(
+      page.getByTestId('transitive-use-sync-external-store-client'),
+    ).toHaveText('ok:browser')
   })
 
   test('use cache function', async ({ page }) => {

--- a/packages/plugin-rsc/examples/basic/package.json
+++ b/packages/plugin-rsc/examples/basic/package.json
@@ -22,6 +22,7 @@
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "latest",
     "@vitejs/test-dep-transitive-cjs": "file:./test-dep/transitive-cjs",
+    "@vitejs/test-dep-transitive-use-sync-external-store": "file:./test-dep/transitive-use-sync-external-store",
     "@vitejs/test-dep-client-in-server": "file:./test-dep/client-in-server",
     "@vitejs/test-dep-client-in-server2": "file:./test-dep/client-in-server2",
     "@vitejs/test-dep-server-in-client": "file:./test-dep/server-in-client",

--- a/packages/plugin-rsc/examples/basic/src/routes/deps/transitive-cjs/client.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/deps/transitive-cjs/client.tsx
@@ -3,10 +3,18 @@
 // @ts-ignore
 import { TestClient } from '@vitejs/test-dep-transitive-cjs/client'
 
+// @ts-ignore
+import { TestClient as TestClient2 } from '@vitejs/test-dep-transitive-use-sync-external-store/client'
+
 export function TestTransitiveCjsClient() {
   return (
-    <div>
-      [test-dep-transitive-cjs-client: <TestClient />]
-    </div>
+    <>
+      <div>
+        [test-dep-transitive-cjs-client: <TestClient />]
+      </div>
+      <div>
+        [test-dep-transitive-use-sync-external-store-client: <TestClient2 />]
+      </div>
+    </>
   )
 }

--- a/packages/plugin-rsc/examples/basic/test-dep/cjs/index.js
+++ b/packages/plugin-rsc/examples/basic/test-dep/cjs/index.js
@@ -1,0 +1,1 @@
+exports.ok = 'ok'

--- a/packages/plugin-rsc/examples/basic/test-dep/cjs/package.json
+++ b/packages/plugin-rsc/examples/basic/test-dep/cjs/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@vitejs/test-dep-cjs",
+  "private": true,
+  "type": "commonjs",
+  "exports": "./index.js",
+  "peerDependencies": {
+    "react": "*"
+  }
+}

--- a/packages/plugin-rsc/examples/basic/test-dep/transitive-cjs/client.js
+++ b/packages/plugin-rsc/examples/basic/test-dep/transitive-cjs/client.js
@@ -2,26 +2,16 @@
 
 import React from 'react'
 
-// similar to swr
-// https://github.com/vercel/swr/blob/063fe55dddb95f0b6c3f1637a935c43d732ded78/src/index/use-swr.ts#L3
-import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
+import { ok } from '@vitejs/test-dep-cjs'
 
 const h = React.createElement
 
-const noopStore = () => () => {}
-
 export function TestClient() {
-  const value = useSyncExternalStore(
-    noopStore,
-    () => 'ok:browser',
-    () => 'ok:ssr',
-  )
-
   return h(
     'span',
     {
       'data-testid': 'transitive-cjs-client',
     },
-    value,
+    ok,
   )
 }

--- a/packages/plugin-rsc/examples/basic/test-dep/transitive-use-sync-external-store/client.js
+++ b/packages/plugin-rsc/examples/basic/test-dep/transitive-use-sync-external-store/client.js
@@ -1,0 +1,28 @@
+'use client'
+
+import React from 'react'
+
+// similar to
+// https://github.com/vercel/swr/blob/063fe55dddb95f0b6c3f1637a935c43d732ded78/src/index/use-swr.ts#L3
+// https://github.com/TanStack/store/blob/1d1323283e79059821d6c731eaaee60e4143dbc2/packages/react-store/src/index.ts#L1
+import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
+
+const h = React.createElement
+
+const noopStore = () => () => {}
+
+export function TestClient() {
+  const value = useSyncExternalStore(
+    noopStore,
+    () => 'ok:browser',
+    () => 'ok:ssr',
+  )
+
+  return h(
+    'span',
+    {
+      'data-testid': 'transitive-use-sync-external-store-client',
+    },
+    value,
+  )
+}

--- a/packages/plugin-rsc/examples/basic/test-dep/transitive-use-sync-external-store/package.json
+++ b/packages/plugin-rsc/examples/basic/test-dep/transitive-use-sync-external-store/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@vitejs/test-dep-transitive-cjs",
+  "name": "@vitejs/test-dep-transitive-use-sync-external-store",
   "private": true,
   "type": "module",
   "exports": {
     "./client": "./client.js"
   },
   "dependencies": {
-    "@vitejs/test-dep-cjs": "file:../cjs"
+    "use-sync-external-store": "^1.5.0"
   },
   "peerDependencies": {
     "react": "*"

--- a/packages/plugin-rsc/examples/basic/vite.config.ts
+++ b/packages/plugin-rsc/examples/basic/vite.config.ts
@@ -151,6 +151,11 @@ export default { fetch: handler };
         ],
       },
     },
+    ssr: {
+      optimizeDeps: {
+        include: ['@vitejs/test-dep-transitive-cjs > @vitejs/test-dep-cjs'],
+      },
+    },
   },
 }) as any
 

--- a/packages/plugin-rsc/examples/basic/vite.config.ts
+++ b/packages/plugin-rsc/examples/basic/vite.config.ts
@@ -151,13 +151,6 @@ export default { fetch: handler };
         ],
       },
     },
-    ssr: {
-      optimizeDeps: {
-        include: [
-          '@vitejs/test-dep-transitive-cjs > use-sync-external-store/shim/index.js',
-        ],
-      },
-    },
   },
 }) as any
 

--- a/packages/plugin-rsc/package.json
+++ b/packages/plugin-rsc/package.json
@@ -44,6 +44,7 @@
     "magic-string": "^0.30.17",
     "periscopic": "^4.0.2",
     "turbo-stream": "^3.1.0",
+    "use-sync-external-store": "^1.5.0",
     "vitefu": "^1.1.1"
   },
   "devDependencies": {
@@ -61,7 +62,6 @@
     "rsc-html-stream": "^0.0.7",
     "tinyexec": "^1.0.1",
     "tsdown": "^0.13.2",
-    "use-sync-external-store": "^1.5.0",
     "vite-plugin-inspect": "^11.3.2"
   },
   "peerDependencies": {

--- a/packages/plugin-rsc/package.json
+++ b/packages/plugin-rsc/package.json
@@ -61,6 +61,7 @@
     "rsc-html-stream": "^0.0.7",
     "tinyexec": "^1.0.1",
     "tsdown": "^0.13.2",
+    "use-sync-external-store": "^1.5.0",
     "vite-plugin-inspect": "^11.3.2"
   },
   "peerDependencies": {

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -265,6 +265,18 @@ export default function vitePluginRsc(
           ...result.ssr.noExternal.sort(),
         ]
 
+        // vendor and optimize use-sync-external-store since
+        // this is a common transitive cjs dep, which tends to cause a cryptic error.
+        const vendorDeps = [
+          `${PKG_NAME}/vendor/use-sync-external-store`,
+          `${PKG_NAME}/vendor/use-sync-external-store/with-selector`,
+          `${PKG_NAME}/vendor/use-sync-external-store/with-selector.js`,
+          `${PKG_NAME}/vendor/use-sync-external-store/shim`,
+          `${PKG_NAME}/vendor/use-sync-external-store/shim/index.js`,
+          `${PKG_NAME}/vendor/use-sync-external-store/shim/with-selector`,
+          `${PKG_NAME}/vendor/use-sync-external-store/shim/with-selector.js`,
+        ]
+
         return {
           appType: 'custom',
           define: {
@@ -311,6 +323,7 @@ export default function vitePluginRsc(
                   'react/jsx-dev-runtime',
                   'react-dom/server.edge',
                   `${REACT_SERVER_DOM_NAME}/client.edge`,
+                  ...vendorDeps,
                 ],
                 exclude: [PKG_NAME],
               },

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -2128,24 +2128,19 @@ function validateImportPlugin(): Plugin {
 function vendorUseSyncExternalStorePlugin(): Plugin[] {
   // vendor and optimize use-sync-external-store out of the box
   // since this is a commonly used cjs dep (e.g. swr, @tanstack/react-store)
+  const DEP_NAME = 'use-sync-external-store'
+  const VENDOR_DEP_NAME = `${PKG_NAME}/vendor/use-sync-external-store`
 
-  const vendorDeps = [
-    `${PKG_NAME}/vendor/use-sync-external-store/index`,
-    `${PKG_NAME}/vendor/use-sync-external-store/with-selector`,
-    `${PKG_NAME}/vendor/use-sync-external-store/shim/index`,
-    `${PKG_NAME}/vendor/use-sync-external-store/shim/with-selector`,
-  ]
-
-  // map exports to vendor deps
+  // map exports
   // cf. https://github.com/facebook/react/blob/c499adf8c89bbfd884f4d3a58c4e510001383525/packages/use-sync-external-store/package.json#L5-L20
   const alias: Record<string, string> = {
-    'use-sync-external-store': `${PKG_NAME}/vendor/use-sync-external-store/index`,
-    'use-sync-external-store/with-selector': `${PKG_NAME}/vendor/use-sync-external-store/with-selector`,
-    'use-sync-external-store/with-selector.js': `${PKG_NAME}/vendor/use-sync-external-store/with-selector`,
-    'use-sync-external-store/shim': `${PKG_NAME}/vendor/use-sync-external-store/shim/index`,
-    'use-sync-external-store/shim/index.js': `${PKG_NAME}/vendor/use-sync-external-store/shim/index`,
-    'use-sync-external-store/shim/with-selector': `${PKG_NAME}/vendor/use-sync-external-store/shim/with-selector`,
-    'use-sync-external-store/shim/with-selector.js': `${PKG_NAME}/vendor/use-sync-external-store/shim/with-selector`,
+    [DEP_NAME]: `${VENDOR_DEP_NAME}/index`,
+    [`${DEP_NAME}/with-selector`]: `${VENDOR_DEP_NAME}/with-selector`,
+    [`${DEP_NAME}/with-selector.js`]: `${VENDOR_DEP_NAME}/with-selector`,
+    [`${DEP_NAME}/shim`]: `${VENDOR_DEP_NAME}/shim/index`,
+    [`${DEP_NAME}/shim/index.js`]: `${VENDOR_DEP_NAME}/shim/index`,
+    [`${DEP_NAME}/shim/with-selector`]: `${VENDOR_DEP_NAME}/shim/with-selector`,
+    [`${DEP_NAME}/shim/with-selector.js`]: `${VENDOR_DEP_NAME}/shim/with-selector`,
   }
 
   return [
@@ -2157,7 +2152,7 @@ function vendorUseSyncExternalStorePlugin(): Plugin[] {
           environments: {
             ssr: {
               optimizeDeps: {
-                include: vendorDeps,
+                include: [...new Set(Object.values(alias))],
               },
             },
           },

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -2128,20 +2128,17 @@ function validateImportPlugin(): Plugin {
 function vendorUseSyncExternalStorePlugin(): Plugin[] {
   // vendor and optimize use-sync-external-store out of the box
   // since this is a commonly used cjs dep (e.g. swr, @tanstack/react-store)
-  const DEP_NAME = 'use-sync-external-store'
-  const VENDOR_DEP_NAME = `${PKG_NAME}/vendor/use-sync-external-store`
 
-  // map exports
-  // cf. https://github.com/facebook/react/blob/c499adf8c89bbfd884f4d3a58c4e510001383525/packages/use-sync-external-store/package.json#L5-L20
-  const alias: Record<string, string> = {
-    [DEP_NAME]: `${VENDOR_DEP_NAME}/index`,
-    [`${DEP_NAME}/with-selector`]: `${VENDOR_DEP_NAME}/with-selector`,
-    [`${DEP_NAME}/with-selector.js`]: `${VENDOR_DEP_NAME}/with-selector`,
-    [`${DEP_NAME}/shim`]: `${VENDOR_DEP_NAME}/shim/index`,
-    [`${DEP_NAME}/shim/index.js`]: `${VENDOR_DEP_NAME}/shim/index`,
-    [`${DEP_NAME}/shim/with-selector`]: `${VENDOR_DEP_NAME}/shim/with-selector`,
-    [`${DEP_NAME}/shim/with-selector.js`]: `${VENDOR_DEP_NAME}/shim/with-selector`,
-  }
+  // https://github.com/facebook/react/blob/c499adf8c89bbfd884f4d3a58c4e510001383525/packages/use-sync-external-store/package.json#L5-L20
+  const exports = [
+    'use-sync-external-store',
+    'use-sync-external-store/with-selector',
+    'use-sync-external-store/with-selector.js',
+    'use-sync-external-store/shim',
+    'use-sync-external-store/shim/index.js',
+    'use-sync-external-store/shim/with-selector',
+    'use-sync-external-store/shim/with-selector.js',
+  ]
 
   return [
     {
@@ -2152,27 +2149,11 @@ function vendorUseSyncExternalStorePlugin(): Plugin[] {
           environments: {
             ssr: {
               optimizeDeps: {
-                include: [...new Set(Object.values(alias))],
+                include: exports.map((e) => `${PKG_NAME} > ${e}`),
               },
             },
           },
         }
-      },
-    },
-    // TODO: why not alias?
-    {
-      name: 'rsc:vendor-use-sync-external-store:resolve',
-      applyToEnvironment: (e) => e.name === 'ssr',
-      enforce: 'pre',
-      resolveId: {
-        order: 'pre',
-        async handler(source) {
-          const target = alias[source]
-          if (target) {
-            const resolved = await this.resolve(target)
-            return resolved
-          }
-        },
       },
     },
   ]

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -2127,7 +2127,8 @@ function validateImportPlugin(): Plugin {
 
 function vendorUseSyncExternalStorePlugin(): Plugin[] {
   // vendor and optimize use-sync-external-store out of the box
-  // since this is a commonly used cjs dep (e.g. swr, @tanstack/react-store)
+  // since this is a common enough cjs, which tends to break
+  // other packages (e.g. swr, @tanstack/react-store)
 
   // https://github.com/facebook/react/blob/c499adf8c89bbfd884f4d3a58c4e510001383525/packages/use-sync-external-store/package.json#L5-L20
   const exports = [

--- a/packages/plugin-rsc/tsdown.config.ts
+++ b/packages/plugin-rsc/tsdown.config.ts
@@ -44,6 +44,15 @@ export default defineConfig({
           recursive: true,
           force: true,
         })
+        fs.cpSync(
+          './node_modules/use-sync-external-store',
+          './dist/vendor/use-sync-external-store',
+          { recursive: true, dereference: true },
+        )
+        fs.rmSync('./dist/vendor/use-sync-external-store/node_modules', {
+          recursive: true,
+          force: true,
+        })
       },
     },
   ],

--- a/packages/plugin-rsc/tsdown.config.ts
+++ b/packages/plugin-rsc/tsdown.config.ts
@@ -44,15 +44,6 @@ export default defineConfig({
           recursive: true,
           force: true,
         })
-        fs.cpSync(
-          './node_modules/use-sync-external-store',
-          './dist/vendor/use-sync-external-store',
-          { recursive: true, dereference: true },
-        )
-        fs.rmSync('./dist/vendor/use-sync-external-store/node_modules', {
-          recursive: true,
-          force: true,
-        })
       },
     },
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -551,6 +551,9 @@ importers:
       '@vitejs/test-dep-transitive-cjs':
         specifier: file:./test-dep/transitive-cjs
         version: file:packages/plugin-rsc/examples/basic/test-dep/transitive-cjs(react@19.1.1)
+      '@vitejs/test-dep-transitive-use-sync-external-store':
+        specifier: file:./test-dep/transitive-use-sync-external-store
+        version: file:packages/plugin-rsc/examples/basic/test-dep/transitive-use-sync-external-store(react@19.1.1)
       rsc-html-stream:
         specifier: ^0.0.7
         version: 0.0.7
@@ -2597,6 +2600,11 @@ packages:
   '@vitejs/release-scripts@1.6.0':
     resolution: {integrity: sha512-XV+w22Fvn+wqDtEkz8nQIJzvmRVSh90c2xvOO7cX9fkX8+39ZJpYRiXDIRJG1JRnF8khm1rHjulid+l+khc7TQ==}
 
+  '@vitejs/test-dep-cjs@file:packages/plugin-rsc/examples/basic/test-dep/cjs':
+    resolution: {directory: packages/plugin-rsc/examples/basic/test-dep/cjs, type: directory}
+    peerDependencies:
+      react: '*'
+
   '@vitejs/test-dep-client-in-server2@file:packages/plugin-rsc/examples/basic/test-dep/client-in-server2':
     resolution: {directory: packages/plugin-rsc/examples/basic/test-dep/client-in-server2, type: directory}
     peerDependencies:
@@ -2629,6 +2637,11 @@ packages:
 
   '@vitejs/test-dep-transitive-cjs@file:packages/plugin-rsc/examples/basic/test-dep/transitive-cjs':
     resolution: {directory: packages/plugin-rsc/examples/basic/test-dep/transitive-cjs, type: directory}
+    peerDependencies:
+      react: '*'
+
+  '@vitejs/test-dep-transitive-use-sync-external-store@file:packages/plugin-rsc/examples/basic/test-dep/transitive-use-sync-external-store':
+    resolution: {directory: packages/plugin-rsc/examples/basic/test-dep/transitive-use-sync-external-store, type: directory}
     peerDependencies:
       react: '*'
 
@@ -6404,6 +6417,10 @@ snapshots:
     transitivePeerDependencies:
       - conventional-commits-filter
 
+  '@vitejs/test-dep-cjs@file:packages/plugin-rsc/examples/basic/test-dep/cjs(react@19.1.1)':
+    dependencies:
+      react: 19.1.1
+
   '@vitejs/test-dep-client-in-server2@file:packages/plugin-rsc/examples/basic/test-dep/client-in-server2(react@19.1.1)':
     dependencies:
       react: 19.1.1
@@ -6429,6 +6446,11 @@ snapshots:
       react: 19.1.1
 
   '@vitejs/test-dep-transitive-cjs@file:packages/plugin-rsc/examples/basic/test-dep/transitive-cjs(react@19.1.1)':
+    dependencies:
+      '@vitejs/test-dep-cjs': file:packages/plugin-rsc/examples/basic/test-dep/cjs(react@19.1.1)
+      react: 19.1.1
+
+  '@vitejs/test-dep-transitive-use-sync-external-store@file:packages/plugin-rsc/examples/basic/test-dep/transitive-use-sync-external-store(react@19.1.1)':
     dependencies:
       react: 19.1.1
       use-sync-external-store: 1.5.0(react@19.1.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -456,6 +456,9 @@ importers:
       turbo-stream:
         specifier: ^3.1.0
         version: 3.1.0
+      use-sync-external-store:
+        specifier: ^1.5.0
+        version: 1.5.0(react@19.1.1)
       vitefu:
         specifier: ^1.1.1
         version: 1.1.1(vite@7.0.6(@types/node@22.17.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))
@@ -502,9 +505,6 @@ importers:
       tsdown:
         specifier: ^0.13.2
         version: 0.13.2(publint@0.3.12)(typescript@5.9.2)
-      use-sync-external-store:
-        specifier: ^1.5.0
-        version: 1.5.0(react@19.1.1)
       vite-plugin-inspect:
         specifier: ^11.3.2
         version: 11.3.2(vite@7.0.6(@types/node@22.17.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))
@@ -646,7 +646,7 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.11.0
-        version: 1.11.0(rollup@4.44.1)(vite@7.0.6(@types/node@22.17.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))(workerd@1.20250730.0)
+        version: 1.11.0(rollup@4.44.1)(vite@7.0.6(@types/node@22.17.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))(workerd@1.20250730.0)(wrangler@4.27.0)
       '@react-router/dev':
         specifier: 7.7.0
         version: 7.7.0(@types/node@22.17.0)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(react-router@7.7.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(tsx@4.20.3)(typescript@5.9.2)(vite@7.0.6(@types/node@22.17.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))(wrangler@4.27.0)(yaml@2.7.1)
@@ -751,7 +751,7 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.11.0
-        version: 1.11.0(rollup@4.44.1)(vite@7.0.6(@types/node@22.17.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))(workerd@1.20250730.0)
+        version: 1.11.0(rollup@4.44.1)(vite@7.0.6(@types/node@22.17.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))(workerd@1.20250730.0)(wrangler@4.27.0)
       '@types/react':
         specifier: ^19.1.9
         version: 19.1.9
@@ -1234,6 +1234,7 @@ packages:
     resolution: {integrity: sha512-NVK5n6CTRf0cXItSc+X3UJZ37xKCLybbSEUDYuZNGzvAsbwivgI66eKl7+BKTVq55fo17YbrrIBQAUsQkgopHQ==}
     peerDependencies:
       vite: ^6.1.0 || ^7.0.0
+      wrangler: ^4.27.0
 
   '@cloudflare/workerd-darwin-64@1.20250730.0':
     resolution: {integrity: sha512-X3egNyTjLQaECYe34x8Al7r4oXAhcN3a8+8qcpNCcq1sgtuHIeAwS9potgRR/mwkGfmrJn7nfAyDKC4vrkniQQ==}
@@ -5191,7 +5192,7 @@ snapshots:
     optionalDependencies:
       workerd: 1.20250730.0
 
-  '@cloudflare/vite-plugin@1.11.0(rollup@4.44.1)(vite@7.0.6(@types/node@22.17.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))(workerd@1.20250730.0)':
+  '@cloudflare/vite-plugin@1.11.0(rollup@4.44.1)(vite@7.0.6(@types/node@22.17.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))(workerd@1.20250730.0)(wrangler@4.27.0)':
     dependencies:
       '@cloudflare/unenv-preset': 2.5.0(unenv@2.0.0-rc.19)(workerd@1.20250730.0)
       '@mjackson/node-fetch-server': 0.6.1
@@ -5205,7 +5206,6 @@ snapshots:
       wrangler: 4.27.0
       ws: 8.18.0
     transitivePeerDependencies:
-      - '@cloudflare/workers-types'
       - bufferutil
       - rollup
       - utf-8-validate

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -502,6 +502,9 @@ importers:
       tsdown:
         specifier: ^0.13.2
         version: 0.13.2(publint@0.3.12)(typescript@5.9.2)
+      use-sync-external-store:
+        specifier: ^1.5.0
+        version: 1.5.0(react@19.1.1)
       vite-plugin-inspect:
         specifier: ^11.3.2
         version: 11.3.2(vite@7.0.6(@types/node@22.17.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))
@@ -643,7 +646,7 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.11.0
-        version: 1.11.0(rollup@4.44.1)(vite@7.0.6(@types/node@22.17.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))(workerd@1.20250730.0)(wrangler@4.27.0)
+        version: 1.11.0(rollup@4.44.1)(vite@7.0.6(@types/node@22.17.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))(workerd@1.20250730.0)
       '@react-router/dev':
         specifier: 7.7.0
         version: 7.7.0(@types/node@22.17.0)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(react-router@7.7.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(tsx@4.20.3)(typescript@5.9.2)(vite@7.0.6(@types/node@22.17.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))(wrangler@4.27.0)(yaml@2.7.1)
@@ -748,7 +751,7 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.11.0
-        version: 1.11.0(rollup@4.44.1)(vite@7.0.6(@types/node@22.17.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))(workerd@1.20250730.0)(wrangler@4.27.0)
+        version: 1.11.0(rollup@4.44.1)(vite@7.0.6(@types/node@22.17.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))(workerd@1.20250730.0)
       '@types/react':
         specifier: ^19.1.9
         version: 19.1.9
@@ -1231,7 +1234,6 @@ packages:
     resolution: {integrity: sha512-NVK5n6CTRf0cXItSc+X3UJZ37xKCLybbSEUDYuZNGzvAsbwivgI66eKl7+BKTVq55fo17YbrrIBQAUsQkgopHQ==}
     peerDependencies:
       vite: ^6.1.0 || ^7.0.0
-      wrangler: ^4.27.0
 
   '@cloudflare/workerd-darwin-64@1.20250730.0':
     resolution: {integrity: sha512-X3egNyTjLQaECYe34x8Al7r4oXAhcN3a8+8qcpNCcq1sgtuHIeAwS9potgRR/mwkGfmrJn7nfAyDKC4vrkniQQ==}
@@ -5189,7 +5191,7 @@ snapshots:
     optionalDependencies:
       workerd: 1.20250730.0
 
-  '@cloudflare/vite-plugin@1.11.0(rollup@4.44.1)(vite@7.0.6(@types/node@22.17.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))(workerd@1.20250730.0)(wrangler@4.27.0)':
+  '@cloudflare/vite-plugin@1.11.0(rollup@4.44.1)(vite@7.0.6(@types/node@22.17.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))(workerd@1.20250730.0)':
     dependencies:
       '@cloudflare/unenv-preset': 2.5.0(unenv@2.0.0-rc.19)(workerd@1.20250730.0)
       '@mjackson/node-fetch-server': 0.6.1
@@ -5203,6 +5205,7 @@ snapshots:
       wrangler: 4.27.0
       ws: 8.18.0
     transitivePeerDependencies:
+      - '@cloudflare/workers-types'
       - bufferutil
       - rollup
       - utf-8-validate


### PR DESCRIPTION
### Description

- Related https://github.com/vitejs/vite-plugin-react/issues/610

This is like a more hacky territory, but I think this use case is worth saving to reduce minor paper cut as much as possible.

---

Actually we might not need to vendor as a copy, but simply optimizing `@vitejs/plugin-rsc > use-sync-external-store/**/*` might be enough since Vite cannot differentiate where the dep comes from.