### PR TITLE
fix(rsc): optimize `react-dom/server`

### DIFF
--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -309,6 +309,7 @@ export default function vitePluginRsc(
                   'react-dom',
                   'react/jsx-runtime',
                   'react/jsx-dev-runtime',
+                  'react-dom/server',
                   'react-dom/server.edge',
                   `${REACT_SERVER_DOM_NAME}/client.edge`,
                 ],


### PR DESCRIPTION
### Description

- related https://github.com/vitejs/vite-plugin-react/issues/610

For example, this is used by tanstack https://github.com/TanStack/router/blob/8efac91d6d7d3e12ed5ef1964392241142492f6a/packages/react-router/src/ssr/renderRouterToStream.tsx#L2.

I remember one annoying thing about React node build is that it includes node builtin without `node:...` prefix, so it can ends up optimizing with node polyfill package, which then actually breaks code e.g. `util` not implementing `TextEncoder` properly https://github.com/browserify/node-util. But I think it's fine it only happens when users installs `util` in their own `node_modules`.