### PR TITLE
refactor(rsc): update `@mjackson/node-fetch-server` to `@remix-run/node-fetch-server`

### DIFF
--- a/packages/plugin-rsc/package.json
+++ b/packages/plugin-rsc/package.json
@@ -38,7 +38,7 @@
     "prepack": "tsdown"
   },
   "dependencies": {
-    "@mjackson/node-fetch-server": "^0.7.0",
+    "@remix-run/node-fetch-server": "^0.8.0",
     "es-module-lexer": "^1.7.0",
     "estree-walker": "^3.0.3",
     "magic-string": "^0.30.17",

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs'
 import { createRequire } from 'node:module'
 import path from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
-import { createRequestListener } from '@mjackson/node-fetch-server'
+import { createRequestListener } from '@remix-run/node-fetch-server'
 import * as esModuleLexer from 'es-module-lexer'
 import MagicString from 'magic-string'
 import {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -438,9 +438,9 @@ importers:
 
   packages/plugin-rsc:
     dependencies:
-      '@mjackson/node-fetch-server':
-        specifier: ^0.7.0
-        version: 0.7.0
+      '@remix-run/node-fetch-server':
+        specifier: ^0.8.0
+        version: 0.8.0
       es-module-lexer:
         specifier: ^1.7.0
         version: 1.7.0
@@ -1855,9 +1855,6 @@ packages:
   '@mjackson/node-fetch-server@0.6.1':
     resolution: {integrity: sha512-9ZJnk/DJjt805uv5PPv11haJIW+HHf3YEEyVXv+8iLQxLD/iXA68FH220XoiTPBC4gCg5q+IMadDw8qPqlA5wg==}
 
-  '@mjackson/node-fetch-server@0.7.0':
-    resolution: {integrity: sha512-un8diyEBKU3BTVj3GzlTPA1kIjCkGdD+AMYQy31Gf9JCkfoZzwgJ79GUtHrF2BN3XPNMLpubbzPcxys+a3uZEw==}
-
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -1951,6 +1948,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@remix-run/node-fetch-server@0.8.0':
+    resolution: {integrity: sha512-8/sKegb4HrM6IdcQeU0KPhj9VOHm5SUqswJDHuMCS3mwbr/NRx078QDbySmn0xslahvvZoOENd7EnK40kWKxkg==}
 
   '@rolldown/binding-android-arm64@1.0.0-beta.30':
     resolution: {integrity: sha512-4j7QBitb/WMT1fzdJo7BsFvVNaFR5WCQPdf/RPDHEsgQIYwBaHaL47KTZxncGFQDD1UAKN3XScJ0k7LAsZfsvg==}
@@ -5701,8 +5701,6 @@ snapshots:
 
   '@mjackson/node-fetch-server@0.6.1': {}
 
-  '@mjackson/node-fetch-server@0.7.0': {}
-
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.4.5
@@ -5845,6 +5843,8 @@ snapshots:
       react-router: 7.7.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
     optionalDependencies:
       typescript: 5.9.2
+
+  '@remix-run/node-fetch-server@0.8.0': {}
 
   '@rolldown/binding-android-arm64@1.0.0-beta.30':
     optional: true


### PR DESCRIPTION
### Description

`@mjackson/node-fetch-server` is now deprecated and [`@remix-run/node-fetch-server`](npm.im/@remix-run/node-fetch-server) should be used instead