### PR TITLE
fix(react): always skip react-compiler on non client envrionment

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -245,6 +245,14 @@ export default function viteReact(opts: Options = {}): Plugin[] {
         })()
         const plugins = [...babelOptions.plugins]
 
+        // remove react-compiler plugin on non client environment
+        if (ssr) {
+          const reactCompilerPlugin = getReactCompilerPlugin(plugins)
+          if (reactCompilerPlugin) {
+            plugins.splice(plugins.indexOf(reactCompilerPlugin), 1)
+          }
+        }
+
         const isJSX = filepath.endsWith('x')
         const useFastRefresh =
           !skipFastRefresh &&

--- a/packages/plugin-rsc/e2e/react-compiler.test.ts
+++ b/packages/plugin-rsc/e2e/react-compiler.test.ts
@@ -22,12 +22,7 @@ test.describe(() => {
 
           const overrideConfig = defineConfig({
             plugins: [
-              react({
-                babel: { plugins: ['babel-plugin-react-compiler'] },
-              }).map((p) => ({
-                ...p,
-                applyToEnvironment: (e) => e.name === 'client',
-              })),
+              react({ babel: { plugins: ['babel-plugin-react-compiler'] } }),
               rsc(),
             ],
           })


### PR DESCRIPTION
### Description

- Closes https://github.com/vitejs/vite-plugin-react/issues/627

This assumes people always CSR only on client environment, but I think this is fair assumption in the same way we assume refresh transform on client environment.

Though I actually recently encountered an exception where `react_client` environment does CSR in https://github.com/kasperpeulen/vitest-plugin-rsc, neither react compiler nor hmr is on the table for this usage, so it's fine to not take that into account.