### PR TITLE
fix(rsc): replace non-optimized server cjs warning with debug only log

### DIFF
--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -58,7 +58,15 @@ test.describe('dev-non-optimized-cjs', () => {
     )
   })
 
-  const f = useFixture({ root: 'examples/basic', mode: 'dev' })
+  const f = useFixture({
+    root: 'examples/basic',
+    mode: 'dev',
+    cliOptions: {
+      env: {
+        DEBUG: 'vite-rsc:cjs',
+      },
+    },
+  })
 
   test('show warning', async ({ page }) => {
     await page.goto(f.url())

--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -70,8 +70,8 @@ test.describe('dev-non-optimized-cjs', () => {
 
   test('show warning', async ({ page }) => {
     await page.goto(f.url())
-    expect(f.proc().stderr()).toContain(
-      `Found non-optimized CJS dependency in 'ssr' environment.`,
+    expect(f.proc().stderr()).toMatch(
+      /non-optimized CJS dependency in 'ssr' environment.*@vitejs\/test-dep-cjs\/index.js/,
     )
   })
 })

--- a/packages/plugin-rsc/examples/react-router/cf/vite.config.ts
+++ b/packages/plugin-rsc/examples/react-router/cf/vite.config.ts
@@ -45,13 +45,11 @@ export default defineConfig({
     },
     ssr: {
       optimizeDeps: {
-        include: ['react-router > cookie', 'react-router > set-cookie-parser'],
         exclude: ['react-router'],
       },
     },
     rsc: {
       optimizeDeps: {
-        include: ['react-router > cookie', 'react-router > set-cookie-parser'],
         exclude: ['react-router'],
       },
     },

--- a/packages/plugin-rsc/src/plugins/cjs.ts
+++ b/packages/plugin-rsc/src/plugins/cjs.ts
@@ -46,8 +46,7 @@ export function cjsModuleRunnerPlugin(): Plugin[] {
           const packageKey = extractPackageKey(id)
           if (!warnedPackages.has(packageKey)) {
             debug(
-              `Found non-optimized CJS dependency in '${this.environment.name}' environment. ` +
-                `It is recommended to add the dependency to 'environments.${this.environment.name}.optimizeDeps.include'.`,
+              `non-optimized CJS dependency in '${this.environment.name}' environment: ${id}`,
             )
             warnedPackages.add(packageKey)
           }

--- a/packages/plugin-rsc/src/plugins/cjs.ts
+++ b/packages/plugin-rsc/src/plugins/cjs.ts
@@ -10,8 +10,7 @@ import { createDebug } from '@hiogawa/utils'
 const debug = createDebug('vite-rsc:cjs')
 
 export function cjsModuleRunnerPlugin(): Plugin[] {
-  // use-sync-external-store is known to work fine so don't show warning
-  const warnedPackages = new Set<string>(['use-sync-external-store'])
+  const warnedPackages = new Set<string>()
 
   return [
     {

--- a/packages/plugin-rsc/src/plugins/cjs.ts
+++ b/packages/plugin-rsc/src/plugins/cjs.ts
@@ -5,6 +5,9 @@ import path from 'node:path'
 import fs from 'node:fs'
 import * as esModuleLexer from 'es-module-lexer'
 import { transformCjsToEsm } from '../transforms/cjs'
+import { createDebug } from '@hiogawa/utils'
+
+const debug = createDebug('vite-rsc:cjs')
 
 export function cjsModuleRunnerPlugin(): Plugin[] {
   // use-sync-external-store is known to work fine so don't show warning
@@ -43,7 +46,7 @@ export function cjsModuleRunnerPlugin(): Plugin[] {
           // warning once per package
           const packageKey = extractPackageKey(id)
           if (!warnedPackages.has(packageKey)) {
-            this.warn(
+            debug(
               `Found non-optimized CJS dependency in '${this.environment.name}' environment. ` +
                 `It is recommended to add the dependency to 'environments.${this.environment.name}.optimizeDeps.include'.`,
             )


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

Replacing always-on warning with `DEBUG=vite-rsc:cjs` based warning.
