### PR TITLE
chore(rsc): fix csp example for Vite server ping SharedWorker

### DIFF
--- a/packages/plugin-rsc/examples/basic/src/server.tsx
+++ b/packages/plugin-rsc/examples/basic/src/server.tsx
@@ -22,15 +22,17 @@ export default async function handler(request: Request): Promise<Response> {
     nonce,
   })
   if (nonce && response.headers.get('content-type')?.includes('text/html')) {
-    response.headers.set(
-      'content-security-policy',
-      `default-src 'self'; ` +
-        // `unsafe-eval` is required during dev since React uses eval for findSourceMapURL feature
-        `script-src 'self' 'nonce-${nonce}' ${
-          import.meta.env.DEV ? `'unsafe-eval'` : ``
-        } ; ` +
-        `style-src 'self' 'nonce-${nonce}'; `,
-    )
+    const cspValue = [
+      `default-src 'self';`,
+      // `unsafe-eval` is required during dev since React uses eval for findSourceMapURL feature
+      `script-src 'self' 'nonce-${nonce}' ${import.meta.env.DEV ? `'unsafe-eval'` : ``};`,
+      `style-src 'self' 'nonce-${nonce}';`,
+      // allow blob: worker for Vite server ping shared worker
+      import.meta.hot && `worker-src 'self' blob:;`,
+    ]
+      .filter(Boolean)
+      .join('')
+    response.headers.set('content-security-policy', cspValue)
   }
   return response
 }


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

Without this, Vite's SharedWorker get blocked by:

```sh
Refused to create a worker from 'blob:http://localhost:5173/4600b782-fd0b-4ee7-b8f6-9e0e1156c691' because it violates the following Content Security Policy directive: "script-src 'self' 'nonce-d6241950-ac41-4fff-b52b-6948b203bfbe' 'unsafe-eval'". Note that 'worker-src' was not explicitly set, so 'script-src' is used as a fallback.

client:938 Uncaught (in promise) SecurityError: Failed to construct 'SharedWorker': Access to the script at 'blob:http://localhost:5173/4600b782-fd0b-4ee7-b8f6-9e0e1156c691' is denied by the document's Content Security Policy.
    at waitForSuccessfulPing (client:938:23)
    at handleMessage (client:869:12)
```
