### PR TITLE
fix(rsc): warn dual module of optimized and non-optimized client reference

### DIFF
--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -76,11 +76,34 @@ test.describe('dev-non-optimized-cjs', () => {
   })
 })
 
+test.describe('dev-inconsistent-client-optimization', () => {
+  test.beforeAll(async () => {
+    // remove explicitly added optimizeDeps.exclude
+    const editor = f.createEditor('vite.config.ts')
+    editor.edit((s) =>
+      s.replace(`'@vitejs/test-dep-client-in-server2/client',`, ``),
+    )
+  })
+
+  const f = useFixture({
+    root: 'examples/basic',
+    mode: 'dev',
+  })
+
+  test('show warning', async ({ page }) => {
+    await page.goto(f.url())
+    expect(f.proc().stderr()).toContain(
+      'client component dependency is inconsistently optimized.',
+    )
+  })
+})
+
 function defineTest(f: Fixture) {
   test('basic', async ({ page }) => {
     using _ = expectNoPageError(page)
     await page.goto(f.url())
     await waitForHydration(page)
+    expect(f.proc().stderr()).toBe('')
   })
 
   test('client component', async ({ page }) => {

--- a/packages/plugin-rsc/e2e/fixture.ts
+++ b/packages/plugin-rsc/e2e/fixture.ts
@@ -106,7 +106,7 @@ export function useFixture(options: {
         await proc.done
         assert(proc.proc.exitCode === 0)
       }
-      const proc = runCli({
+      proc = runCli({
         command: options.command ?? `pnpm preview`,
         label: `${options.root}:preview`,
         cwd,

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -952,7 +952,7 @@ function vitePluginUseClient(
     useClientPluginOptions.environment?.browser ?? 'client'
 
   // TODO: warning for late optimizer discovery
-  function warnNonOptimizedClientId(
+  function warnInoncistentClientOptimization(
     ctx: Rollup.TransformPluginContext,
     id: string,
   ) {
@@ -961,7 +961,7 @@ function vitePluginUseClient(
       for (const dep of Object.values(depsOptimizer.metadata.optimized)) {
         if (dep.src === id) {
           ctx.warn(
-            `Client component dependency is inconsistently optimized. ` +
+            `client component dependency is inconsistently optimized. ` +
               `It's recommended to add the dependency to 'optimizeDeps.exclude'.`,
           )
         }
@@ -1005,7 +1005,7 @@ function vitePluginUseClient(
             )
           }
           id = cleanUrl(id)
-          warnNonOptimizedClientId(this, id)
+          warnInoncistentClientOptimization(this, id)
           importId = `/@id/__x00__virtual:vite-rsc/client-in-server-package-proxy/${encodeURIComponent(id)}`
           referenceKey = importId
         } else if (packageSource) {

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -951,6 +951,8 @@ function vitePluginUseClient(
   const browserEnvironmentName =
     useClientPluginOptions.environment?.browser ?? 'client'
 
+  const nonOptimizedClientIds = new Set<string>()
+
   return [
     {
       name: 'rsc:use-client',
@@ -986,7 +988,9 @@ function vitePluginUseClient(
               `[vite-rsc] detected an internal client boundary created by a package imported on rsc environment`,
             )
           }
-          importId = `/@id/__x00__virtual:vite-rsc/client-in-server-package-proxy/${encodeURIComponent(cleanUrl(id))}`
+          id = cleanUrl(id)
+          nonOptimizedClientIds.add(id)
+          importId = `/@id/__x00__virtual:vite-rsc/client-in-server-package-proxy/${encodeURIComponent(id)}`
           referenceKey = importId
         } else if (packageSource) {
           if (this.environment.mode === 'dev') {

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -953,6 +953,24 @@ function vitePluginUseClient(
 
   const nonOptimizedClientIds = new Set<string>()
 
+  // TODO: handle when optimizer discovers this later
+  // TODO: use logger
+  function warnNonOptimizedClientId(id: string) {
+    const { depsOptimizer } = server.environments.client
+    if (!depsOptimizer) return
+
+    nonOptimizedClientIds.add(id)
+    for (const dep of depsOptimizer.metadata.depInfoList) {
+      if (dep.src === id) {
+        console.error(
+          `\
+[vite-rsc] client component dependency is inconsistently optimized. It's recommended to add the dependency it to 'optimizeDeps.exclude'.
+File: ${id}`,
+        )
+      }
+    }
+  }
+
   return [
     {
       name: 'rsc:use-client',
@@ -989,7 +1007,7 @@ function vitePluginUseClient(
             )
           }
           id = cleanUrl(id)
-          nonOptimizedClientIds.add(id)
+          warnNonOptimizedClientId(id)
           importId = `/@id/__x00__virtual:vite-rsc/client-in-server-package-proxy/${encodeURIComponent(id)}`
           referenceKey = importId
         } else if (packageSource) {


### PR DESCRIPTION
### Description

- Related https://github.com/vitejs/vite-plugin-react/pull/697

TODO 
- [x] test
- [x] test on waku

---

Example

```
8:55:28 AM [vite] (rsc) warning: client component dependency is inconsistently optimized. It's recommended to add the dependency to 'optimizeDeps.exclude'.
  Plugin: rsc:use-client
  File: /home/hiroshi/code/others/vite-plugin-react/node_modules/.pnpm/@vitejs+test-dep-client-in-server2@file+packages+plugin-rsc+examples+basic+test-dep+client-in-server2_react@19.1.1/node_modules/@vitejs/test-dep-client-in-server2/client.js?v=a2d049ff
```
