### PR TITLE
fix(react): refreshWrapper was injected twice for class components when using babel plugins and rolldown-vite

### DIFF
--- a/packages/plugin-react/CHANGELOG.md
+++ b/packages/plugin-react/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### Fix `RefreshRuntime` being injected twice for class components on rolldown-vite ([#708](https://github.com/vitejs/vite-plugin-react/pull/708))
+
 ## 5.0.0 (2025-08-07)
 
 ## 5.0.0-beta.0 (2025-07-28)

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -255,6 +255,7 @@ export default function viteReact(opts: Options = {}): Plugin[] {
 
         const isJSX = filepath.endsWith('x')
         const useFastRefresh =
+          !isRolldownVite &&
           !skipFastRefresh &&
           !ssr &&
           (isJSX ||
@@ -262,7 +263,7 @@ export default function viteReact(opts: Options = {}): Plugin[] {
               ? importReactRE.test(code)
               : code.includes(jsxImportDevRuntime) ||
                 code.includes(jsxImportRuntime)))
-        if (useFastRefresh && !isRolldownVite) {
+        if (useFastRefresh) {
           plugins.push([
             await loadPlugin('react-refresh/babel'),
             { skipEnvCheck: true },
@@ -324,8 +325,7 @@ export default function viteReact(opts: Options = {}): Plugin[] {
         })
 
         if (result) {
-          // refresh wrapper is added later for rolldown-vite
-          if (!useFastRefresh || isRolldownVite) {
+          if (!useFastRefresh) {
             return { code: result.code!, map: result.map }
           }
           return addRefreshWrapper(

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -324,7 +324,8 @@ export default function viteReact(opts: Options = {}): Plugin[] {
         })
 
         if (result) {
-          if (!useFastRefresh) {
+          // refresh wrapper is added later for rolldown-vite
+          if (!useFastRefresh || isRolldownVite) {
             return { code: result.code!, map: result.map }
           }
           return addRefreshWrapper(

--- a/playground/compiler/__tests__/compiler.spec.ts
+++ b/playground/compiler/__tests__/compiler.spec.ts
@@ -5,6 +5,7 @@ test('should render', async () => {
   expect(await page.textContent('button')).toMatch('count is 0')
   expect(await page.click('button'))
   expect(await page.textContent('button')).toMatch('count is 1')
+  expect(await page.textContent('.class-component')).toMatch('ClassComponent')
 })
 
 test.runIf(isServe)('should hmr', async () => {

--- a/playground/compiler/src/App.tsx
+++ b/playground/compiler/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import './App.css'
+import { ClassComponent } from './ClassComponent'
 
 export function App() {
   const [count, setCount] = useState(0)
@@ -18,6 +19,7 @@ export function App() {
       <p className="read-the-docs">
         Click on the Vite and React logos to learn more
       </p>
+      <ClassComponent />
     </>
   )
 }

--- a/playground/compiler/src/ClassComponent.tsx
+++ b/playground/compiler/src/ClassComponent.tsx
@@ -1,0 +1,7 @@
+import { Component } from 'react'
+
+export class ClassComponent extends Component {
+  public render() {
+    return <div className="class-component">ClassComponent</div>
+  }
+}


### PR DESCRIPTION
### Description

fixes https://github.com/vitejs/rolldown-vite/issues/368

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
