### PR TITLE
chore(rsc): rework ssg example

### DIFF
--- a/packages/plugin-rsc/examples/ssg/src/framework/entry.rsc.tsx
+++ b/packages/plugin-rsc/examples/ssg/src/framework/entry.rsc.tsx
@@ -36,3 +36,27 @@ export default async function handler(request: Request): Promise<Response> {
     },
   })
 }
+
+// return both rsc and html streams at once for ssg
+export async function handleSsg(request: Request): Promise<{
+  html: ReadableStream<Uint8Array>
+  rsc: ReadableStream<Uint8Array>
+}> {
+  const url = new URL(request.url)
+  const rscPayload: RscPayload = { root: <Root url={url} /> }
+  const rscStream = ReactServer.renderToReadableStream<RscPayload>(rscPayload)
+  const [rscStream1, rscStream2] = rscStream.tee()
+
+  const ssr = await import.meta.viteRsc.loadModule<
+    typeof import('./entry.ssr')
+  >('ssr', 'index')
+  const htmlStream = await ssr.renderHtml(rscStream1, {
+    ssg: true,
+  })
+
+  return { html: htmlStream, rsc: rscStream2 }
+}
+
+if (import.meta.hot) {
+  import.meta.hot.accept()
+}

--- a/packages/plugin-rsc/examples/ssg/src/framework/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/ssg/src/framework/entry.ssr.tsx
@@ -4,7 +4,12 @@ import * as ReactDomServer from 'react-dom/server.edge'
 import { injectRSCPayload } from 'rsc-html-stream/server'
 import type { RscPayload } from './shared'
 
-export async function renderHtml(rscStream: ReadableStream<Uint8Array>) {
+export async function renderHtml(
+  rscStream: ReadableStream<Uint8Array>,
+  options?: {
+    ssg?: boolean
+  },
+) {
   const [rscStream1, rscStream2] = rscStream.tee()
 
   let payload: Promise<RscPayload>
@@ -20,8 +25,9 @@ export async function renderHtml(rscStream: ReadableStream<Uint8Array>) {
   const htmlStream = await ReactDomServer.renderToReadableStream(<SsrRoot />, {
     bootstrapScriptContent,
   })
-  // for SSG
-  await htmlStream.allReady
+  if (options?.ssg) {
+    await htmlStream.allReady
+  }
 
   let responseStream: ReadableStream<Uint8Array> = htmlStream
   responseStream = responseStream.pipeThrough(injectRSCPayload(rscStream2))

--- a/packages/plugin-rsc/examples/ssg/vite.config.ts
+++ b/packages/plugin-rsc/examples/ssg/vite.config.ts
@@ -1,4 +1,3 @@
-import assert from 'node:assert'
 import fs from 'node:fs'
 import path from 'node:path'
 import { Readable } from 'node:stream'


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

This adds `handleSsg` export to server entry to replace calling `handler` twice for each route during ssg.