### PR TITLE
fix(react): respect `reactRefreshHost` option on rolldown-vite

### DIFF
--- a/packages/plugin-react/CHANGELOG.md
+++ b/packages/plugin-react/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### Fix `reactRefreshHost` option on rolldown-vite ([#716](https://github.com/vitejs/vite-plugin-react/pull/716))
+
 ### Fix `RefreshRuntime` being injected twice for class components on rolldown-vite ([#708](https://github.com/vitejs/vite-plugin-react/pull/708))
 
 ### Skip `babel-plugin-react-compiler` on non client environment ([689](https://github.com/vitejs/vite-plugin-react/pull/689))

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -369,6 +369,7 @@ export default function viteReact(opts: Options = {}): Plugin[] {
               avoidSourceMapOption,
               '@vitejs/plugin-react',
               id,
+              opts.reactRefreshHost,
             )
             return { code: newCode, map: null }
           },


### PR DESCRIPTION
### Description

See https://github.com/vitejs/vite-plugin-react/pull/708#issuecomment-3186316740