### PR TITLE
refactor(react): simplify rolldown-vite only plugins

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -340,43 +340,43 @@ export default function viteReact(opts: Options = {}): Plugin[] {
     },
   }
 
+  // for rolldown-vite
   const viteRefreshWrapper: Plugin = {
     name: 'vite:react:refresh-wrapper',
     apply: 'serve',
-    transform: isRolldownVite
-      ? {
-          filter: {
-            id: {
-              include: makeIdFiltersToMatchWithQuery(include),
-              exclude: makeIdFiltersToMatchWithQuery(exclude),
-            },
-          },
-          handler(code, id, options) {
-            const ssr = options?.ssr === true
+    transform: {
+      filter: {
+        id: {
+          include: makeIdFiltersToMatchWithQuery(include),
+          exclude: makeIdFiltersToMatchWithQuery(exclude),
+        },
+      },
+      handler(code, id, options) {
+        const ssr = options?.ssr === true
 
-            const [filepath] = id.split('?')
-            const isJSX = filepath.endsWith('x')
-            const useFastRefresh =
-              !skipFastRefresh &&
-              !ssr &&
-              (isJSX ||
-                code.includes(jsxImportDevRuntime) ||
-                code.includes(jsxImportRuntime))
-            if (!useFastRefresh) return
+        const [filepath] = id.split('?')
+        const isJSX = filepath.endsWith('x')
+        const useFastRefresh =
+          !skipFastRefresh &&
+          !ssr &&
+          (isJSX ||
+            code.includes(jsxImportDevRuntime) ||
+            code.includes(jsxImportRuntime))
+        if (!useFastRefresh) return
 
-            const { code: newCode } = addRefreshWrapper(
-              code,
-              avoidSourceMapOption,
-              '@vitejs/plugin-react',
-              id,
-              opts.reactRefreshHost,
-            )
-            return { code: newCode, map: null }
-          },
-        }
-      : undefined,
+        const { code: newCode } = addRefreshWrapper(
+          code,
+          avoidSourceMapOption,
+          '@vitejs/plugin-react',
+          id,
+          opts.reactRefreshHost,
+        )
+        return { code: newCode, map: null }
+      },
+    },
   }
 
+  // for rolldown-vite
   const viteConfigPost: Plugin = {
     name: 'vite:react:config-post',
     enforce: 'post',
@@ -449,7 +449,11 @@ export default function viteReact(opts: Options = {}): Plugin[] {
     },
   }
 
-  return [viteBabel, viteRefreshWrapper, viteConfigPost, viteReactRefresh]
+  return [
+    viteBabel,
+    ...(isRolldownVite ? [viteRefreshWrapper, viteConfigPost] : []),
+    viteReactRefresh,
+  ]
 }
 
 viteReact.preambleCode = preambleCode


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

I moved `isRolldownVite` branch to where plugins array is returned.