### PR TITLE
chore(rsc): fix `examples/basic` on stackblitz

### DIFF
--- a/packages/plugin-rsc/examples/basic/package.json
+++ b/packages/plugin-rsc/examples/basic/package.json
@@ -33,5 +33,9 @@
     "vite": "^7.1.1",
     "vite-plugin-inspect": "^11.3.2",
     "wrangler": "^4.28.1"
+  },
+  "stackblitz": {
+    "installDependencies": false,
+    "startCommand": "pnpm i && pnpm dev"
   }
 }


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

This example doesn't work with npm since it has a different behavior for a bunch of test deps using `file:./test-dep/...`

I confirmed this branch is working now https://stackblitz.com/github/vitejs/vite-plugin-react/tree/08-16-chore_rsc_fix_examples_basic_on_stackblitz/packages/plugin-rsc/examples/basic