### PR TITLE
chore(rsc): tweak React.cache example

### DIFF
--- a/packages/plugin-rsc/examples/basic/src/routes/react-cache/server.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/react-cache/server.tsx
@@ -6,14 +6,12 @@ import React from 'react'
 
 export async function TestReactCache(props: { url: URL }) {
   if (props.url.searchParams.has('test-react-cache')) {
-    await Promise.all([
-      testCacheFn('test1'),
-      testCacheFn('test2'),
-      testCacheFn('test1'),
-      testNonCacheFn('test1'),
-      testNonCacheFn('test2'),
-      testNonCacheFn('test1'),
-    ])
+    await testCacheFn('test1')
+    await testCacheFn('test2')
+    await testCacheFn('test1')
+    await testNonCacheFn('test1')
+    await testNonCacheFn('test2')
+    await testNonCacheFn('test1')
   } else {
     cacheFnCount = 0
     nonCacheFnCount = 0


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

The previous one is testing only "synchronous" cache mechanism as they are all called in side Promise.all. Changing it so the asynchronus tracking can be seen more obviously. And this actually shows `React.cache` is broken on Stackblitz since it internally uses `AsyncLocalStorage` which doesn't work properly.

https://github.com/vitejs/vite-plugin-react/blob/f5d222ac7f28da6c0f95c21616b89ca0894edf91/packages/plugin-rsc/examples/basic/src/routes/react-cache/server.tsx#L24

This should show

https://github.com/vitejs/vite-plugin-react/blob/f5d222ac7f28da6c0f95c21616b89ca0894edf91/packages/plugin-rsc/e2e/basic.test.ts#L1148

but on stackblitz, it shows

> (cacheFnCount = 3, nonCacheFnCount = 3)
