### PR TITLE
chore(rsc): use named imports

### DIFF
--- a/packages/plugin-rsc/README.md
+++ b/packages/plugin-rsc/README.md
@@ -131,7 +131,7 @@ export default defineConfig({
 - [`entry.rsc.tsx`](./examples/starter/src/framework/entry.rsc.tsx)
 
 ```tsx
-import { renderToReadableStream } from '@vitejs/plugin-rsc/rsc' // re-export of react-server-dom/server.edge and client.edge
+import { renderToReadableStream } from '@vitejs/plugin-rsc/rsc'
 
 // the plugin assumes `rsc` entry having default export of request handler
 export default async function handler(request: Request): Promise<Response> {
@@ -173,7 +173,7 @@ export default async function handler(request: Request): Promise<Response> {
 - [`entry.ssr.tsx`](./examples/starter/src/framework/entry.ssr.tsx)
 
 ```tsx
-import { createFromReadableStream } from '@vitejs/plugin-rsc/ssr' // re-export of react-server-dom/client.edge
+import { createFromReadableStream } from '@vitejs/plugin-rsc/ssr'
 import { renderToReadableStream } from 'react-dom/server.edge'
 
 export async function handleSsr(rscStream: ReadableStream) {
@@ -196,7 +196,7 @@ export async function handleSsr(rscStream: ReadableStream) {
 - [`entry.browser.tsx`](./examples/starter/src/framework/entry.browser.tsx)
 
 ```tsx
-import { createFromReadableStream } from '@vitejs/plugin-rsc/browser' // re-export of react-server-dom/client.browser
+import { createFromReadableStream } from '@vitejs/plugin-rsc/browser'
 import { hydrateRoot } from 'react-dom/client'
 
 async function main() {

--- a/packages/plugin-rsc/examples/basic/src/framework/entry.browser.tsx
+++ b/packages/plugin-rsc/examples/basic/src/framework/entry.browser.tsx
@@ -1,6 +1,12 @@
-import * as ReactClient from '@vitejs/plugin-rsc/browser'
+import {
+  createFromReadableStream,
+  createFromFetch,
+  setServerCallback,
+  createTemporaryReferenceSet,
+  encodeReply,
+} from '@vitejs/plugin-rsc/browser'
 import React from 'react'
-import * as ReactDOMClient from 'react-dom/client'
+import { hydrateRoot } from 'react-dom/client'
 import { rscStream } from 'rsc-html-stream/client'
 import type { RscPayload } from './entry.rsc'
 
@@ -10,7 +16,7 @@ async function main() {
   let setPayload: (v: RscPayload) => void
 
   // deserialize RSC stream back to React VDOM for CSR
-  const initialPayload = await ReactClient.createFromReadableStream<RscPayload>(
+  const initialPayload = await createFromReadableStream<RscPayload>(
     // initial RSC stream is injected in SSR stream as <script>...FLIGHT_DATA...</script>
     rscStream,
   )
@@ -33,7 +39,7 @@ async function main() {
 
   // re-fetch RSC and trigger re-rendering
   async function fetchRscPayload() {
-    const payload = await ReactClient.createFromFetch<RscPayload>(
+    const payload = await createFromFetch<RscPayload>(
       fetch(window.location.href),
     )
     setPayload(payload)
@@ -41,13 +47,13 @@ async function main() {
 
   // register a handler which will be internally called by React
   // on server function request after hydration.
-  ReactClient.setServerCallback(async (id, args) => {
+  setServerCallback(async (id, args) => {
     const url = new URL(window.location.href)
-    const temporaryReferences = ReactClient.createTemporaryReferenceSet()
-    const payload = await ReactClient.createFromFetch<RscPayload>(
+    const temporaryReferences = createTemporaryReferenceSet()
+    const payload = await createFromFetch<RscPayload>(
       fetch(url, {
         method: 'POST',
-        body: await ReactClient.encodeReply(args, { temporaryReferences }),
+        body: await encodeReply(args, { temporaryReferences }),
         headers: {
           'x-rsc-action': id,
         },
@@ -64,7 +70,7 @@ async function main() {
       <BrowserRoot />
     </React.StrictMode>
   )
-  ReactDOMClient.hydrateRoot(document, browserRoot, {
+  hydrateRoot(document, browserRoot, {
     formState: initialPayload.formState,
   })
 

--- a/packages/plugin-rsc/examples/basic/src/framework/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/basic/src/framework/entry.ssr.tsx
@@ -1,7 +1,7 @@
-import * as ReactClient from '@vitejs/plugin-rsc/ssr' // RSC API
+import { createFromReadableStream } from '@vitejs/plugin-rsc/ssr' // RSC API
 import React from 'react'
 import type { ReactFormState } from 'react-dom/client'
-import * as ReactDOMServer from 'react-dom/server.edge'
+import { renderToReadableStream } from 'react-dom/server.edge'
 import { injectRSCPayload } from 'rsc-html-stream/server'
 import type { RscPayload } from './entry.rsc'
 
@@ -23,7 +23,7 @@ export async function renderHTML(
   function SsrRoot() {
     // deserialization needs to be kicked off inside ReactDOMServer context
     // for ReactDomServer preinit/preloading to work
-    payload ??= ReactClient.createFromReadableStream<RscPayload>(rscStream1)
+    payload ??= createFromReadableStream<RscPayload>(rscStream1)
     return <FixSsrThenable>{React.use(payload).root}</FixSsrThenable>
   }
 
@@ -34,7 +34,7 @@ export async function renderHTML(
   // render html (traditional SSR)
   const bootstrapScriptContent =
     await import.meta.viteRsc.loadBootstrapScriptContent('index')
-  const htmlStream = await ReactDOMServer.renderToReadableStream(<SsrRoot />, {
+  const htmlStream = await renderToReadableStream(<SsrRoot />, {
     bootstrapScriptContent: options?.debugNojs
       ? undefined
       : bootstrapScriptContent,

--- a/packages/plugin-rsc/examples/basic/src/framework/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/basic/src/framework/entry.ssr.tsx
@@ -1,4 +1,4 @@
-import { createFromReadableStream } from '@vitejs/plugin-rsc/ssr' // RSC API
+import { createFromReadableStream } from '@vitejs/plugin-rsc/ssr'
 import React from 'react'
 import type { ReactFormState } from 'react-dom/client'
 import { renderToReadableStream } from 'react-dom/server.edge'

--- a/packages/plugin-rsc/examples/no-ssr/src/framework/entry.rsc.tsx
+++ b/packages/plugin-rsc/examples/no-ssr/src/framework/entry.rsc.tsx
@@ -1,4 +1,11 @@
-import * as ReactServer from '@vitejs/plugin-rsc/rsc'
+import {
+  renderToReadableStream,
+  createTemporaryReferenceSet,
+  decodeReply,
+  loadServerAction,
+  decodeAction,
+  decodeFormState,
+} from '@vitejs/plugin-rsc/rsc'
 import type { ReactFormState } from 'react-dom/client'
 import { Root } from '../root.tsx'
 
@@ -20,24 +27,21 @@ export default async function handler(request: Request): Promise<Response> {
       const body = contentType?.startsWith('multipart/form-data')
         ? await request.formData()
         : await request.text()
-      temporaryReferences = ReactServer.createTemporaryReferenceSet()
-      const args = await ReactServer.decodeReply(body, { temporaryReferences })
-      const action = await ReactServer.loadServerAction(actionId)
+      temporaryReferences = createTemporaryReferenceSet()
+      const args = await decodeReply(body, { temporaryReferences })
+      const action = await loadServerAction(actionId)
       returnValue = await action.apply(null, args)
     } else {
       const formData = await request.formData()
-      const decodedAction = await ReactServer.decodeAction(formData)
+      const decodedAction = await decodeAction(formData)
       const result = await decodedAction()
-      formState = await ReactServer.decodeFormState(result, formData)
+      formState = await decodeFormState(result, formData)
     }
   }
 
   const rscPayload: RscPayload = { root: <Root />, formState, returnValue }
   const rscOptions = { temporaryReferences }
-  const rscStream = ReactServer.renderToReadableStream<RscPayload>(
-    rscPayload,
-    rscOptions,
-  )
+  const rscStream = renderToReadableStream<RscPayload>(rscPayload, rscOptions)
 
   return new Response(rscStream, {
     headers: {

--- a/packages/plugin-rsc/examples/ssg/src/framework/entry.browser.tsx
+++ b/packages/plugin-rsc/examples/ssg/src/framework/entry.browser.tsx
@@ -1,6 +1,9 @@
-import * as ReactClient from '@vitejs/plugin-rsc/browser'
+import {
+  createFromFetch,
+  createFromReadableStream,
+} from '@vitejs/plugin-rsc/browser'
 import React from 'react'
-import ReactDomClient from 'react-dom/client'
+import { hydrateRoot } from 'react-dom/client'
 import { rscStream } from 'rsc-html-stream/client'
 import { RSC_POSTFIX, type RscPayload } from './shared'
 
@@ -8,12 +11,11 @@ async function hydrate(): Promise<void> {
   async function onNavigation() {
     const url = new URL(window.location.href)
     url.pathname = url.pathname + RSC_POSTFIX
-    const payload = await ReactClient.createFromFetch<RscPayload>(fetch(url))
+    const payload = await createFromFetch<RscPayload>(fetch(url))
     setPayload(payload)
   }
 
-  const initialPayload =
-    await ReactClient.createFromReadableStream<RscPayload>(rscStream)
+  const initialPayload = await createFromReadableStream<RscPayload>(rscStream)
 
   let setPayload: (v: RscPayload) => void
 
@@ -37,7 +39,7 @@ async function hydrate(): Promise<void> {
     </React.StrictMode>
   )
 
-  ReactDomClient.hydrateRoot(document, browserRoot)
+  hydrateRoot(document, browserRoot)
 
   if (import.meta.hot) {
     import.meta.hot.on('rsc:update', () => {

--- a/packages/plugin-rsc/examples/ssg/src/framework/entry.rsc.tsx
+++ b/packages/plugin-rsc/examples/ssg/src/framework/entry.rsc.tsx
@@ -1,4 +1,4 @@
-import * as ReactServer from '@vitejs/plugin-rsc/rsc'
+import { renderToReadableStream } from '@vitejs/plugin-rsc/rsc'
 import { Root, getStaticPaths } from '../root'
 import { RSC_POSTFIX, type RscPayload } from './shared'
 
@@ -13,7 +13,7 @@ export default async function handler(request: Request): Promise<Response> {
   }
 
   const rscPayload: RscPayload = { root: <Root url={url} /> }
-  const rscStream = ReactServer.renderToReadableStream<RscPayload>(rscPayload)
+  const rscStream = renderToReadableStream<RscPayload>(rscPayload)
 
   if (isRscRequest) {
     return new Response(rscStream, {
@@ -44,7 +44,7 @@ export async function handleSsg(request: Request): Promise<{
 }> {
   const url = new URL(request.url)
   const rscPayload: RscPayload = { root: <Root url={url} /> }
-  const rscStream = ReactServer.renderToReadableStream<RscPayload>(rscPayload)
+  const rscStream = renderToReadableStream<RscPayload>(rscPayload)
   const [rscStream1, rscStream2] = rscStream.tee()
 
   const ssr = await import.meta.viteRsc.loadModule<

--- a/packages/plugin-rsc/examples/ssg/src/framework/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/ssg/src/framework/entry.ssr.tsx
@@ -1,6 +1,6 @@
-import * as ReactClient from '@vitejs/plugin-rsc/ssr'
+import { createFromReadableStream } from '@vitejs/plugin-rsc/ssr'
 import React from 'react'
-import * as ReactDomServer from 'react-dom/server.edge'
+import { renderToReadableStream } from 'react-dom/server.edge'
 import { injectRSCPayload } from 'rsc-html-stream/server'
 import type { RscPayload } from './shared'
 
@@ -14,7 +14,7 @@ export async function renderHtml(
 
   let payload: Promise<RscPayload>
   function SsrRoot() {
-    payload ??= ReactClient.createFromReadableStream<RscPayload>(rscStream1)
+    payload ??= createFromReadableStream<RscPayload>(rscStream1)
     const root = React.use(payload).root
     return root
   }
@@ -22,7 +22,7 @@ export async function renderHtml(
   const bootstrapScriptContent =
     await import.meta.viteRsc.loadBootstrapScriptContent('index')
 
-  const htmlStream = await ReactDomServer.renderToReadableStream(<SsrRoot />, {
+  const htmlStream = await renderToReadableStream(<SsrRoot />, {
     bootstrapScriptContent,
   })
   if (options?.ssg) {

--- a/packages/plugin-rsc/examples/starter-cf-single/src/framework/entry.browser.tsx
+++ b/packages/plugin-rsc/examples/starter-cf-single/src/framework/entry.browser.tsx
@@ -1,6 +1,12 @@
-import * as ReactClient from '@vitejs/plugin-rsc/browser'
+import {
+  createFromReadableStream,
+  createFromFetch,
+  setServerCallback,
+  createTemporaryReferenceSet,
+  encodeReply,
+} from '@vitejs/plugin-rsc/browser'
 import React from 'react'
-import * as ReactDOMClient from 'react-dom/client'
+import { hydrateRoot } from 'react-dom/client'
 import { rscStream } from 'rsc-html-stream/client'
 import type { RscPayload } from './entry.rsc'
 
@@ -10,7 +16,7 @@ async function main() {
   let setPayload: (v: RscPayload) => void
 
   // deserialize RSC stream back to React VDOM for CSR
-  const initialPayload = await ReactClient.createFromReadableStream<RscPayload>(
+  const initialPayload = await createFromReadableStream<RscPayload>(
     // initial RSC stream is injected in SSR stream as <script>...FLIGHT_DATA...</script>
     rscStream,
   )
@@ -33,7 +39,7 @@ async function main() {
 
   // re-fetch RSC and trigger re-rendering
   async function fetchRscPayload() {
-    const payload = await ReactClient.createFromFetch<RscPayload>(
+    const payload = await createFromFetch<RscPayload>(
       fetch(window.location.href),
     )
     setPayload(payload)
@@ -41,13 +47,13 @@ async function main() {
 
   // register a handler which will be internally called by React
   // on server function request after hydration.
-  ReactClient.setServerCallback(async (id, args) => {
+  setServerCallback(async (id, args) => {
     const url = new URL(window.location.href)
-    const temporaryReferences = ReactClient.createTemporaryReferenceSet()
-    const payload = await ReactClient.createFromFetch<RscPayload>(
+    const temporaryReferences = createTemporaryReferenceSet()
+    const payload = await createFromFetch<RscPayload>(
       fetch(url, {
         method: 'POST',
-        body: await ReactClient.encodeReply(args, { temporaryReferences }),
+        body: await encodeReply(args, { temporaryReferences }),
         headers: {
           'x-rsc-action': id,
         },
@@ -64,7 +70,7 @@ async function main() {
       <BrowserRoot />
     </React.StrictMode>
   )
-  ReactDOMClient.hydrateRoot(document, browserRoot, {
+  hydrateRoot(document, browserRoot, {
     formState: initialPayload.formState,
   })
 

--- a/packages/plugin-rsc/examples/starter-cf-single/src/framework/entry.rsc.tsx
+++ b/packages/plugin-rsc/examples/starter-cf-single/src/framework/entry.rsc.tsx
@@ -1,4 +1,11 @@
-import * as ReactServer from '@vitejs/plugin-rsc/rsc'
+import {
+  renderToReadableStream,
+  createTemporaryReferenceSet,
+  decodeReply,
+  loadServerAction,
+  decodeAction,
+  decodeFormState,
+} from '@vitejs/plugin-rsc/rsc'
 import type { ReactFormState } from 'react-dom/client'
 import { Root } from '../root.tsx'
 
@@ -22,18 +29,18 @@ async function handler(request: Request): Promise<Response> {
       const body = contentType?.startsWith('multipart/form-data')
         ? await request.formData()
         : await request.text()
-      temporaryReferences = ReactServer.createTemporaryReferenceSet()
-      const args = await ReactServer.decodeReply(body, { temporaryReferences })
-      const action = await ReactServer.loadServerAction(actionId)
+      temporaryReferences = createTemporaryReferenceSet()
+      const args = await decodeReply(body, { temporaryReferences })
+      const action = await loadServerAction(actionId)
       returnValue = await action.apply(null, args)
     } else {
       // otherwise server function is called via `<form action={...}>`
       // before hydration (e.g. when javascript is disabled).
       // aka progressive enhancement.
       const formData = await request.formData()
-      const decodedAction = await ReactServer.decodeAction(formData)
+      const decodedAction = await decodeAction(formData)
       const result = await decodedAction()
-      formState = await ReactServer.decodeFormState(result, formData)
+      formState = await decodeFormState(result, formData)
     }
   }
 
@@ -43,10 +50,7 @@ async function handler(request: Request): Promise<Response> {
   // to achieve single round trip to mutate and fetch from server.
   const rscPayload: RscPayload = { root: <Root />, formState, returnValue }
   const rscOptions = { temporaryReferences }
-  const rscStream = ReactServer.renderToReadableStream<RscPayload>(
-    rscPayload,
-    rscOptions,
-  )
+  const rscStream = renderToReadableStream<RscPayload>(rscPayload, rscOptions)
 
   // respond RSC stream without HTML rendering based on framework's convention.
   // here we use request header `content-type`.

--- a/packages/plugin-rsc/examples/starter-cf-single/src/framework/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/starter-cf-single/src/framework/entry.ssr.tsx
@@ -1,7 +1,7 @@
-import * as ReactClient from '@vitejs/plugin-rsc/ssr' // RSC API
+import { createFromReadableStream } from '@vitejs/plugin-rsc/ssr' // RSC API
 import React from 'react'
 import type { ReactFormState } from 'react-dom/client'
-import * as ReactDOMServer from 'react-dom/server.edge'
+import { renderToReadableStream } from 'react-dom/server.edge'
 import { injectRSCPayload } from 'rsc-html-stream/server'
 import type { RscPayload } from './entry.rsc'
 
@@ -25,14 +25,14 @@ export async function renderHTML(
   function SsrRoot() {
     // deserialization needs to be kicked off inside ReactDOMServer context
     // for ReactDomServer preinit/preloading to work
-    payload ??= ReactClient.createFromReadableStream<RscPayload>(rscStream1)
+    payload ??= createFromReadableStream<RscPayload>(rscStream1)
     return React.use(payload).root
   }
 
   // render html (traditional SSR)
   const bootstrapScriptContent =
     await import.meta.viteRsc.loadBootstrapScriptContent('index')
-  const htmlStream = await ReactDOMServer.renderToReadableStream(<SsrRoot />, {
+  const htmlStream = await renderToReadableStream(<SsrRoot />, {
     bootstrapScriptContent: options?.debugNojs
       ? undefined
       : bootstrapScriptContent,

--- a/packages/plugin-rsc/examples/starter-cf-single/src/framework/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/starter-cf-single/src/framework/entry.ssr.tsx
@@ -1,4 +1,4 @@
-import { createFromReadableStream } from '@vitejs/plugin-rsc/ssr' // RSC API
+import { createFromReadableStream } from '@vitejs/plugin-rsc/ssr'
 import React from 'react'
 import type { ReactFormState } from 'react-dom/client'
 import { renderToReadableStream } from 'react-dom/server.edge'

--- a/packages/plugin-rsc/examples/starter/src/framework/entry.browser.tsx
+++ b/packages/plugin-rsc/examples/starter/src/framework/entry.browser.tsx
@@ -1,6 +1,12 @@
-import * as ReactClient from '@vitejs/plugin-rsc/browser'
+import {
+  createFromReadableStream,
+  createFromFetch,
+  setServerCallback,
+  createTemporaryReferenceSet,
+  encodeReply,
+} from '@vitejs/plugin-rsc/browser'
 import React from 'react'
-import * as ReactDOMClient from 'react-dom/client'
+import { hydrateRoot } from 'react-dom/client'
 import { rscStream } from 'rsc-html-stream/client'
 import type { RscPayload } from './entry.rsc'
 
@@ -10,7 +16,7 @@ async function main() {
   let setPayload: (v: RscPayload) => void
 
   // deserialize RSC stream back to React VDOM for CSR
-  const initialPayload = await ReactClient.createFromReadableStream<RscPayload>(
+  const initialPayload = await createFromReadableStream<RscPayload>(
     // initial RSC stream is injected in SSR stream as <script>...FLIGHT_DATA...</script>
     rscStream,
   )
@@ -33,7 +39,7 @@ async function main() {
 
   // re-fetch RSC and trigger re-rendering
   async function fetchRscPayload() {
-    const payload = await ReactClient.createFromFetch<RscPayload>(
+    const payload = await createFromFetch<RscPayload>(
       fetch(window.location.href),
     )
     setPayload(payload)
@@ -41,13 +47,13 @@ async function main() {
 
   // register a handler which will be internally called by React
   // on server function request after hydration.
-  ReactClient.setServerCallback(async (id, args) => {
+  setServerCallback(async (id, args) => {
     const url = new URL(window.location.href)
-    const temporaryReferences = ReactClient.createTemporaryReferenceSet()
-    const payload = await ReactClient.createFromFetch<RscPayload>(
+    const temporaryReferences = createTemporaryReferenceSet()
+    const payload = await createFromFetch<RscPayload>(
       fetch(url, {
         method: 'POST',
-        body: await ReactClient.encodeReply(args, { temporaryReferences }),
+        body: await encodeReply(args, { temporaryReferences }),
         headers: {
           'x-rsc-action': id,
         },
@@ -64,7 +70,7 @@ async function main() {
       <BrowserRoot />
     </React.StrictMode>
   )
-  ReactDOMClient.hydrateRoot(document, browserRoot, {
+  hydrateRoot(document, browserRoot, {
     formState: initialPayload.formState,
   })
 

--- a/packages/plugin-rsc/examples/starter/src/framework/entry.rsc.tsx
+++ b/packages/plugin-rsc/examples/starter/src/framework/entry.rsc.tsx
@@ -1,4 +1,11 @@
-import * as ReactServer from '@vitejs/plugin-rsc/rsc'
+import {
+  renderToReadableStream,
+  createTemporaryReferenceSet,
+  decodeReply,
+  loadServerAction,
+  decodeAction,
+  decodeFormState,
+} from '@vitejs/plugin-rsc/rsc'
 import type { ReactFormState } from 'react-dom/client'
 import { Root } from '../root.tsx'
 
@@ -32,18 +39,18 @@ export default async function handler(request: Request): Promise<Response> {
       const body = contentType?.startsWith('multipart/form-data')
         ? await request.formData()
         : await request.text()
-      temporaryReferences = ReactServer.createTemporaryReferenceSet()
-      const args = await ReactServer.decodeReply(body, { temporaryReferences })
-      const action = await ReactServer.loadServerAction(actionId)
+      temporaryReferences = createTemporaryReferenceSet()
+      const args = await decodeReply(body, { temporaryReferences })
+      const action = await loadServerAction(actionId)
       returnValue = await action.apply(null, args)
     } else {
       // otherwise server function is called via `<form action={...}>`
       // before hydration (e.g. when javascript is disabled).
       // aka progressive enhancement.
       const formData = await request.formData()
-      const decodedAction = await ReactServer.decodeAction(formData)
+      const decodedAction = await decodeAction(formData)
       const result = await decodedAction()
-      formState = await ReactServer.decodeFormState(result, formData)
+      formState = await decodeFormState(result, formData)
     }
   }
 
@@ -53,10 +60,7 @@ export default async function handler(request: Request): Promise<Response> {
   // to achieve single round trip to mutate and fetch from server.
   const rscPayload: RscPayload = { root: <Root />, formState, returnValue }
   const rscOptions = { temporaryReferences }
-  const rscStream = ReactServer.renderToReadableStream<RscPayload>(
-    rscPayload,
-    rscOptions,
-  )
+  const rscStream = renderToReadableStream<RscPayload>(rscPayload, rscOptions)
 
   // respond RSC stream without HTML rendering based on framework's convention.
   // here we use request header `content-type`.

--- a/packages/plugin-rsc/examples/starter/src/framework/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/starter/src/framework/entry.ssr.tsx
@@ -1,4 +1,4 @@
-import { createFromReadableStream } from '@vitejs/plugin-rsc/ssr' // RSC API
+import { createFromReadableStream } from '@vitejs/plugin-rsc/ssr'
 import React from 'react'
 import type { ReactFormState } from 'react-dom/client'
 import { renderToReadableStream } from 'react-dom/server.edge'

--- a/packages/plugin-rsc/examples/starter/src/framework/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/starter/src/framework/entry.ssr.tsx
@@ -1,7 +1,7 @@
-import * as ReactClient from '@vitejs/plugin-rsc/ssr' // RSC API
+import { createFromReadableStream } from '@vitejs/plugin-rsc/ssr' // RSC API
 import React from 'react'
 import type { ReactFormState } from 'react-dom/client'
-import * as ReactDOMServer from 'react-dom/server.edge'
+import { renderToReadableStream } from 'react-dom/server.edge'
 import { injectRSCPayload } from 'rsc-html-stream/server'
 import type { RscPayload } from './entry.rsc'
 
@@ -23,7 +23,7 @@ export async function renderHTML(
   function SsrRoot() {
     // deserialization needs to be kicked off inside ReactDOMServer context
     // for ReactDomServer preinit/preloading to work
-    payload ??= ReactClient.createFromReadableStream<RscPayload>(rscStream1)
+    payload ??= createFromReadableStream<RscPayload>(rscStream1)
     return <FixSsrThenable>{React.use(payload).root}</FixSsrThenable>
   }
 
@@ -39,7 +39,7 @@ export async function renderHTML(
   // render html (traditional SSR)
   const bootstrapScriptContent =
     await import.meta.viteRsc.loadBootstrapScriptContent('index')
-  const htmlStream = await ReactDOMServer.renderToReadableStream(<SsrRoot />, {
+  const htmlStream = await renderToReadableStream(<SsrRoot />, {
     bootstrapScriptContent: options?.debugNojs
       ? undefined
       : bootstrapScriptContent,


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

We should avoid saying `import * as ReactServer from "@vitejs/plugin-rsc/rsc"` since `@vitejs/plugin-rsc/rsc` re-exports API both from `react-server-dom/server.edge` and `react-server-dom/client.edge`.