### PR TITLE
chore: remove vite-plugin-inspect dependency from examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.39.0",
     "vite": "^7.1.1",
+    "vite-plugin-inspect": "^11.3.2",
     "vitest": "^3.2.4"
   },
   "simple-git-hooks": {

--- a/packages/plugin-rsc/examples/basic/package.json
+++ b/packages/plugin-rsc/examples/basic/package.json
@@ -31,7 +31,6 @@
     "rsc-html-stream": "^0.0.7",
     "tailwindcss": "^4.1.11",
     "vite": "^7.1.1",
-    "vite-plugin-inspect": "^11.3.2",
     "wrangler": "^4.28.1"
   },
   "stackblitz": {

--- a/packages/plugin-rsc/examples/basic/vite.config.ts
+++ b/packages/plugin-rsc/examples/basic/vite.config.ts
@@ -3,12 +3,13 @@ import rsc, { transformHoistInlineDirective } from '@vitejs/plugin-rsc'
 import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
 import { type Plugin, defineConfig, normalizePath, parseAstAsync } from 'vite'
-import inspect from 'vite-plugin-inspect'
+// import inspect from 'vite-plugin-inspect'
 import path from 'node:path'
 
 export default defineConfig({
   clearScreen: false,
   plugins: [
+    // inspect(),
     tailwindcss(),
     react(),
     vitePluginUseCache(),
@@ -23,8 +24,6 @@ export default defineConfig({
       copyServerAssetsToClient: (fileName) =>
         fileName !== '__server_secret.txt',
     }),
-    // avoid ecosystem CI fail due to vite-plugin-inspect compatibility
-    !process.env.ECOSYSTEM_CI && inspect(),
     {
       name: 'test-client-reference-tree-shaking',
       enforce: 'post',

--- a/packages/plugin-rsc/examples/react-router/cf/vite.config.ts
+++ b/packages/plugin-rsc/examples/react-router/cf/vite.config.ts
@@ -3,7 +3,7 @@ import rsc from '@vitejs/plugin-rsc'
 import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
-import inspect from 'vite-plugin-inspect'
+// import inspect from 'vite-plugin-inspect'
 import { reactRouter } from '../react-router-vite/plugin'
 
 export default defineConfig({
@@ -12,6 +12,7 @@ export default defineConfig({
     minify: false,
   },
   plugins: [
+    // inspect(),
     tailwindcss(),
     react(),
     reactRouter(),
@@ -21,7 +22,6 @@ export default defineConfig({
       },
       serverHandler: false,
     }),
-    inspect(),
     cloudflare({
       configPath: './cf/wrangler.ssr.jsonc',
       viteEnvironment: {

--- a/packages/plugin-rsc/examples/react-router/package.json
+++ b/packages/plugin-rsc/examples/react-router/package.json
@@ -28,7 +28,6 @@
     "@vitejs/plugin-rsc": "latest",
     "tailwindcss": "^4.1.11",
     "vite": "^7.1.1",
-    "vite-plugin-inspect": "^11.3.2",
     "wrangler": "^4.28.1"
   }
 }

--- a/packages/plugin-rsc/examples/react-router/vite.config.ts
+++ b/packages/plugin-rsc/examples/react-router/vite.config.ts
@@ -2,7 +2,7 @@ import rsc from '@vitejs/plugin-rsc'
 import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
-import inspect from 'vite-plugin-inspect'
+// import inspect from 'vite-plugin-inspect'
 import { reactRouter } from './react-router-vite/plugin'
 
 export default defineConfig({
@@ -11,6 +11,7 @@ export default defineConfig({
     minify: false,
   },
   plugins: [
+    // inspect(),
     tailwindcss(),
     react(),
     reactRouter(),
@@ -21,7 +22,6 @@ export default defineConfig({
         rsc: './react-router-vite/entry.rsc.single.tsx',
       },
     }),
-    inspect(),
   ],
   optimizeDeps: {
     include: ['react-router', 'react-router/internal/react-server-client'],

--- a/packages/plugin-rsc/examples/ssg/package.json
+++ b/packages/plugin-rsc/examples/ssg/package.json
@@ -18,7 +18,6 @@
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "latest",
-    "@vitejs/plugin-rsc": "latest",
-    "vite-plugin-inspect": "^11.3.2"
+    "@vitejs/plugin-rsc": "latest"
   }
 }

--- a/packages/plugin-rsc/examples/ssg/vite.config.ts
+++ b/packages/plugin-rsc/examples/ssg/vite.config.ts
@@ -6,11 +6,12 @@ import rsc from '@vitejs/plugin-rsc'
 import mdx from '@mdx-js/rollup'
 import react from '@vitejs/plugin-react'
 import { type Plugin, type ResolvedConfig, defineConfig } from 'vite'
-import inspect from 'vite-plugin-inspect'
+// import inspect from 'vite-plugin-inspect'
 import { RSC_POSTFIX } from './src/framework/shared'
 
 export default defineConfig((env) => ({
   plugins: [
+    // inspect(),
     mdx(),
     react(),
     rsc({
@@ -23,7 +24,6 @@ export default defineConfig((env) => ({
       useBuildAppHook: true,
     }),
     rscSsgPlugin(),
-    inspect(),
   ],
 }))
 

--- a/packages/plugin-rsc/examples/starter/package.json
+++ b/packages/plugin-rsc/examples/starter/package.json
@@ -19,7 +19,6 @@
     "@vitejs/plugin-react": "latest",
     "@vitejs/plugin-rsc": "latest",
     "rsc-html-stream": "^0.0.7",
-    "vite": "^7.1.1",
-    "vite-plugin-inspect": "^11.3.2"
+    "vite": "^7.1.1"
   }
 }

--- a/packages/plugin-rsc/package.json
+++ b/packages/plugin-rsc/package.json
@@ -60,8 +60,7 @@
     "react-server-dom-webpack": "^19.1.1",
     "rsc-html-stream": "^0.0.7",
     "tinyexec": "^1.0.1",
-    "tsdown": "^0.14.0",
-    "vite-plugin-inspect": "^11.3.2"
+    "tsdown": "^0.14.0"
   },
   "peerDependencies": {
     "react": "*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       vite:
         specifier: ^7.1.1
         version: 7.1.1(@types/node@22.17.1)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1)
+      vite-plugin-inspect:
+        specifier: ^11.3.2
+        version: 11.3.2(vite@7.1.1(@types/node@22.17.1)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.1)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1)
@@ -502,9 +505,6 @@ importers:
       tsdown:
         specifier: ^0.14.0
         version: 0.14.0(publint@0.3.12)(typescript@5.9.2)
-      vite-plugin-inspect:
-        specifier: ^11.3.2
-        version: 11.3.2(vite@7.1.1(@types/node@22.17.1)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))
 
   packages/plugin-rsc/examples/basic:
     dependencies:
@@ -560,9 +560,6 @@ importers:
       vite:
         specifier: ^7.1.1
         version: 7.1.1(@types/node@22.17.1)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1)
-      vite-plugin-inspect:
-        specifier: ^11.3.2
-        version: 11.3.2(vite@7.1.1(@types/node@22.17.1)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))
       wrangler:
         specifier: ^4.28.1
         version: 4.28.1
@@ -671,9 +668,6 @@ importers:
       vite:
         specifier: ^7.1.1
         version: 7.1.1(@types/node@22.17.1)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1)
-      vite-plugin-inspect:
-        specifier: ^11.3.2
-        version: 11.3.2(vite@7.1.1(@types/node@22.17.1)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))
       wrangler:
         specifier: ^4.28.1
         version: 4.28.1
@@ -702,9 +696,6 @@ importers:
       '@vitejs/plugin-rsc':
         specifier: latest
         version: link:../..
-      vite-plugin-inspect:
-        specifier: ^11.3.2
-        version: 11.3.2(vite@7.1.1(@types/node@22.17.1)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))
 
   packages/plugin-rsc/examples/starter:
     dependencies:
@@ -733,9 +724,6 @@ importers:
       vite:
         specifier: ^7.1.1
         version: 7.1.1(@types/node@22.17.1)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1)
-      vite-plugin-inspect:
-        specifier: ^11.3.2
-        version: 11.3.2(vite@7.1.1(@types/node@22.17.1)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.7.1))
 
   packages/plugin-rsc/examples/starter-cf-single:
     dependencies:


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

Removing the dependency from examples and move it to monorepo root. Still keeping as commented out code, so they can be easily enabled for debugging.
