### PR TITLE
fix(rsc): include non-entry optimized modules for `optimizeDeps.exclude` suggestion

### DIFF
--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1227,6 +1227,7 @@ function extraOptimizerMetadataPlugin({
   return [
     {
       name: 'rsc:use-client:optimizer-metadata',
+      apply: 'serve',
       config() {
         return {
           environments: {
@@ -1248,22 +1249,20 @@ function extraOptimizerMetadataPlugin({
         }
       },
       configResolved(config) {
-        if (config.command === 'serve') {
-          // https://github.com/vitejs/vite/blob/84079a84ad94de4c1ef4f1bdb2ab448ff2c01196/packages/vite/src/node/optimizer/index.ts#L941
-          const metadataFile = path.join(
-            config.cacheDir,
-            'deps',
-            EXTRA_OPTIMIZER_METADATA_FILE,
-          )
-          if (fs.existsSync(metadataFile)) {
-            try {
-              const optimizerMetadata = JSON.parse(
-                fs.readFileSync(metadataFile, 'utf-8'),
-              )
-              setMetadata(optimizerMetadata)
-            } catch (e) {
-              this.warn(`failed to load '${metadataFile}'`)
-            }
+        // https://github.com/vitejs/vite/blob/84079a84ad94de4c1ef4f1bdb2ab448ff2c01196/packages/vite/src/node/optimizer/index.ts#L941
+        const metadataFile = path.join(
+          config.cacheDir,
+          'deps',
+          EXTRA_OPTIMIZER_METADATA_FILE,
+        )
+        if (fs.existsSync(metadataFile)) {
+          try {
+            const optimizerMetadata = JSON.parse(
+              fs.readFileSync(metadataFile, 'utf-8'),
+            )
+            setMetadata(optimizerMetadata)
+          } catch (e) {
+            this.warn(`failed to load '${metadataFile}'`)
           }
         }
       },

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1192,11 +1192,11 @@ function customOptimizerMetadataPlugin({
           if (!result.metafile?.inputs || !build.initialOptions.outdir) return
 
           const ids = Object.keys(result.metafile.inputs)
-          const optimizerMetadata: CustomOptimizerMetadata = { ids }
-          setMetadata(optimizerMetadata)
+          const metadata: CustomOptimizerMetadata = { ids }
+          setMetadata(metadata)
           fs.writeFileSync(
             path.join(build.initialOptions.outdir, MEATADATA_FILE),
-            JSON.stringify(optimizerMetadata, null, 2),
+            JSON.stringify(metadata, null, 2),
           )
         })
       },
@@ -1211,11 +1211,11 @@ function customOptimizerMetadataPlugin({
         const ids = [...this.getModuleIds()].map((id) =>
           path.relative(process.cwd(), id),
         )
-        const optimizerMetadata: CustomOptimizerMetadata = { ids }
-        setMetadata(optimizerMetadata)
+        const metadata: CustomOptimizerMetadata = { ids }
+        setMetadata(metadata)
         fs.writeFileSync(
           path.join(options.dir!, MEATADATA_FILE),
-          JSON.stringify(optimizerMetadata, null, 2),
+          JSON.stringify(metadata, null, 2),
         )
       },
     }
@@ -1250,8 +1250,8 @@ function customOptimizerMetadataPlugin({
         const file = path.join(config.cacheDir, 'deps', MEATADATA_FILE)
         if (fs.existsSync(file)) {
           try {
-            const optimizerMetadata = JSON.parse(fs.readFileSync(file, 'utf-8'))
-            setMetadata(optimizerMetadata)
+            const metadata = JSON.parse(fs.readFileSync(file, 'utf-8'))
+            setMetadata(metadata)
           } catch (e) {
             this.warn(`failed to load '${file}'`)
           }

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -964,7 +964,7 @@ function vitePluginUseClient(
   ) {
     // metafile data is relative to cwd
     // https://github.com/vitejs/vite/blob/dd96c2cd831ecba3874458b318ad4f0a7f173736/packages/vite/src/node/optimizer/index.ts#L644
-    id = path.relative(process.cwd(), id)
+    id = normalizePath(path.relative(process.cwd(), id))
     if (optimizerMetadata?.optimizedFiles.includes(id)) {
       ctx.warn(
         `client component dependency is inconsistently optimized. ` +

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -976,6 +976,9 @@ function vitePluginUseClient(
 
   const debug = createDebug('vite-rsc:use-client')
 
+  const optimizerPluginEsbuild = {}
+  const optimizerPluginRolldown = {}
+
   return [
     {
       name: 'rsc:use-client',

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -962,7 +962,7 @@ function vitePluginUseClient(
     ctx: Rollup.TransformPluginContext,
     id: string,
   ) {
-    // metafile data is relative to cwd
+    // path in metafile is relative to cwd
     // https://github.com/vitejs/vite/blob/dd96c2cd831ecba3874458b318ad4f0a7f173736/packages/vite/src/node/optimizer/index.ts#L644
     id = normalizePath(path.relative(process.cwd(), id))
     if (optimizerMetadata?.optimizedFiles.includes(id)) {

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -962,6 +962,8 @@ function vitePluginUseClient(
     ctx: Rollup.TransformPluginContext,
     id: string,
   ) {
+    // metafile data is relative to cwd
+    // https://github.com/vitejs/vite/blob/dd96c2cd831ecba3874458b318ad4f0a7f173736/packages/vite/src/node/optimizer/index.ts#L644
     id = path.relative(process.cwd(), id)
     if (optimizerMetadata?.optimizedFiles.includes(id)) {
       ctx.warn(

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -979,6 +979,42 @@ function vitePluginUseClient(
   return [
     {
       name: 'rsc:use-client',
+      config() {
+        return {
+          environments: {
+            client: {
+              optimizeDeps: {
+                // TODO: rolldown
+                esbuildOptions: {
+                  plugins: [
+                    {
+                      name: 'custom-metafile',
+                      setup(build) {
+                        build.onEnd((result) => {
+                          // skip optimizer scan
+                          if (!result.metafile?.inputs) return
+
+                          const optimizedFiles = Object.keys(
+                            result.metafile.inputs,
+                          )
+                          const metadata = { optimizedFiles }
+                          fs.writeFileSync(
+                            path.join(
+                              build.initialOptions.outdir!,
+                              '_metadata-vite-rsc.json',
+                            ),
+                            JSON.stringify(metadata, null, 2),
+                          )
+                        })
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        }
+      },
       async transform(code, id) {
         if (this.environment.name !== serverEnvironmentName) return
         if (!code.includes('use client')) return


### PR DESCRIPTION
### Description

- Closes https://github.com/vitejs/vite-plugin-react/issues/736

TODO
- [x] test with `@ai-sdk/rsc`
```
10:46:10 AM [vite] (rsc) warning: client component dependency is inconsistently optimized. It's recommended to add the dependency to 'optimizeDeps.exclude'.
  Plugin: rsc:use-client
  File: /home/hiroshi/code/others/waku/node_modules/.pnpm/@ai-sdk+rsc@1.0.10_react@19.1.1_zod@3.25.76/node_modules/@ai-sdk/rsc/dist/rsc-shared.mjs?v=5d0e105d
```
- [x] esbuild
- [x] rolldown
- [x] refactor
- [ ] upstream to vite? https://github.com/vitejs/vite/discussions/20610