### PR TITLE
fix(rsc): inject `__vite_rsc_importer_resources` import only once

### DIFF
--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1800,6 +1800,7 @@ export function vitePluginRscCss(
 
         assert(this.environment.name === 'rsc')
         const output = new MagicString(code)
+        let importAdded = false
 
         for (const match of code.matchAll(
           /import\.meta\.viteRsc\.loadCss\(([\s\S]*?)\)/dg,
@@ -1833,7 +1834,11 @@ export function vitePluginRscCss(
             })`
           } else {
             const hash = hashString(importId)
-            if (!code.includes(`__vite_rsc_importer_resources_${hash}`)) {
+            if (
+              !importAdded &&
+              !code.includes(`__vite_rsc_importer_resources_${hash}`)
+            ) {
+              importAdded = true
               output.prepend(
                 `import * as __vite_rsc_importer_resources_${hash} from ${JSON.stringify(
                   importId,


### PR DESCRIPTION
### Description

- Reported by Waku user https://discord.com/channels/627656437971288081/1407392302070239242/1407392302070239242

Previously each `import.meta.viteRsc.loadCss()` adds `import __vite_rsc_importer_resources_xxx from "..."` and it causes a name crash when they are added multiple times (either manually or due to auto `loadCss` injection). For example:

```
✗ Build failed in 32ms
error during build:
src/root.tsx (10:6): Identifier "__vite_rsc_importer_resources_366c10439797" has already been declared
file: /home/hiroshi/code/others/vite-plugin-react/packages/plugin-rsc/examples/starter/src/root.tsx:10:6

 8:   return (
 9:     <html lang="en">
10:       <head>
          ^
11:         <meta charSet="UTF-8" />
12:         <link rel="icon" type="image/svg+xml" href="/vite.svg" />
```