### PR TITLE
fix(rsc): ensure `.js` suffix for internal virtual modules

### DIFF
--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1978,8 +1978,7 @@ export function vitePluginRscCss(
             const result = collectCss(server.environments.rsc!, importer)
             const cssHrefs = result.hrefs.map((href) => href.slice(1))
             const jsHrefs = [
-              '@id/__x00__virtual:vite-rsc/importer-resources-browser?importer=' +
-                encodeURIComponent(importer),
+              `@id/__x00__virtual:vite-rsc/importer-resources-browser?importer=${encodeURIComponent(importer)}&lang.js`,
             ]
             const deps = assetsURLOfDeps({ css: cssHrefs, js: jsHrefs })
             return generateResourcesCode(serializeValueWithRuntime(deps))
@@ -2025,11 +2024,11 @@ export function vitePluginRscCss(
               const importer = encodeURIComponent(mod.id)
               invalidteModuleById(
                 server.environments.rsc!,
-                `\0virtual:vite-rsc/importer-resources?importer=${importer}`,
+                `\0virtual:vite-rsc/importer-resources?importer=${importer}&lang.js`,
               )
               invalidteModuleById(
                 server.environments.client,
-                `\0virtual:vite-rsc/importer-resources-browser?importer=${importer}`,
+                `\0virtual:vite-rsc/importer-resources-browser?importer=${importer}&lang.js`,
               )
             }
           }

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -43,7 +43,6 @@ import {
   getEntrySource,
   hashString,
   normalizeRelativePath,
-  parseIdQuery,
   sortObject,
   withRollupError,
 } from './plugins/utils'
@@ -51,7 +50,7 @@ import { createDebug } from '@hiogawa/utils'
 import { transformScanBuildStrip } from './plugins/scan'
 import { validateImportPlugin } from './plugins/validate-import'
 import { vitePluginFindSourceMapURL } from './plugins/find-source-map-url'
-import { parseCssVirtual, toCssVirtual } from './plugins/shared'
+import { parseCssVirtual, toCssVirtual, parseIdQuery } from './plugins/shared'
 
 const BUILD_ASSETS_MANIFEST_NAME = '__vite_rsc_assets_manifest.js'
 

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1821,9 +1821,12 @@ export function vitePluginRscCss(
               continue
             }
           }
+
+          // ensure other plugins treat it as a plain js file
+          // e.g. https://github.com/vitejs/rolldown-vite/issues/372#issuecomment-3193401601
           const importId = `virtual:vite-rsc/importer-resources?importer=${encodeURIComponent(
             importer,
-          )}`
+          )}&lang.js`
 
           // use dynamic import during dev to delay crawling and discover css correctly.
           let replacement: string

--- a/packages/plugin-rsc/src/plugins/cjs.ts
+++ b/packages/plugin-rsc/src/plugins/cjs.ts
@@ -1,11 +1,11 @@
 import { parseAstAsync, type Plugin } from 'vite'
-import { parseIdQuery } from './utils'
 import { findClosestPkgJsonPath } from 'vitefu'
 import path from 'node:path'
 import fs from 'node:fs'
 import * as esModuleLexer from 'es-module-lexer'
 import { transformCjsToEsm } from '../transforms/cjs'
 import { createDebug } from '@hiogawa/utils'
+import { parseIdQuery } from './shared'
 
 const debug = createDebug('vite-rsc:cjs')
 

--- a/packages/plugin-rsc/src/plugins/shared.ts
+++ b/packages/plugin-rsc/src/plugins/shared.ts
@@ -17,10 +17,7 @@ export function parseCssVirtual(id: string):
     }
   | undefined {
   if (id.startsWith('\0virtual:vite-rsc/css?')) {
-    return parseIdQuery(id).query as {
-      id: string
-      type: 'ssr' | 'rsc' | 'rsc-browser'
-    }
+    return parseIdQuery(id).query as any
   }
 }
 

--- a/packages/plugin-rsc/src/plugins/shared.ts
+++ b/packages/plugin-rsc/src/plugins/shared.ts
@@ -1,0 +1,38 @@
+export function toCssVirtual({
+  id,
+  type,
+}: {
+  id: string
+  type: 'ssr' | 'rsc' | 'rsc-browser'
+}) {
+  // ensure other plugins treat it as a plain js file
+  // e.g. https://github.com/vitejs/rolldown-vite/issues/372#issuecomment-3193401601
+  return `virtual:vite-rsc/css?type=${type}&id=${encodeURIComponent(id)}&lang.js`
+}
+
+export function parseCssVirtual(id: string):
+  | {
+      id: string
+      type: 'ssr' | 'rsc' | 'rsc-browser'
+    }
+  | undefined {
+  if (id.startsWith('\0virtual:vite-rsc/css?')) {
+    return parseIdQuery(id).query as {
+      id: string
+      type: 'ssr' | 'rsc' | 'rsc-browser'
+    }
+  }
+}
+
+// https://github.com/vitejs/vite-plugin-vue/blob/06931b1ea2b9299267374cb8eb4db27c0626774a/packages/plugin-vue/src/utils/query.ts#L13
+export function parseIdQuery(id: string): {
+  filename: string
+  query: {
+    [k: string]: string
+  }
+} {
+  if (!id.includes('?')) return { filename: id, query: {} }
+  const [filename, rawQuery] = id.split(`?`, 2) as [string, string]
+  const query = Object.fromEntries(new URLSearchParams(rawQuery))
+  return { filename, query }
+}

--- a/packages/plugin-rsc/src/plugins/shared.ts
+++ b/packages/plugin-rsc/src/plugins/shared.ts
@@ -1,21 +1,15 @@
-export function toCssVirtual({
-  id,
-  type,
-}: {
+type CssVirtual = {
   id: string
   type: 'ssr' | 'rsc' | 'rsc-browser'
-}) {
+}
+
+export function toCssVirtual({ id, type }: CssVirtual) {
   // ensure other plugins treat it as a plain js file
   // e.g. https://github.com/vitejs/rolldown-vite/issues/372#issuecomment-3193401601
   return `virtual:vite-rsc/css?type=${type}&id=${encodeURIComponent(id)}&lang.js`
 }
 
-export function parseCssVirtual(id: string):
-  | {
-      id: string
-      type: 'ssr' | 'rsc' | 'rsc-browser'
-    }
-  | undefined {
+export function parseCssVirtual(id: string): CssVirtual | undefined {
   if (id.startsWith('\0virtual:vite-rsc/css?')) {
     return parseIdQuery(id).query as any
   }

--- a/packages/plugin-rsc/src/plugins/utils.ts
+++ b/packages/plugin-rsc/src/plugins/utils.ts
@@ -16,19 +16,6 @@ export function evalValue<T = any>(rawValue: string): T {
   return fn()
 }
 
-// https://github.com/vitejs/vite-plugin-vue/blob/06931b1ea2b9299267374cb8eb4db27c0626774a/packages/plugin-vue/src/utils/query.ts#L13
-export function parseIdQuery(id: string): {
-  filename: string
-  query: {
-    [k: string]: string
-  }
-} {
-  if (!id.includes('?')) return { filename: id, query: {} }
-  const [filename, rawQuery] = id.split(`?`, 2) as [string, string]
-  const query = Object.fromEntries(new URLSearchParams(rawQuery))
-  return { filename, query }
-}
-
 // https://github.com/vitejs/vite/blob/946831f986cb797009b8178659d2b31f570c44ff/packages/vite/src/shared/utils.ts#L31-L34
 const postfixRE = /[?#].*$/
 export function cleanUrl(url: string): string {

--- a/packages/plugin-rsc/src/ssr.tsx
+++ b/packages/plugin-rsc/src/ssr.tsx
@@ -17,7 +17,7 @@ function initialize(): void {
       if (!import.meta.env.__vite_rsc_build__) {
         const mod = await import(/* @vite-ignore */ id)
         const modCss = await import(
-          /* @vite-ignore */ `/@id/__x00__${toCssVirtual({ id, type: 'ssr' })}`
+          /* @vite-ignore */ '/@id/__x00__' + toCssVirtual({ id, type: 'ssr' })
         )
         return wrapResourceProxy(mod, { js: [], css: modCss.default })
       } else {

--- a/packages/plugin-rsc/src/ssr.tsx
+++ b/packages/plugin-rsc/src/ssr.tsx
@@ -3,6 +3,7 @@ import * as clientReferences from 'virtual:vite-rsc/client-references'
 import * as ReactDOM from 'react-dom'
 import { setRequireModule } from './core/ssr'
 import type { ResolvedAssetDeps } from './plugin'
+import { toCssVirtual } from './plugins/shared'
 
 export { createServerConsumerManifest } from './core/ssr'
 
@@ -16,7 +17,7 @@ function initialize(): void {
       if (!import.meta.env.__vite_rsc_build__) {
         const mod = await import(/* @vite-ignore */ id)
         const modCss = await import(
-          /* @vite-ignore */ '/@id/__x00__virtual:vite-rsc/css/dev-ssr/' + id
+          /* @vite-ignore */ `/@id/__x00__${toCssVirtual({ id, type: 'ssr' })}`
         )
         return wrapResourceProxy(mod, { js: [], css: modCss.default })
       } else {


### PR DESCRIPTION
### Description

- Related https://github.com/vitejs/rolldown-vite/issues/372#issuecomment-3193401601

Along with the fix, we also reworked three css virtual types to have consistent format:

```
virtual:vite-rsc/css?type=...&id=...&lang.js
```