### PR TITLE
fix(rsc): isolate plugin state per plugin instance

### DIFF
--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -601,6 +601,7 @@ export default function vitePluginRsc(
       },
       renderChunk(code, chunk) {
         if (!code.includes('__vite_rsc_load_module')) return
+        const { config } = manager
         const s = new MagicString(code)
         for (const match of code.matchAll(
           /['"]__vite_rsc_load_module:(\w+):(\w+):(\w+)['"]/dg,
@@ -609,12 +610,12 @@ export default function vitePluginRsc(
           const importPath = normalizeRelativePath(
             path.relative(
               path.join(
-                manager.config.environments[fromEnv!]!.build.outDir,
+                config.environments[fromEnv!]!.build.outDir,
                 chunk.fileName,
                 '..',
               ),
               path.join(
-                manager.config.environments[toEnv!]!.build.outDir,
+                config.environments[toEnv!]!.build.outDir,
                 // TODO: this breaks when custom entyFileNames
                 `${entryName}.js`,
               ),
@@ -1561,12 +1562,13 @@ function serializeValueWithRuntime(value: any) {
 }
 
 function assetsURL(url: string, manager: RscPluginManager) {
+  const { config } = manager
   if (
-    manager.config.command === 'build' &&
-    typeof manager.config.experimental?.renderBuiltUrl === 'function'
+    config.command === 'build' &&
+    typeof config.experimental?.renderBuiltUrl === 'function'
   ) {
     // https://github.com/vitejs/vite/blob/bdde0f9e5077ca1a21a04eefc30abad055047226/packages/vite/src/node/build.ts#L1369
-    const result = manager.config.experimental.renderBuiltUrl(url, {
+    const result = config.experimental.renderBuiltUrl(url, {
       type: 'asset',
       hostType: 'js',
       ssr: true,
@@ -1587,7 +1589,7 @@ function assetsURL(url: string, manager: RscPluginManager) {
   }
 
   // https://github.com/vitejs/vite/blob/2a7473cfed96237711cda9f736465c84d442ddef/packages/vite/src/node/plugins/importAnalysisBuild.ts#L222-L230
-  return manager.config.base + url
+  return config.base + url
 }
 
 function assetsURLOfDeps(deps: AssetDeps, manager: RscPluginManager) {

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -80,6 +80,14 @@ function resolvePackage(name: string) {
   return pathToFileURL(require.resolve(name)).href
 }
 
+export type { RscPluginManager }
+
+class RscPluginManager {
+  serverReferences: Record<string, string> = {}
+  clientReferenceMetaMap: Record</* id */ string, ClientReferenceMeta> = {}
+  serverResourcesMetaMap: Record<string, { key: string }> = {}
+}
+
 export type RscPluginOptions = {
   /**
    * shorthand for configuring `environments.(name).build.rollupOptions.input.index`
@@ -201,6 +209,9 @@ export function vitePluginRscMinimal(
 export default function vitePluginRsc(
   rscPluginOptions: RscPluginOptions = {},
 ): Plugin[] {
+  const manager = new RscPluginManager()
+  manager.clientReferenceMetaMap
+
   const buildApp: NonNullable<BuilderOptions['buildApp']> = async (builder) => {
     // no-ssr case
     // rsc -> client -> rsc -> client

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -46,6 +46,16 @@ import { vitePluginFindSourceMapURL } from './plugins/find-source-map-url'
 
 const BUILD_ASSETS_MANIFEST_NAME = '__vite_rsc_assets_manifest.js'
 
+type ClientReferenceMeta = {
+  importId: string
+  // same as `importId` during dev. hashed id during build.
+  referenceKey: string
+  packageSource?: string
+  // build only for tree-shaking unused export
+  exportNames: string[]
+  renderedExports: string[]
+}
+
 const PKG_NAME = '@vitejs/plugin-rsc'
 const REACT_SERVER_DOM_NAME = `${PKG_NAME}/vendor/react-server-dom`
 
@@ -69,16 +79,6 @@ class RscPluginManager {
   serverReferences: Record<string, string> = {}
   clientReferenceMetaMap: Record<string, ClientReferenceMeta> = {}
   serverResourcesMetaMap: Record<string, { key: string }> = {}
-}
-
-type ClientReferenceMeta = {
-  importId: string
-  // same as `importId` during dev. hashed id during build.
-  referenceKey: string
-  packageSource?: string
-  // build only for tree-shaking unused export
-  exportNames: string[]
-  renderedExports: string[]
 }
 
 export type RscPluginOptions = {

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -87,9 +87,9 @@ class RscPluginManager {
   config!: ResolvedConfig
   rscBundle!: Rollup.OutputBundle
   buildAssetsManifest: AssetsManifest | undefined
-  isScanBuild = false
+  isScanBuild: boolean = false
   serverReferences: Record<string, string> = {}
-  clientReferenceMetaMap: Record</* id */ string, ClientReferenceMeta> = {}
+  clientReferenceMetaMap: Record<string, ClientReferenceMeta> = {}
   serverResourcesMetaMap: Record<string, { key: string }> = {}
 }
 

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -83,6 +83,11 @@ function resolvePackage(name: string) {
 export type { RscPluginManager }
 
 class RscPluginManager {
+  server!: ViteDevServer
+  config!: ResolvedConfig
+  rscBundle!: Rollup.OutputBundle
+  buildAssetsManifest: AssetsManifest | undefined
+  isScanBuild = false
   serverReferences: Record<string, string> = {}
   clientReferenceMetaMap: Record</* id */ string, ClientReferenceMeta> = {}
   serverResourcesMetaMap: Record<string, { key: string }> = {}

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -44,27 +44,7 @@ import { transformScanBuildStrip } from './plugins/scan'
 import { validateImportPlugin } from './plugins/validate-import'
 import { vitePluginFindSourceMapURL } from './plugins/find-source-map-url'
 
-// state for build orchestration
-// let serverReferences: Record<string, string> = {}
-// let server: ViteDevServer
-// let config: ResolvedConfig
-// let rscBundle: Rollup.OutputBundle
-// let buildAssetsManifest: AssetsManifest | undefined
-// let isScanBuild = false
 const BUILD_ASSETS_MANIFEST_NAME = '__vite_rsc_assets_manifest.js'
-
-type ClientReferenceMeta = {
-  importId: string
-  // same as `importId` during dev. hashed id during build.
-  referenceKey: string
-  packageSource?: string
-  // build only for tree-shaking unused export
-  exportNames: string[]
-  renderedExports: string[]
-}
-// let clientReferenceMetaMap: Record</* id */ string, ClientReferenceMeta> = {}
-
-// let serverResourcesMetaMap: Record<string, { key: string }> = {}
 
 const PKG_NAME = '@vitejs/plugin-rsc'
 const REACT_SERVER_DOM_NAME = `${PKG_NAME}/vendor/react-server-dom`
@@ -80,8 +60,6 @@ function resolvePackage(name: string) {
   return pathToFileURL(require.resolve(name)).href
 }
 
-export type { RscPluginManager }
-
 class RscPluginManager {
   server!: ViteDevServer
   config!: ResolvedConfig
@@ -91,6 +69,16 @@ class RscPluginManager {
   serverReferences: Record<string, string> = {}
   clientReferenceMetaMap: Record<string, ClientReferenceMeta> = {}
   serverResourcesMetaMap: Record<string, { key: string }> = {}
+}
+
+type ClientReferenceMeta = {
+  importId: string
+  // same as `importId` during dev. hashed id during build.
+  referenceKey: string
+  packageSource?: string
+  // build only for tree-shaking unused export
+  exportNames: string[]
+  renderedExports: string[]
 }
 
 export type RscPluginOptions = {

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -48,7 +48,7 @@ import { vitePluginFindSourceMapURL } from './plugins/find-source-map-url'
 let serverReferences: Record<string, string> = {}
 let server: ViteDevServer
 let config: ResolvedConfig
-let rscBundle: Rollup.OutputBundle
+// let rscBundle: Rollup.OutputBundle
 // let buildAssetsManifest: AssetsManifest | undefined
 // let isScanBuild = false
 const BUILD_ASSETS_MANIFEST_NAME = '__vite_rsc_assets_manifest.js'
@@ -719,7 +719,7 @@ export default function vitePluginRsc(
       generateBundle(_options, bundle) {
         // copy assets from rsc build to client build
         if (this.environment.name === 'rsc') {
-          rscBundle = bundle
+          manager.rscBundle = bundle
         }
 
         if (this.environment.name === 'client') {
@@ -730,7 +730,7 @@ export default function vitePluginRsc(
             typeof rscBuildOptions.manifest === 'string'
               ? rscBuildOptions.manifest
               : rscBuildOptions.manifest && '.vite/manifest.json'
-          for (const asset of Object.values(rscBundle)) {
+          for (const asset of Object.values(manager.rscBundle)) {
             if (asset.fileName === rscViteManifest) continue
             if (asset.type === 'asset' && filterAssets(asset.fileName)) {
               this.emitFile({
@@ -742,7 +742,7 @@ export default function vitePluginRsc(
           }
 
           const serverResources: Record<string, AssetDeps> = {}
-          const rscAssetDeps = collectAssetDeps(rscBundle)
+          const rscAssetDeps = collectAssetDeps(manager.rscBundle)
           for (const [id, meta] of Object.entries(serverResourcesMetaMap)) {
             serverResources[meta.key] = assetsURLOfDeps({
               js: [],

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -64,7 +64,7 @@ type ClientReferenceMeta = {
 }
 let clientReferenceMetaMap: Record</* id */ string, ClientReferenceMeta> = {}
 
-let serverResourcesMetaMap: Record<string, { key: string }> = {}
+// let serverResourcesMetaMap: Record<string, { key: string }> = {}
 
 const PKG_NAME = '@vitejs/plugin-rsc'
 const REACT_SERVER_DOM_NAME = `${PKG_NAME}/vendor/react-server-dom`
@@ -232,7 +232,9 @@ export default function vitePluginRsc(
       await builder.build(builder.environments.rsc!)
       // sort for stable build
       clientReferenceMetaMap = sortObject(clientReferenceMetaMap)
-      serverResourcesMetaMap = sortObject(serverResourcesMetaMap)
+      manager.serverResourcesMetaMap = sortObject(
+        manager.serverResourcesMetaMap,
+      )
       await builder.build(builder.environments.client!)
       writeAssetsManifest(['rsc'])
       return
@@ -250,7 +252,7 @@ export default function vitePluginRsc(
     await builder.build(builder.environments.rsc!)
     // sort for stable build
     clientReferenceMetaMap = sortObject(clientReferenceMetaMap)
-    serverResourcesMetaMap = sortObject(serverResourcesMetaMap)
+    manager.serverResourcesMetaMap = sortObject(manager.serverResourcesMetaMap)
     await builder.build(builder.environments.client!)
     await builder.build(builder.environments.ssr!)
     writeAssetsManifest(['ssr', 'rsc'])
@@ -745,7 +747,9 @@ export default function vitePluginRsc(
 
           const serverResources: Record<string, AssetDeps> = {}
           const rscAssetDeps = collectAssetDeps(manager.rscBundle)
-          for (const [id, meta] of Object.entries(serverResourcesMetaMap)) {
+          for (const [id, meta] of Object.entries(
+            manager.serverResourcesMetaMap,
+          )) {
             serverResources[meta.key] = assetsURLOfDeps(
               {
                 js: [],
@@ -1931,7 +1935,7 @@ function vitePluginRscCss(
             const key = normalizePath(
               path.relative(manager.config.root, importer),
             )
-            serverResourcesMetaMap[importer] = { key }
+            manager.serverResourcesMetaMap[importer] = { key }
             return `
               import __vite_rsc_assets_manifest__ from "virtual:vite-rsc/assets-manifest";
               ${generateResourcesCode(

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -45,7 +45,7 @@ import { validateImportPlugin } from './plugins/validate-import'
 import { vitePluginFindSourceMapURL } from './plugins/find-source-map-url'
 
 // state for build orchestration
-let serverReferences: Record<string, string> = {}
+// let serverReferences: Record<string, string> = {}
 // let server: ViteDevServer
 // let config: ResolvedConfig
 // let rscBundle: Rollup.OutputBundle
@@ -1426,7 +1426,7 @@ function vitePluginUseServer(
               : undefined,
           })
           if (!output.hasChanged()) return
-          serverReferences[getNormalizedId()] = id
+          manager.serverReferences[getNormalizedId()] = id
           const importSource = resolvePackage(`${PKG_NAME}/react/rsc`)
           output.prepend(`import * as $$ReactServer from "${importSource}";\n`)
           if (enableEncryption) {
@@ -1463,7 +1463,7 @@ function vitePluginUseServer(
           })
           const output = result?.output
           if (!output?.hasChanged()) return
-          serverReferences[getNormalizedId()] = id
+          manager.serverReferences[getNormalizedId()] = id
           const name =
             this.environment.name === browserEnvironmentName ? 'browser' : 'ssr'
           const importSource = resolvePackage(`${PKG_NAME}/react/${name}`)
@@ -1479,7 +1479,7 @@ function vitePluginUseServer(
       if (this.environment.mode === 'dev') {
         return { code: `export {}`, map: null }
       }
-      const code = generateDynamicImportCode(serverReferences)
+      const code = generateDynamicImportCode(manager.serverReferences)
       return { code, map: null }
     }),
   ]

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -49,7 +49,7 @@ let serverReferences: Record<string, string> = {}
 let server: ViteDevServer
 let config: ResolvedConfig
 let rscBundle: Rollup.OutputBundle
-let buildAssetsManifest: AssetsManifest | undefined
+// let buildAssetsManifest: AssetsManifest | undefined
 // let isScanBuild = false
 const BUILD_ASSETS_MANIFEST_NAME = '__vite_rsc_assets_manifest.js'
 
@@ -262,7 +262,7 @@ export default function vitePluginRsc(
     // output client manifest to non-client build directly.
     // this makes server build to be self-contained and deploy-able for cloudflare.
     const assetsManifestCode = `export default ${serializeValueWithRuntime(
-      buildAssetsManifest,
+      manager.buildAssetsManifest,
     )}`
     for (const name of environmentNames) {
       const manifestPath = path.join(
@@ -771,7 +771,7 @@ export default function vitePluginRsc(
               `"import(" + JSON.stringify(${entryUrl.runtime}) + ")"`,
             )
           }
-          buildAssetsManifest = {
+          manager.buildAssetsManifest = {
             bootstrapScriptContent,
             clientReferenceDeps,
             serverResources,


### PR DESCRIPTION
### Description


Currently all plugin states are managed in module scope (as a reminiscence of my original prototype). These states should be isolated per plugin instance. This also helps splitting up more plugins from single file `plugin.ts`. Also helps fixing an issues like https://github.com/vitejs/vite-plugin-react/issues/575.

For now, let's do something mechanical by moving the state to `RscPluginManager` and just passing around `manager`. As a follow up, we could move some helpers to manager class such as `assetURL` method.

TODO
- [x] test
  - build two different rsc apps programatically?
