### PR TITLE
fix(rsc): handle added/removed `"use client"` during dev

### DIFF
--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -435,9 +435,21 @@ function defineTest(f: Fixture) {
     test('hmr switch server to client', async ({ page }) => {
       await page.goto(f.url())
       await waitForHydration(page)
+      await using _ = await expectNoReload(page)
 
-      const editor = f.createEditor('src/routes/hmr-switch/client.tsx')
+      await expect(page.getByTestId('test-hmr-switch-server')).toContainText(
+        '(useState: false)',
+      )
+      const editor = f.createEditor('src/routes/hmr-switch/server.tsx')
       editor.edit((s) => `"use client";\n` + s)
+      await expect(page.getByTestId('test-hmr-switch-server')).toContainText(
+        '(useState: true)',
+      )
+      // TODO
+      // editor.reset();
+      // await expect(page.getByTestId('test-hmr-switch-server')).toContainText(
+      //   '(useState: false)',
+      // )
     })
 
     test('hmr switch client to server', async ({ page }) => {

--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -435,7 +435,7 @@ function defineTest(f: Fixture) {
     test('hmr switch server to client', async ({ page }) => {
       await page.goto(f.url())
       await waitForHydration(page)
-      // await using _ = await expectNoReload(page)
+      await using _ = await expectNoReload(page)
 
       await expect(page.getByTestId('test-hmr-switch-server')).toContainText(
         '(useState: false)',
@@ -446,32 +446,32 @@ function defineTest(f: Fixture) {
         '(useState: true)',
       )
 
+      await page.waitForTimeout(100)
       editor.reset()
-      // TODO: currently reload is required
-      await expect(async () => {
-        await page.reload()
-        await expect(page.getByTestId('test-hmr-switch-server')).toContainText(
-          '(useState: false)',
-          { timeout: 0 },
-        )
-      }).toPass()
-      // await expect(page.getByTestId('test-hmr-switch-server')).toContainText(
-      //   '(useState: false)',
-      // )
+      await expect(page.getByTestId('test-hmr-switch-server')).toContainText(
+        '(useState: false)',
+      )
     })
 
     test('hmr switch client to server', async ({ page }) => {
       await page.goto(f.url())
       await waitForHydration(page)
+      await using _ = await expectNoReload(page)
 
       await expect(page.getByTestId('test-hmr-switch-client')).toContainText(
         '(useState: true)',
       )
       const editor = f.createEditor('src/routes/hmr-switch/client.tsx')
       editor.edit((s) => s.replace(`'use client'`, ''))
-      // await expect(page.getByTestId('test-hmr-switch-client')).toContainText(
-      //   '(useState: false)',
-      // )
+      await expect(page.getByTestId('test-hmr-switch-client')).toContainText(
+        '(useState: false)',
+      )
+
+      await page.waitForTimeout(100)
+      editor.reset()
+      await expect(page.getByTestId('test-hmr-switch-client')).toContainText(
+        '(useState: true)',
+      )
     })
   })
 

--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -431,6 +431,22 @@ function defineTest(f: Fixture) {
       await page.reload()
       await expect(page.getByText('ok (test-shared)')).toBeVisible()
     })
+
+    test('hmr switch server to client', async ({ page }) => {
+      await page.goto(f.url())
+      await waitForHydration(page)
+
+      const editor = f.createEditor('src/routes/hmr-switch/client.tsx')
+      editor.edit((s) => `"use client";\n` + s)
+    })
+
+    test('hmr switch client to server', async ({ page }) => {
+      await page.goto(f.url())
+      await waitForHydration(page)
+
+      const editor = f.createEditor('src/routes/hmr-switch/client.tsx')
+      editor.edit((s) => s.replace('"use client";', ''))
+    })
   })
 
   test('css @js', async ({ page }) => {

--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -435,7 +435,7 @@ function defineTest(f: Fixture) {
     test('hmr switch server to client', async ({ page }) => {
       await page.goto(f.url())
       await waitForHydration(page)
-      await using _ = await expectNoReload(page)
+      // await using _ = await expectNoReload(page)
 
       await expect(page.getByTestId('test-hmr-switch-server')).toContainText(
         '(useState: false)',
@@ -445,8 +445,16 @@ function defineTest(f: Fixture) {
       await expect(page.getByTestId('test-hmr-switch-server')).toContainText(
         '(useState: true)',
       )
-      // TODO
-      // editor.reset();
+
+      editor.reset()
+      // TODO: currently reload is required
+      await expect(async () => {
+        await page.reload()
+        await expect(page.getByTestId('test-hmr-switch-server')).toContainText(
+          '(useState: false)',
+          { timeout: 0 },
+        )
+      }).toPass()
       // await expect(page.getByTestId('test-hmr-switch-server')).toContainText(
       //   '(useState: false)',
       // )
@@ -456,8 +464,14 @@ function defineTest(f: Fixture) {
       await page.goto(f.url())
       await waitForHydration(page)
 
+      await expect(page.getByTestId('test-hmr-switch-client')).toContainText(
+        '(useState: true)',
+      )
       const editor = f.createEditor('src/routes/hmr-switch/client.tsx')
-      editor.edit((s) => s.replace('"use client";', ''))
+      editor.edit((s) => s.replace(`'use client'`, ''))
+      // await expect(page.getByTestId('test-hmr-switch-client')).toContainText(
+      //   '(useState: false)',
+      // )
     })
   })
 

--- a/packages/plugin-rsc/examples/basic/src/routes/hmr-switch/client.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/hmr-switch/client.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 export function TestHmrSwitchClient() {
   return (
     <div data-testid="test-hmr-switch-client">
-      test-hmr-foo-switch-clietn (useState: {String(!!React.useState)})
+      test-hmr-switch-client (useState: {String(!!React.useState)})
     </div>
   )
 }

--- a/packages/plugin-rsc/examples/basic/src/routes/hmr-switch/client.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/hmr-switch/client.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export function TestHmrMixedClient() {
+  return <div>test-hmr-mixed-client</div>
+}

--- a/packages/plugin-rsc/examples/basic/src/routes/hmr-switch/client.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/hmr-switch/client.tsx
@@ -1,5 +1,11 @@
 'use client'
 
+import React from 'react'
+
 export function TestHmrSwitchClient() {
-  return <div>test-hmr-switch-client</div>
+  return (
+    <div data-testid="test-hmr-switch-client">
+      test-hmr-foo-switch-clietn (useState: {String(!!React.useState)})
+    </div>
+  )
 }

--- a/packages/plugin-rsc/examples/basic/src/routes/hmr-switch/client.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/hmr-switch/client.tsx
@@ -1,5 +1,5 @@
 'use client'
 
-export function TestHmrMixedClient() {
-  return <div>test-hmr-mixed-client</div>
+export function TestHmrSwitchClient() {
+  return <div>test-hmr-switch-client</div>
 }

--- a/packages/plugin-rsc/examples/basic/src/routes/hmr-switch/server.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/hmr-switch/server.tsx
@@ -1,3 +1,9 @@
-export function TestHmrMixedServer() {
-  return <div>test-hmr-mixed-server</div>
+import React from 'react'
+
+export function TestHmrSwitchServer() {
+  return (
+    <div data-testid="test-hmr-switch-server">
+      test-hmr-foo-switch-server (useState: {String(!!React.useState)})
+    </div>
+  )
 }

--- a/packages/plugin-rsc/examples/basic/src/routes/hmr-switch/server.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/hmr-switch/server.tsx
@@ -1,0 +1,3 @@
+export function TestHmrMixedServer() {
+  return <div>test-hmr-mixed-server</div>
+}

--- a/packages/plugin-rsc/examples/basic/src/routes/hmr-switch/server.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/hmr-switch/server.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 export function TestHmrSwitchServer() {
   return (
     <div data-testid="test-hmr-switch-server">
-      test-hmr-foo-switch-server (useState: {String(!!React.useState)})
+      test-hmr-switch-server (useState: {String(!!React.useState)})
     </div>
   )
 }

--- a/packages/plugin-rsc/examples/basic/src/routes/root.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/root.tsx
@@ -38,6 +38,8 @@ import { TestHmrSharedAtomic } from './hmr-shared/atomic/server'
 import { TestCssQueries } from './css-queries/server'
 import { TestImportMetaGlob } from './import-meta-glob/server'
 import { TestAssetsServer } from './assets/server'
+import { TestHmrMixedServer } from './hmr-switch/server'
+import { TestHmrMixedClient } from './hmr-switch/client'
 
 export function Root(props: { url: URL }) {
   return (
@@ -65,6 +67,8 @@ export function Root(props: { url: URL }) {
         <TestHmrSharedServer />
         <TestHmrSharedClient />
         <TestHmrSharedAtomic />
+        <TestHmrMixedServer />
+        <TestHmrMixedClient />
         <TestTemporaryReference />
         <TestServerActionError />
         <TestReplayConsoleLogs url={props.url} />

--- a/packages/plugin-rsc/examples/basic/src/routes/root.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/root.tsx
@@ -38,8 +38,8 @@ import { TestHmrSharedAtomic } from './hmr-shared/atomic/server'
 import { TestCssQueries } from './css-queries/server'
 import { TestImportMetaGlob } from './import-meta-glob/server'
 import { TestAssetsServer } from './assets/server'
-import { TestHmrMixedServer } from './hmr-switch/server'
-import { TestHmrMixedClient } from './hmr-switch/client'
+import { TestHmrSwitchServer } from './hmr-switch/server'
+import { TestHmrSwitchClient } from './hmr-switch/client'
 
 export function Root(props: { url: URL }) {
   return (
@@ -67,8 +67,8 @@ export function Root(props: { url: URL }) {
         <TestHmrSharedServer />
         <TestHmrSharedClient />
         <TestHmrSharedAtomic />
-        <TestHmrMixedServer />
-        <TestHmrMixedClient />
+        <TestHmrSwitchServer />
+        <TestHmrSwitchClient />
         <TestTemporaryReference />
         <TestServerActionError />
         <TestReplayConsoleLogs url={props.url} />

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1083,6 +1083,7 @@ function vitePluginUseClient(
         })
         if (!result) return
         const { output, exportNames } = result
+        // TODO
         manager.clientReferenceMetaMap[id] = {
           importId,
           referenceKey,


### PR DESCRIPTION
### Description

- Related https://github.com/vitejs/vite-plugin-react/issues/575

TODO
- [x] server -> client
  - this triggers "server hmr" and it naturally pulls in new client component via new render
- [x] client -> server
  - this change is currently detected as "client  hmr". this needs to trigger server hmr instead.

---

For `"use server"`, it shouldn't cause any issues since the state is only for build, but it would be still nice to synchronize properly. This should be done after we also align the state for `"use server"` and `"use client"` like https://github.com/hi-ogawa/vite-plugins/pull/880