### PR TITLE
chore(rsc): example to coordinate react transition and `window.history`

### DIFF
--- a/packages/plugin-rsc/examples/starter/src/framework/entry.browser.tsx
+++ b/packages/plugin-rsc/examples/starter/src/framework/entry.browser.tsx
@@ -139,15 +139,13 @@ type NavigationAction =
       payload: RscPayload
     }
 
-const UPDATE_HISTORY = 'UPDATE_HISTORY'
+const PUSH_HISTORY = 'PUSH_HISTORY'
 
 function HistoryUpdater({ state }: { state: NavigationState }) {
   React.useInsertionEffect(() => {
     if (state.push) {
       state.push = false
-      window.history.pushState({ [UPDATE_HISTORY]: true }, '', state.url)
-    } else {
-      window.history.replaceState({ [UPDATE_HISTORY]: true }, '', state.url)
+      window.history.pushState({ [PUSH_HISTORY]: true }, '', state.url)
     }
   }, [state])
 
@@ -155,10 +153,10 @@ function HistoryUpdater({ state }: { state: NavigationState }) {
 }
 
 function listenNavigation() {
-  const originalPushState = window.history.pushState
+  const oldPushState = window.history.pushState
   window.history.pushState = function (...args) {
-    if (args[0] && typeof args[0] === 'object' && UPDATE_HISTORY in args[0]) {
-      originalPushState.apply(this, args)
+    if (args[0] && typeof args[0] === 'object' && PUSH_HISTORY in args[0]) {
+      oldPushState.apply(this, args)
       return
     }
     const href = window.location.href
@@ -167,12 +165,8 @@ function listenNavigation() {
     return
   }
 
-  const originalReplaceState = window.history.replaceState
+  const oldReplaceState = window.history.replaceState
   window.history.replaceState = function (...args) {
-    if (args[0] && typeof args[0] === 'object' && UPDATE_HISTORY in args[0]) {
-      originalReplaceState.apply(this, args)
-      return
-    }
     const href = window.location.href
     const url = new URL(args[2] || href, href)
     dispatch({ type: 'replace', url: url.href })
@@ -210,8 +204,8 @@ function listenNavigation() {
   return () => {
     document.removeEventListener('click', onClick)
     window.removeEventListener('popstate', onPopstate)
-    window.history.pushState = originalPushState
-    window.history.replaceState = originalReplaceState
+    window.history.pushState = oldPushState
+    window.history.replaceState = oldReplaceState
   }
 }
 

--- a/packages/plugin-rsc/examples/starter/src/framework/entry.browser.tsx
+++ b/packages/plugin-rsc/examples/starter/src/framework/entry.browser.tsx
@@ -29,28 +29,24 @@ async function main() {
     push: false,
   }
 
-  function reducer(action: NavigationAction): NavigationState {
-    if (action.payload) {
-      return {
-        url: action.url,
-        payloadPromise: Promise.resolve(action.payload),
-      }
-    }
-    return {
-      url: action.url,
-      push: action.push,
-      payloadPromise: createFromFetch<RscPayload>(fetch(action.url)),
-    }
-  }
-
   // browser root component to (re-)render RSC payload as state
   function BrowserRoot() {
     const [state, setState_] = React.useState(initialNavigationState)
 
     // https://github.com/vercel/next.js/blob/08bf0e08f74304afb3a9f79e521e5148b77bf96e/packages/next/src/client/components/use-action-queue.ts#L49
-    dispatch = (action: NavigationAction) => {
-      React.startTransition(() => setState_(reducer(action)))
-    }
+    React.useEffect(() => {
+      dispatch = (action: NavigationAction) => {
+        React.startTransition(() => {
+          setState_({
+            url: action.url,
+            push: action.push,
+            payloadPromise: action.payload
+              ? Promise.resolve(action.payload)
+              : createFromFetch<RscPayload>(fetch(action.url)),
+          })
+        })
+      }
+    }, [setState_])
 
     React.useEffect(() => {
       return listenNavigation()

--- a/packages/plugin-rsc/examples/starter/src/framework/entry.browser.tsx
+++ b/packages/plugin-rsc/examples/starter/src/framework/entry.browser.tsx
@@ -175,7 +175,7 @@ function listenNavigation() {
       !e.defaultPrevented
     ) {
       e.preventDefault()
-      window.history.pushState(null, '', link.href)
+      history.pushState(null, '', link.href)
     }
   }
   document.addEventListener('click', onClick)

--- a/packages/plugin-rsc/examples/starter/src/framework/entry.browser.tsx
+++ b/packages/plugin-rsc/examples/starter/src/framework/entry.browser.tsx
@@ -82,6 +82,72 @@ async function main() {
   }
 }
 
+type NavigationState = {
+  url: string
+  pushRef: {
+    pendingPush: boolean
+  }
+}
+
+type NavigationAction = {
+  type: 'push' | 'replace'
+  url: string
+}
+
+const initialNavigationState: NavigationState = {
+  url: window.location.href,
+  pushRef: {
+    pendingPush: false,
+  },
+}
+
+function useSetupNavigation() {
+  React.useInsertionEffect
+
+  type NavigationState = {
+    url: string
+    pushRef: {
+      pendingPush: boolean
+    }
+  }
+
+  type NavigationAction = {
+    type: 'push' | 'replace'
+    url: string
+  }
+
+  const initialState: NavigationState = {
+    url: window.location.href,
+    pushRef: {
+      pendingPush: false,
+    },
+  }
+
+  const [state, dispatch] = React.useReducer(
+    (state: NavigationState, action: NavigationAction) => {
+      switch (action.type) {
+        // case "push": {
+        //   window.history.pushState(null, '', action.url);
+        //   return { url: action.url };
+        // }
+        // case "replace": {
+        //   window.history.replaceState(null, '', action.url);
+        //   return { url: action.url };
+        // }
+        default:
+          return state
+      }
+    },
+    initialState,
+  )
+
+  // React.use(state);
+  state
+  dispatch
+}
+
+function HistoryUpdater() {}
+
 // a little helper to setup events interception for client side navigation
 function listenNavigation(onNavigation: () => void) {
   window.addEventListener('popstate', onNavigation)

--- a/packages/plugin-rsc/examples/starter/src/framework/entry.rsc.tsx
+++ b/packages/plugin-rsc/examples/starter/src/framework/entry.rsc.tsx
@@ -58,14 +58,18 @@ export default async function handler(request: Request): Promise<Response> {
   // we render RSC stream after handling server function request
   // so that new render reflects updated state from server function call
   // to achieve single round trip to mutate and fetch from server.
-  const rscPayload: RscPayload = { root: <Root />, formState, returnValue }
+  const url = new URL(request.url)
+  const rscPayload: RscPayload = {
+    root: <Root url={url} />,
+    formState,
+    returnValue,
+  }
   const rscOptions = { temporaryReferences }
   const rscStream = renderToReadableStream<RscPayload>(rscPayload, rscOptions)
 
   // respond RSC stream without HTML rendering based on framework's convention.
   // here we use request header `content-type`.
   // additionally we allow `?__rsc` and `?__html` to easily view payload directly.
-  const url = new URL(request.url)
   const isRscRequest =
     (!request.headers.get('accept')?.includes('text/html') &&
       !url.searchParams.has('__html')) ||

--- a/packages/plugin-rsc/examples/starter/src/root.tsx
+++ b/packages/plugin-rsc/examples/starter/src/root.tsx
@@ -4,7 +4,7 @@ import { getServerCounter, updateServerCounter } from './action.tsx'
 import reactLogo from './assets/react.svg'
 import { ClientCounter } from './client.tsx'
 
-export function Root() {
+export function Root(props: { url: URL }) {
   return (
     <html lang="en">
       <head>
@@ -14,13 +14,13 @@ export function Root() {
         <title>Vite + RSC</title>
       </head>
       <body>
-        <App />
+        <App {...props} />
       </body>
     </html>
   )
 }
 
-function App() {
+function App(props: { url: URL }) {
   return (
     <div id="root">
       <div>
@@ -65,6 +65,31 @@ function App() {
           to test server action without js enabled.
         </li>
       </ul>
+      <div>
+        <div>url: {props.url.href}</div>
+        <div>
+          <a href="/">Home</a> | <a href="/fast">Fast</a> |{' '}
+          <a href="/slow">Slow</a>
+        </div>
+        <div>
+          <Sleep
+            ms={
+              props.url.pathname === '/slow'
+                ? 2000
+                : props.url.pathname === '/fast'
+                  ? 500
+                  : 0
+            }
+          />
+        </div>
+      </div>
     </div>
   )
+}
+
+async function Sleep(props: { ms: number }) {
+  console.log('sleep:start', props.ms, 'ms')
+  await new Promise((resolve) => setTimeout(resolve, props.ms))
+  console.log('sleep:end', props.ms, 'ms')
+  return <>Slept for {props.ms}ms</>
 }


### PR DESCRIPTION
### Description

- Related https://github.com/wakujs/waku/pull/1516#issuecomment-3209061729

Minimal experiment to implement Next.js-like browser navigation and react transition coorditionation.