### PR TITLE
chore(rsc): remove custom `react-dom/server.edge` types

### DIFF
--- a/packages/plugin-rsc/examples/basic/src/framework/react.d.ts
+++ b/packages/plugin-rsc/examples/basic/src/framework/react.d.ts
@@ -1,3 +1,0 @@
-declare module 'react-dom/server.edge' {
-  export * from 'react-dom/server'
-}

--- a/packages/plugin-rsc/examples/react-router/react-router-vite/types.d.ts
+++ b/packages/plugin-rsc/examples/react-router/react-router-vite/types.d.ts
@@ -1,10 +1,6 @@
 /// <reference types="vite/client" />
 /// <reference types="@vitejs/plugin-rsc/types" />
 
-declare module 'react-dom/server.edge' {
-  export * from 'react-dom/server'
-}
-
 declare module 'virtual:react-router-routes' {
   const routes: any
   export default routes

--- a/packages/plugin-rsc/examples/ssg/src/react.d.ts
+++ b/packages/plugin-rsc/examples/ssg/src/react.d.ts
@@ -1,3 +1,0 @@
-declare module 'react-dom/server.edge' {
-  export * from 'react-dom/server'
-}

--- a/packages/plugin-rsc/examples/starter-cf-single/src/framework/react.d.ts
+++ b/packages/plugin-rsc/examples/starter-cf-single/src/framework/react.d.ts
@@ -1,3 +1,0 @@
-declare module 'react-dom/server.edge' {
-  export * from 'react-dom/server'
-}

--- a/packages/plugin-rsc/examples/starter/src/framework/react.d.ts
+++ b/packages/plugin-rsc/examples/starter/src/framework/react.d.ts
@@ -1,3 +1,0 @@
-declare module 'react-dom/server.edge' {
-  export * from 'react-dom/server'
-}

--- a/packages/plugin-rsc/src/types/react.ts
+++ b/packages/plugin-rsc/src/types/react.ts
@@ -1,3 +1,0 @@
-declare module 'react-dom/server.edge' {
-  export * from 'react-dom/server'
-}


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

It looks like this has been shipped from `@types/react-dom` since https://github.com/DefinitelyTyped/DefinitelyTyped/pull/72926