### PR TITLE
feat(rsc): ability to merge client reference chunks

### DIFF
--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -143,7 +143,7 @@ test.describe('build-stable-chunks', () => {
       .sort()
     expect(newChunks).toEqual([
       'src/framework/entry.browser.tsx',
-      'src/routes/client.tsx',
+      'virtual:vite-rsc/client-references/group/src/routes/client.tsx',
     ])
     expect(oldChunks).toEqual(newChunks)
   })

--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -9,6 +9,8 @@ import {
   waitForHydration,
 } from './helper'
 import { x } from 'tinyexec'
+import { normalizePath, type Rollup } from 'vite'
+import path from 'node:path'
 
 test.describe('dev-default', () => {
   const f = useFixture({ root: 'examples/basic', mode: 'dev' })
@@ -45,6 +47,17 @@ test.describe('dev-initial', () => {
 test.describe('build-default', () => {
   const f = useFixture({ root: 'examples/basic', mode: 'build' })
   defineTest(f)
+
+  test('custom client chunk', async () => {
+    const { chunks }: { chunks: Rollup.OutputChunk[] } = JSON.parse(
+      f.createEditor('dist/client/.vite/test.json').read(),
+    )
+    const chunk = chunks.find((c) => c.name === 'custom-chunk')
+    const expected = [1, 2, 3].map((i) =>
+      normalizePath(path.join(f.root, `src/routes/chunk/client${i}.tsx`)),
+    )
+    expect(chunk?.moduleIds).toEqual(expect.arrayContaining(expected))
+  })
 })
 
 test.describe('dev-non-optimized-cjs', () => {

--- a/packages/plugin-rsc/examples/basic/src/routes/chunk/client1.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/chunk/client1.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+export function TestClientChunk1() {
+  return <span>test-chunk1</span>
+}
+
+export function TestClientChunkConflict() {
+  return <span>test-chunk-conflict1</span>
+}

--- a/packages/plugin-rsc/examples/basic/src/routes/chunk/client2.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/chunk/client2.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export function TestClientChunk2() {
+  return <span>test-chunk2</span>
+}

--- a/packages/plugin-rsc/examples/basic/src/routes/chunk/client3.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/chunk/client3.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+export function TestClientChunk3() {
+  return <span>test-chunk3</span>
+}
+
+export function TestClientChunkConflict() {
+  return <span>test-chunk-conflict3</span>
+}

--- a/packages/plugin-rsc/examples/basic/src/routes/chunk/server.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/chunk/server.tsx
@@ -1,0 +1,21 @@
+import {
+  TestClientChunk1,
+  TestClientChunkConflict as TestClientChunkConflict1,
+} from './client1'
+import { TestClientChunk2 } from './client2'
+import {
+  TestClientChunk3,
+  TestClientChunkConflict as TestClientChunkConflict3,
+} from './client3'
+
+export function TestClientChunkServer() {
+  return (
+    <div data-testid="test-client-chunk">
+      <TestClientChunk1 />|
+      <TestClientChunkConflict1 />|
+      <TestClientChunk2 />|
+      <TestClientChunk3 />|
+      <TestClientChunkConflict3 />
+    </div>
+  )
+}

--- a/packages/plugin-rsc/examples/basic/src/routes/root.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/root.tsx
@@ -41,6 +41,7 @@ import { TestAssetsServer } from './assets/server'
 import { TestHmrSwitchServer } from './hmr-switch/server'
 import { TestHmrSwitchClient } from './hmr-switch/client'
 import { TestTreeShakeServer } from './tree-shake/server'
+import { TestClientChunkServer } from './chunk/server'
 
 export function Root(props: { url: URL }) {
   return (
@@ -95,6 +96,7 @@ export function Root(props: { url: URL }) {
         <TestImportMetaGlob />
         <TestAssetsServer />
         <TestTreeShakeServer />
+        <TestClientChunkServer />
       </body>
     </html>
   )

--- a/packages/plugin-rsc/examples/basic/vite.config.ts
+++ b/packages/plugin-rsc/examples/basic/vite.config.ts
@@ -11,6 +11,7 @@ import {
 } from 'vite'
 // import inspect from 'vite-plugin-inspect'
 import path from 'node:path'
+import fs from 'node:fs'
 import { fileURLToPath } from 'node:url'
 
 export default defineConfig({
@@ -46,6 +47,23 @@ export default defineConfig({
             assert(!chunk.code.includes('__unused_server_export__'))
           }
         }
+      },
+    },
+    {
+      // dump entire bundle to analyze build output for e2e
+      name: 'test-metadata',
+      enforce: 'post',
+      writeBundle(options, bundle) {
+        const chunks: Rollup.OutputChunk[] = []
+        for (const chunk of Object.values(bundle)) {
+          if (chunk.type === 'chunk') {
+            chunks.push(chunk)
+          }
+        }
+        fs.writeFileSync(
+          path.join(options.dir!, '.vite/test.json'),
+          JSON.stringify({ chunks }, null, 2),
+        )
       },
     },
     {

--- a/packages/plugin-rsc/examples/basic/vite.config.ts
+++ b/packages/plugin-rsc/examples/basic/vite.config.ts
@@ -37,8 +37,9 @@ export default defineConfig({
       writeBundle(_options, bundle) {
         for (const chunk of Object.values(bundle)) {
           if (chunk.type === 'chunk') {
-            assert(!chunk.code.includes('__unused_client_reference__'))
-            assert(!chunk.code.includes('__unused_server_export__'))
+            // TODO
+            // assert(!chunk.code.includes('__unused_client_reference__'))
+            // assert(!chunk.code.includes('__unused_server_export__'))
           }
         }
       },

--- a/packages/plugin-rsc/examples/basic/vite.config.ts
+++ b/packages/plugin-rsc/examples/basic/vite.config.ts
@@ -31,8 +31,8 @@ export default defineConfig({
       copyServerAssetsToClient: (fileName) =>
         fileName !== '__server_secret.txt',
       clientChunks(id) {
-        if (id.includes('/src/routes/deps/')) {
-          return 'group'
+        if (id.includes('/src/routes/chunk/')) {
+          return 'custom-chunk'
         }
       },
     }),

--- a/packages/plugin-rsc/examples/basic/vite.config.ts
+++ b/packages/plugin-rsc/examples/basic/vite.config.ts
@@ -30,6 +30,11 @@ export default defineConfig({
       rscCssTransform: false,
       copyServerAssetsToClient: (fileName) =>
         fileName !== '__server_secret.txt',
+      clientChunks(id) {
+        if (id.includes('/src/routes/deps/')) {
+          return 'group'
+        }
+      },
     }),
     {
       name: 'test-tree-shake',

--- a/packages/plugin-rsc/examples/basic/vite.config.ts
+++ b/packages/plugin-rsc/examples/basic/vite.config.ts
@@ -37,9 +37,8 @@ export default defineConfig({
       writeBundle(_options, bundle) {
         for (const chunk of Object.values(bundle)) {
           if (chunk.type === 'chunk') {
-            // TODO
-            // assert(!chunk.code.includes('__unused_client_reference__'))
-            // assert(!chunk.code.includes('__unused_server_export__'))
+            assert(!chunk.code.includes('__unused_client_reference__'))
+            assert(!chunk.code.includes('__unused_server_export__'))
           }
         }
       },

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1125,6 +1125,13 @@ function vitePluginUseClient(
           if (this.environment.mode === 'dev') {
             return { code: `export default {}`, map: null }
           }
+          if (manager.isScanBuild) {
+            let code = ``
+            for (const meta of Object.values(manager.clientReferenceMetaMap)) {
+              code += `import ${JSON.stringify(meta.importId)};\n`
+            }
+            return { code, map: null }
+          }
           let code = ''
           manager.clientReferenceGroupMap = {}
           for (const meta of Object.values(manager.clientReferenceMetaMap)) {

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -180,7 +180,35 @@ export type RscPluginOptions = {
   }
 
   /**
-   * @experimental
+   * Custom chunking strategy for client reference modules.
+   *
+   * This function allows you to group multiple client components into
+   * custom chunks instead of having each module in its own chunk.
+   *
+   * @param id - The absolute path of the client module
+   * @returns The chunk name to group this module with, or undefined to use default behavior
+   *
+   * @example
+   * ```js
+   * clientChunks(id) {
+   *   // Group all client components in a specific route together
+   *   if (id.includes('/src/routes/dashboard/')) {
+   *     return 'dashboard-clients'
+   *   }
+   *   // Group third-party client components
+   *   if (id.includes('node_modules/@company/ui/')) {
+   *     return 'vendor-ui'
+   *   }
+   * }
+   * ```
+   *
+   * Benefits:
+   * - Reduces the number of HTTP requests by bundling related client components
+   * - Improves loading performance for route-based code splitting
+   * - Allows fine-grained control over client-side bundle optimization
+   *
+   * Note: Tree-shaking is still applied, so only the actually used exports
+   * from each module will be included in the final chunk.
    */
   clientChunks?: (id: string) => string | undefined
 }

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -181,7 +181,7 @@ export type RscPluginOptions = {
   /**
    * @experimental
    */
-  clientChunks?: (id: string, meta: ClientReferenceMeta) => string | undefined
+  clientChunks?: (id: string) => string | undefined
 }
 
 /** @experimental */
@@ -1136,7 +1136,7 @@ function vitePluginUseClient(
           manager.clientReferenceGroupMap = {}
           for (const meta of Object.values(manager.clientReferenceMetaMap)) {
             const name =
-              useClientPluginOptions.clientChunks?.(meta.importId, meta) ||
+              useClientPluginOptions.clientChunks?.(meta.importId) ||
               normalizePath(path.relative(manager.config.root, meta.importId))
             const group = (manager.clientReferenceGroupMap[name] ??= [])
             group.push(meta)

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1139,10 +1139,12 @@ function vitePluginUseClient(
           )) {
             const groupVirtual = `virtual:vite-rsc/client-references/group/${name}`
             for (const meta of metas) {
-              code += `${JSON.stringify(meta.referenceKey)}: async () => {
-                const __group = await import(${JSON.stringify(groupVirtual)});
-                return __group.export_${meta.referenceKey}();
-              },`
+              code += `\
+                ${JSON.stringify(meta.referenceKey)}: async () => {
+                  const __group = await import(${JSON.stringify(groupVirtual)});
+                  return __group.export_${meta.referenceKey}();
+                },
+              `
             }
           }
           code = `export default {${code}};\n`
@@ -1164,7 +1166,7 @@ function vitePluginUseClient(
               export const export_${meta.referenceKey} = () => {
                 const {${exports}} = import_${meta.referenceKey};
                 return {${exports}};
-              }
+              };
             `
           }
           return { code, map: null }

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1148,8 +1148,8 @@ function vitePluginUseClient(
             for (const meta of metas) {
               code += `\
                 ${JSON.stringify(meta.referenceKey)}: async () => {
-                  const __group = await import(${JSON.stringify(groupVirtual)});
-                  return __group.export_${meta.referenceKey}();
+                  const m = await import(${JSON.stringify(groupVirtual)});
+                  return m.export_${meta.referenceKey};
                 },
               `
             }
@@ -1166,14 +1166,12 @@ function vitePluginUseClient(
           let code = ``
           for (const meta of metas) {
             const exports = meta.renderedExports
-              .map((name) => (name === 'default' ? 'default: _default' : name))
+              .map((name) => `${name}: import_${meta.referenceKey}.${name},\n`)
               .sort()
+              .join('')
             code += `
               import * as import_${meta.referenceKey} from ${JSON.stringify(meta.importId)};
-              export const export_${meta.referenceKey} = () => {
-                const {${exports}} = import_${meta.referenceKey};
-                return {${exports}};
-              };
+              export const export_${meta.referenceKey} = {${exports}};
             `
           }
           return { code, map: null }

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -176,6 +176,11 @@ export type RscPluginOptions = {
     ssr?: string
     rsc?: string
   }
+
+  /**
+   * @experimental
+   */
+  clientChunks?: (id: string, meta: ClientReferenceMeta) => string | undefined
 }
 
 /** @experimental */
@@ -977,7 +982,7 @@ function scanBuildStripPlugin({
 function vitePluginUseClient(
   useClientPluginOptions: Pick<
     RscPluginOptions,
-    'keepUseCientProxy' | 'environment'
+    'keepUseCientProxy' | 'environment' | 'clientChunks'
   >,
   manager: RscPluginManager,
 ): Plugin[] {
@@ -1160,8 +1165,9 @@ function vitePluginUseClient(
             return { code: `export default {}`, map: null }
           }
           let code = ''
+          // TODO: group client references
+          useClientPluginOptions.clientChunks
           for (const meta of Object.values(manager.clientReferenceMetaMap)) {
-            // TODO: group
             const groupVirtual = [
               `virtual:vite-rsc/client-references/group`,
               `${meta.referenceKey}`,

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1177,7 +1177,7 @@ function vitePluginUseClient(
           assert(metas, `unknown client reference group: ${name}`)
           let code = ``
           for (const meta of metas) {
-            // pick only rendredExports to tree-shake unused client references
+            // pick only renderedExports to tree-shake unused client references
             const exports = meta.renderedExports
               .map((name) => `${name}: import_${meta.referenceKey}.${name},\n`)
               .sort()

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -187,28 +187,6 @@ export type RscPluginOptions = {
    *
    * @param id - The absolute path of the client module
    * @returns The chunk name to group this module with, or undefined to use default behavior
-   *
-   * @example
-   * ```js
-   * clientChunks(id) {
-   *   // Group all client components in a specific route together
-   *   if (id.includes('/src/routes/dashboard/')) {
-   *     return 'dashboard-clients'
-   *   }
-   *   // Group third-party client components
-   *   if (id.includes('node_modules/@company/ui/')) {
-   *     return 'vendor-ui'
-   *   }
-   * }
-   * ```
-   *
-   * Benefits:
-   * - Reduces the number of HTTP requests by bundling related client components
-   * - Improves loading performance for route-based code splitting
-   * - Allows fine-grained control over client-side bundle optimization
-   *
-   * Note: Tree-shaking is still applied, so only the actually used exports
-   * from each module will be included in the final chunk.
    */
   clientChunks?: (id: string) => string | undefined
 }


### PR DESCRIPTION
### Description

- Closes https://github.com/vitejs/vite-plugin-react/issues/605

## todo

- [x] test
- [x] doc
- [ ] group based on rsc async chunk (follow up) https://github.com/vitejs/vite-plugin-react/pull/767
 
## idea

Example:

Use `clientChunks` to specify custom grouping  `custom-a = mod1, mod2` and `custom-b = mod3`

```js
plugins: [
  rsc({
    clientChunks: (id) => {
      if (id === 'mod1' || id === 'mod2') return 'custom-a'
      if (id === 'mod3') return 'custom-b'
    }
  })
]
```

Internally virtual modules will look like following:

```js
// virtual:vite-rsc/client-references
// (the shape of this virtual is same as before)
export default {
  mod1: async () => {
    const m = await import("virtual:vite-rsc/client-reference/group/custom-a");
    return m.export_mod1;
  },
  mod2: () => {
    const m = await import("virtual:vite-rsc/client-reference/group/custom-a");
    return m.export_mod2;     
  },
  mod3: () => {
    const m = await import("virtual:vite-rsc/client-reference/group/custom-b");
    return m.export_mod3; 
  }
}

// virtual:vite-rsc/client-reference/group/custom-a
import * as import_mod1 from "(mod1)";
import * as import_mod2 from "(mod2)";
export const export_mod1 = { 
  // filter by `renderedExports` to tree shake unued client components
  // (this is a same logic as before)
  Counter: import_mod1.Counter,
  ...
}
export const export_mod2 = { ... import_mod2 ... }

// virtual:vite-rsc/client-reference/group/custom-b
import * as import_mod3 from "(mod3)";
export const export_mod3 = { ... import_mod3 ... }
```
