### PR TITLE
feat(rsc): ability to merge client reference chunks based on server chunk usage

### DIFF
--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -60,6 +60,31 @@ test.describe('build-default', () => {
   })
 })
 
+test.describe('build-server-client-chunks', () => {
+  const f = useFixture({
+    root: 'examples/basic',
+    mode: 'build',
+    cliOptions: {
+      env: {
+        TEST_SERVER_CLIENT_CHUNKS: 'true',
+      },
+    },
+  })
+
+  defineTest(f)
+
+  test('custom client chunk', async () => {
+    const { chunks }: { chunks: Rollup.OutputChunk[] } = JSON.parse(
+      f.createEditor('dist/client/.vite/test.json').read(),
+    )
+    const chunk = chunks.find((c) => c.name === 'root')
+    const expected = [1, 2, 3].map((i) =>
+      normalizePath(path.join(f.root, `src/routes/chunk/client${i}.tsx`)),
+    )
+    expect(chunk?.moduleIds).toEqual(expect.arrayContaining(expected))
+  })
+})
+
 test.describe('dev-non-optimized-cjs', () => {
   test.beforeAll(async () => {
     // remove explicitly added optimizeDeps.include

--- a/packages/plugin-rsc/examples/basic/vite.config.ts
+++ b/packages/plugin-rsc/examples/basic/vite.config.ts
@@ -31,13 +31,13 @@ export default defineConfig({
       rscCssTransform: false,
       copyServerAssetsToClient: (fileName) =>
         fileName !== '__server_secret.txt',
-      // clientChunks(id) {
-      //   if (id.includes('/src/routes/chunk/')) {
-      //     return 'custom-chunk'
-      //   }
-      // },
       clientChunks(meta) {
-        return meta.serverChunk
+        if (process.env.TEST_SERVER_CLIENT_CHUNKS) {
+          return meta.serverChunk
+        }
+        if (meta.id.includes('/src/routes/chunk/')) {
+          return 'custom-chunk'
+        }
       },
     }),
     {

--- a/packages/plugin-rsc/examples/basic/vite.config.ts
+++ b/packages/plugin-rsc/examples/basic/vite.config.ts
@@ -36,7 +36,9 @@ export default defineConfig({
       //     return 'custom-chunk'
       //   }
       // },
-      clientChunks: 'server',
+      clientChunks(_id, meta) {
+        return meta.serverChunk
+      },
     }),
     {
       name: 'test-tree-shake',

--- a/packages/plugin-rsc/examples/basic/vite.config.ts
+++ b/packages/plugin-rsc/examples/basic/vite.config.ts
@@ -31,11 +31,12 @@ export default defineConfig({
       rscCssTransform: false,
       copyServerAssetsToClient: (fileName) =>
         fileName !== '__server_secret.txt',
-      clientChunks(id) {
-        if (id.includes('/src/routes/chunk/')) {
-          return 'custom-chunk'
-        }
-      },
+      // clientChunks(id) {
+      //   if (id.includes('/src/routes/chunk/')) {
+      //     return 'custom-chunk'
+      //   }
+      // },
+      clientChunks: 'server',
     }),
     {
       name: 'test-tree-shake',

--- a/packages/plugin-rsc/examples/basic/vite.config.ts
+++ b/packages/plugin-rsc/examples/basic/vite.config.ts
@@ -36,7 +36,7 @@ export default defineConfig({
       //     return 'custom-chunk'
       //   }
       // },
-      clientChunks(_id, meta) {
+      clientChunks(meta) {
         return meta.serverChunk
       },
     }),

--- a/packages/plugin-rsc/examples/starter/vite.config.ts
+++ b/packages/plugin-rsc/examples/starter/vite.config.ts
@@ -6,8 +6,6 @@ import { defineConfig } from 'vite'
 export default defineConfig({
   plugins: [
     rsc({
-      clientChunks: 'server',
-
       // `entries` option is only a shorthand for specifying each `rollupOptions.input` below
       // > entries: { rsc, ssr, client },
       //

--- a/packages/plugin-rsc/examples/starter/vite.config.ts
+++ b/packages/plugin-rsc/examples/starter/vite.config.ts
@@ -6,6 +6,8 @@ import { defineConfig } from 'vite'
 export default defineConfig({
   plugins: [
     rsc({
+      clientChunks: 'server',
+
       // `entries` option is only a shorthand for specifying each `rollupOptions.input` below
       // > entries: { rsc, ssr, client },
       //

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -188,7 +188,10 @@ export type RscPluginOptions = {
    * @param id - The absolute path of the client module
    * @returns The chunk name to group this module with, or undefined to use default behavior
    */
-  clientChunks?: 'server' | ((id: string) => string | undefined)
+  clientChunks?: (
+    id: string,
+    meta: { serverChunk?: string },
+  ) => string | undefined
 }
 
 /** @experimental */
@@ -1142,11 +1145,11 @@ function vitePluginUseClient(
             return { code, map: null }
           }
           let code = ''
-          const serverIdsToGroup: Record<string, string> = {}
+          const serverChunkMap: Record<string, string> = {}
           for (const chunk of Object.values(manager.rscBundle)) {
             if (chunk.type === 'chunk') {
               for (const id of chunk.moduleIds) {
-                serverIdsToGroup[id] = normalizePath(
+                serverChunkMap[id] = normalizePath(
                   path.relative(
                     manager.config.root,
                     chunk.facadeModuleId || chunk.moduleIds[0]!,
@@ -1157,26 +1160,13 @@ function vitePluginUseClient(
           }
           // group client reference modules by `clientChunks` option
           manager.clientReferenceGroups = {}
-          // let clinentChunksFn: (id: string) => string;
-          // if (useClientPluginOptions.clientChunks === 'server') {
-          //   clinentChunksFn = (id) => serverIdsToGroup[id]!
-          // } else {
-          // }
-          //  = useClientPluginOptions.clientChunks;
           for (const meta of Object.values(manager.clientReferenceMetaMap)) {
-            let name = normalizePath(
-              path.relative(manager.config.root, meta.importId),
-            )
-            if (useClientPluginOptions.clientChunks === 'server') {
-              name = serverIdsToGroup[meta.importId] || name
-            } else if (useClientPluginOptions.clientChunks) {
-              name = useClientPluginOptions.clientChunks(meta.importId) || name
-            }
-            // clientChunks === 'server' ? serverIdsToGroup[meta.importId]
-            // const name =
-            //   clientChunks?.(meta.importId) ||
-            //   // use original module id as name by default
-            //   normalizePath(path.relative(manager.config.root, meta.importId))
+            const name =
+              useClientPluginOptions.clientChunks?.(meta.importId, {
+                serverChunk: serverChunkMap[meta.importId],
+              }) ||
+              // use original module id as name by default
+              normalizePath(path.relative(manager.config.root, meta.importId))
             const group = (manager.clientReferenceGroups[name] ??= [])
             group.push(meta)
           }

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1263,12 +1263,14 @@ function vitePluginUseClient(
               const meta = manager.clientReferenceMetaMap[id]
               if (meta) {
                 meta.renderedExports = mod.renderedExports
-                meta.serverChunk = normalizePath(
-                  path.relative(
-                    manager.config.root,
-                    chunk.facadeModuleId ?? [...chunk.moduleIds].sort()[0]!,
-                  ),
-                )
+                meta.serverChunk =
+                  (chunk.facadeModuleId ? 'facade:' : 'non-facade:') +
+                  normalizePath(
+                    path.relative(
+                      manager.config.root,
+                      chunk.facadeModuleId ?? [...chunk.moduleIds].sort()[0]!,
+                    ),
+                  )
               }
             }
           }

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1145,11 +1145,12 @@ function vitePluginUseClient(
             return { code, map: null }
           }
           let code = ''
-          const serverChunkMap: Record<string, string> = {}
+          // collect chunk mapping of client reference (proxy modules) on rsc build
+          const serverChunks: Record<string, string> = {}
           for (const chunk of Object.values(manager.rscBundle)) {
             if (chunk.type === 'chunk') {
               for (const id of chunk.moduleIds) {
-                serverChunkMap[id] = normalizePath(
+                serverChunks[id] = normalizePath(
                   path.relative(
                     manager.config.root,
                     chunk.facadeModuleId || chunk.moduleIds[0]!,
@@ -1163,7 +1164,7 @@ function vitePluginUseClient(
           for (const meta of Object.values(manager.clientReferenceMetaMap)) {
             const name =
               useClientPluginOptions.clientChunks?.(meta.importId, {
-                serverChunk: serverChunkMap[meta.importId],
+                serverChunk: serverChunks[meta.importId],
               }) ||
               // use original module id as name by default
               normalizePath(path.relative(manager.config.root, meta.importId))

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1154,10 +1154,11 @@ function vitePluginUseClient(
               }) ??
               // use original module id as name by default
               normalizePath(path.relative(manager.config.root, meta.importId))
-            name = name.replace(/\b\.\.\b/, '__')
+            name = name.replaceAll('..', '__')
             const group = (manager.clientReferenceGroups[name] ??= [])
             group.push(meta)
           }
+          debug('client-reference-groups', manager.clientReferenceGroups)
           for (const [name, metas] of Object.entries(
             manager.clientReferenceGroups,
           )) {

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -185,10 +185,11 @@ export type RscPluginOptions = {
    *
    * This function allows you to group multiple client components into
    * custom chunks instead of having each module in its own chunk.
-   *
    */
   clientChunks?: (meta: {
+    /** client reference module id */
     id: string
+    /** server chunk which includes a corresponding client reference proxy module */
     serverChunk: string
   }) => string | undefined
 }

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1142,6 +1142,12 @@ function vitePluginUseClient(
             return { code, map: null }
           }
           let code = ''
+          for (const chunk of Object.values(manager.rscBundle)) {
+            if (chunk.type === 'chunk') {
+              chunk.name
+              chunk.moduleIds
+            }
+          }
           // group client reference modules by `clientChunks` option
           manager.clientReferenceGroups = {}
           for (const meta of Object.values(manager.clientReferenceMetaMap)) {

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1151,7 +1151,7 @@ function vitePluginUseClient(
               useClientPluginOptions.clientChunks?.({
                 id: meta.importId,
                 serverChunk: meta.serverChunk!,
-              }) ||
+              }) ??
               // use original module id as name by default
               normalizePath(path.relative(manager.config.root, meta.importId))
             const group = (manager.clientReferenceGroups[name] ??= [])
@@ -1264,7 +1264,7 @@ function vitePluginUseClient(
                 meta.serverChunk = normalizePath(
                   path.relative(
                     manager.config.root,
-                    chunk.facadeModuleId || chunk.moduleIds[0]!,
+                    chunk.facadeModuleId ?? chunk.fileName,
                   ),
                 )
               }

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1147,13 +1147,14 @@ function vitePluginUseClient(
           // group client reference modules by `clientChunks` option
           manager.clientReferenceGroups = {}
           for (const meta of Object.values(manager.clientReferenceMetaMap)) {
-            const name =
+            let name =
               useClientPluginOptions.clientChunks?.({
                 id: meta.importId,
                 serverChunk: meta.serverChunk!,
               }) ??
               // use original module id as name by default
               normalizePath(path.relative(manager.config.root, meta.importId))
+            name = name.replace(/\b\.\.\b/, '__')
             const group = (manager.clientReferenceGroups[name] ??= [])
             group.push(meta)
           }

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1266,7 +1266,7 @@ function vitePluginUseClient(
                 meta.serverChunk = normalizePath(
                   path.relative(
                     manager.config.root,
-                    chunk.facadeModuleId ?? chunk.fileName,
+                    chunk.facadeModuleId ?? [...chunk.moduleIds].sort()[0]!,
                   ),
                 )
               }


### PR DESCRIPTION
### Description

- follow up to https://github.com/vitejs/vite-plugin-react/pull/766

It should be already possible on user land, but this PR adds pass more metadata to `clientChunks` option to do it easily.

This means that controlling server chunk _is_ a way to controlling client reference chunks. And it looks like this actually ends up with a same code splitting strategy as Parcel https://devongovett.me/blog/parcel-rsc.html.

> One interesting thing you might notice is that "use client" is not an explicit code splitting point like dynamic import().

TODO
- [x] test
- [x] doc
- [ ] enabled by default?
- [x] investigate non-preloaded assets in https://github.com/wakujs/waku/pull/1653