### PR TITLE
fix(rsc): fix client reference preload when group chunk re-exports client components from entry chunk

### DIFF
--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -63,7 +63,7 @@ type ClientReferenceMeta = {
   // build only for tree-shaking unused export
   exportNames: string[]
   renderedExports: string[]
-  clientGroupId?: string
+  groupChunkId?: string
 }
 
 type ServerRerferenceMeta = {
@@ -802,7 +802,7 @@ export default function vitePluginRsc(
           const entryUrl = assetsURL(entry.chunk.fileName, manager)
           const clientReferenceDeps: Record<string, AssetDeps> = {}
           for (const meta of Object.values(manager.clientReferenceMetaMap)) {
-            const deps: AssetDeps = assetDeps[meta.clientGroupId!]?.deps ?? {
+            const deps: AssetDeps = assetDeps[meta.groupChunkId!]?.deps ?? {
               js: [],
               css: [],
             }
@@ -1154,7 +1154,7 @@ function vitePluginUseClient(
             name = name.replaceAll('..', '__')
             const group = (manager.clientReferenceGroups[name] ??= [])
             group.push(meta)
-            meta.clientGroupId = `\0virtual:vite-rsc/client-references/group/${name}`
+            meta.groupChunkId = `\0virtual:vite-rsc/client-references/group/${name}`
           }
           debug('client-reference-groups', manager.clientReferenceGroups)
           for (const [name, metas] of Object.entries(


### PR DESCRIPTION
### Description

- regression from https://github.com/vitejs/vite-plugin-react/pull/766

https://github.com/vitejs/vite-plugin-react/pull/766 broke modulepreload of group virtual chunk when the actual client references are included in entry chunk. For example, in https://github.com/wakujs/waku/pull/1653, Waku's client entry chunk itself includes waku's internal client components (e.g. Link) and group virtual re-exports them.