### PR TITLE
fix(rsc): normalize group chunk virtual id properly

### DIFF
--- a/packages/plugin-rsc/examples/react-router/vite.config.ts
+++ b/packages/plugin-rsc/examples/react-router/vite.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
         ssr: './react-router-vite/entry.ssr.tsx',
         rsc: './react-router-vite/entry.rsc.single.tsx',
       },
+      clientChunks: (meta) => meta.serverChunk,
     }),
   ],
   optimizeDeps: {

--- a/packages/plugin-rsc/examples/react-router/vite.config.ts
+++ b/packages/plugin-rsc/examples/react-router/vite.config.ts
@@ -19,7 +19,6 @@ export default defineConfig({
         ssr: './react-router-vite/entry.ssr.tsx',
         rsc: './react-router-vite/entry.rsc.single.tsx',
       },
-      clientChunks: (meta) => meta.serverChunk,
     }),
   ],
   optimizeDeps: {

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1160,7 +1160,7 @@ function vitePluginUseClient(
               // use original module id as name by default
               manager.toRelativeId(meta.importId)
             // ensure clean virtual id to avoid interfering with other plugins
-            name = cleanUrl(name.replaceAll('..', '__')) + '?lang.js'
+            name = cleanUrl(name.replaceAll('..', '__'))
             const group = (manager.clientReferenceGroups[name] ??= [])
             group.push(meta)
             meta.groupChunkId = `\0virtual:vite-rsc/client-references/group/${name}`

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1158,7 +1158,7 @@ function vitePluginUseClient(
               // use original module id as name by default
               normalizePath(path.relative(manager.config.root, meta.importId))
             // ensure clean virtual id to avoid interfering with other plugins
-            name = cleanUrl(name.replaceAll('..', '__')) + '&lang.js'
+            name = cleanUrl(name.replaceAll('..', '__')) + '?lang.js'
             const group = (manager.clientReferenceGroups[name] ??= [])
             group.push(meta)
             meta.groupChunkId = `\0virtual:vite-rsc/client-references/group/${name}`
@@ -1300,32 +1300,6 @@ function vitePluginUseClient(
                 meta.serverChunk = serverChunk
               }
             }
-            // // const metas: [string, ]
-            // // const metas = chunk.moduleIds.map(id => manager.clientReferenceMetaMap[id]).filter(typedBoolean)
-            // // if (metas.length > 0) {
-            // //   for (const meta of metas) {
-            // //     const mod = chunk.modules[meta.importId]
-            // //     if (mod) {
-            // //       meta.renderedExports.push(...mod.renderedExports)
-            // //     }
-            // //   }
-            // // }
-            // for (const [id, mod] of Object.entries(chunk.modules)) {
-            //   const meta = manager.clientReferenceMetaMap[id]
-            //   if (meta) {
-            //     meta.renderedExports = mod.renderedExports
-            //     const normalized = normalizePath(
-            //       path.relative(
-            //         manager.config.root,
-            //         chunk.facadeModuleId ?? [...chunk.moduleIds].sort()[0]!,
-            //       ),
-            //     )
-            //     meta.serverChunk =
-            //       (chunk.facadeModuleId ? 'facade:' : 'non-facade:') +
-            //       // clean url to avoid special query (e.g. `?commonjs-exports`)
-            //       cleanUrl(normalized)
-            //   }
-            // }
           }
         }
       },

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1267,14 +1267,16 @@ function vitePluginUseClient(
               const meta = manager.clientReferenceMetaMap[id]
               if (meta) {
                 meta.renderedExports = mod.renderedExports
+                const normalized = normalizePath(
+                  path.relative(
+                    manager.config.root,
+                    chunk.facadeModuleId ?? [...chunk.moduleIds].sort()[0]!,
+                  ),
+                )
                 meta.serverChunk =
                   (chunk.facadeModuleId ? 'facade:' : 'non-facade:') +
-                  normalizePath(
-                    path.relative(
-                      manager.config.root,
-                      chunk.facadeModuleId ?? [...chunk.moduleIds].sort()[0]!,
-                    ),
-                  )
+                  // clean url to avoid special query (e.g. `?commonjs-exports`)
+                  cleanUrl(normalized)
               }
             }
           }


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

https://github.com/wakujs/waku/pull/1653 is broken when group virtual id ends up with special query such as `?commonjs-exports`, for example,

```sh
$ DEBUG=vite-rsc:use-client pnpm -C e2e/fixtures/use-router build
...
  'non-facade:\x00/home/hiroshi/code/others/waku/node_modules/.pnpm/react@19.1.1/node_modules/react/cjs/react-jsx-runtime.react-server.development.js?commonjs-exports': [
    {
      importId: '/home/hiroshi/code/others/waku/e2e/fixtures/use-router/src/TestRouter.tsx',
      referenceKey: '8a1f82ac61f9',
      packageSource: undefined,
      exportNames: [Array],
      renderedExports: [Array],
      serverChunk: 'non-facade:\x00/home/hiroshi/code/others/waku/node_modules/.pnpm/react@19.1.1/node_modules/react/cjs/react-jsx-runtime.react-server.development.js?commonjs-exports',
      groupChunkId: '\x00virtual:vite-rsc/client-references/group/non-facade:\x00/home/hiroshi/code/others/waku/node_modules/.pnpm/react@19.1.1/node_modules/react/cjs/react-jsx-runtime.react-server.development.js?commonjs-exports'
    }
  ],
...
```
