### PR TITLE
chore(rsc): fix `useBuildAppHook: true` with cloudflare plugin

### DIFF
--- a/packages/plugin-rsc/examples/starter-cf-single/vite.config.ts
+++ b/packages/plugin-rsc/examples/starter-cf-single/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
       },
       serverHandler: false,
       loadModuleDevProxy: true,
+      useBuildAppHook: true,
     }),
     cloudflare({
       configPath: './wrangler.jsonc',

--- a/packages/plugin-rsc/examples/starter-cf-single/vite.config.ts
+++ b/packages/plugin-rsc/examples/starter-cf-single/vite.config.ts
@@ -50,4 +50,9 @@ export default defineConfig({
       },
     },
   },
+  builder: {
+    // empty buildApp to disable cloudflare's buildApp
+    // https://github.com/cloudflare/workers-sdk/blob/19e2aab1d68594c7289d0aa16474544919fd5b9b/packages/vite-plugin-cloudflare/src/index.ts#L183-L186
+    buildApp: async () => {},
+  },
 })


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

- Related https://github.com/wakujs/waku/pull/1655

By default, cloudflare tries to run own build https://github.com/cloudflare/workers-sdk/blob/19e2aab1d68594c7289d0aa16474544919fd5b9b/packages/vite-plugin-cloudflare/src/index.ts#L183-L186, so the users would need empty `builder.buildApp` to prevent that.