### PR TITLE
test(rsc): test `hydrateRoot(..., { formState })`

### DIFF
--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -238,7 +238,10 @@ function defineTest(f: Fixture) {
     await testUseActionState(page)
   })
 
-  test('useActionState nojs to js', async ({ page }) => {
+  test('useActionState nojs to js', async ({ page, browserName }) => {
+    // firefox seems to cache html and route interception doesn't work
+    test.skip(browserName === 'firefox')
+
     // this test fails without `formState` passed to `hydrateRoot(..., { formState })`
 
     // intercept request to disable js

--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -238,6 +238,39 @@ function defineTest(f: Fixture) {
     await testUseActionState(page)
   })
 
+  test('useActionState nojs to js', async ({ page }) => {
+    // this test fails without `formState` passed to `hydrateRoot(..., { formState })`
+
+    // intercept request to disable js
+    let js: boolean
+    await page.route(f.url(), async (route) => {
+      if (!js) {
+        await route.continue({ url: route.request().url() + '?__nojs' })
+        return
+      }
+      await route.continue()
+    })
+
+    // no js
+    js = false
+    await page.goto(f.url())
+    await expect(page.getByTestId('use-action-state')).toContainText(
+      'test-useActionState: 0',
+    )
+    await page.getByTestId('use-action-state').click()
+    await expect(page.getByTestId('use-action-state')).toContainText(
+      'test-useActionState: 1',
+    )
+
+    // with js (hydration)
+    js = true
+    await page.getByTestId('use-action-state').click()
+    await waitForHydration(page)
+    await expect(page.getByTestId('use-action-state')).toContainText(
+      'test-useActionState: 2', // this becomes "0" without formState
+    )
+  })
+
   async function testUseActionState(page: Page) {
     await expect(page.getByTestId('use-action-state')).toContainText(
       'test-useActionState: 0',


### PR DESCRIPTION
### Description

Added a test case to verify this sneaky React feature:

https://github.com/vitejs/vite-plugin-react/blob/a36d91b0c9344ec95e8cf4fd8412eb646a35745d/packages/plugin-rsc/examples/basic/src/framework/entry.browser.tsx#L73-L75