### PR TITLE
chore(deps): update `@types/react-dom` to fix `formState`

### DIFF
--- a/packages/plugin-react-swc/playground/base-path/package.json
+++ b/packages/plugin-react-swc/playground/base-path/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@types/react": "^19.1.11",
-    "@types/react-dom": "^19.1.7",
+    "@types/react-dom": "^19.1.8",
     "@vitejs/plugin-react-swc": "../../dist"
   }
 }

--- a/packages/plugin-react-swc/playground/class-components/package.json
+++ b/packages/plugin-react-swc/playground/class-components/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@types/react": "^19.1.11",
-    "@types/react-dom": "^19.1.7",
+    "@types/react-dom": "^19.1.8",
     "@vitejs/plugin-react-swc": "../../dist"
   }
 }

--- a/packages/plugin-react-swc/playground/decorators/package.json
+++ b/packages/plugin-react-swc/playground/decorators/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@types/react": "^19.1.11",
-    "@types/react-dom": "^19.1.7",
+    "@types/react-dom": "^19.1.8",
     "@vitejs/plugin-react-swc": "../../dist"
   }
 }

--- a/packages/plugin-react-swc/playground/emotion-plugin/package.json
+++ b/packages/plugin-react-swc/playground/emotion-plugin/package.json
@@ -14,9 +14,9 @@
     "react-dom": "^19.1.1"
   },
   "devDependencies": {
+    "@swc/plugin-emotion": "^11.0.2",
     "@types/react": "^19.1.11",
-    "@types/react-dom": "^19.1.7",
-    "@vitejs/plugin-react-swc": "../../dist",
-    "@swc/plugin-emotion": "^11.0.2"
+    "@types/react-dom": "^19.1.8",
+    "@vitejs/plugin-react-swc": "../../dist"
   }
 }

--- a/packages/plugin-react-swc/playground/emotion/package.json
+++ b/packages/plugin-react-swc/playground/emotion/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@types/react": "^19.1.11",
-    "@types/react-dom": "^19.1.7",
+    "@types/react-dom": "^19.1.8",
     "@vitejs/plugin-react-swc": "../../dist"
   }
 }

--- a/packages/plugin-react-swc/playground/hmr/package.json
+++ b/packages/plugin-react-swc/playground/hmr/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@types/react": "^19.1.11",
-    "@types/react-dom": "^19.1.7",
+    "@types/react-dom": "^19.1.8",
     "@vitejs/plugin-react-swc": "../../dist"
   }
 }

--- a/packages/plugin-react-swc/playground/mdx/package.json
+++ b/packages/plugin-react-swc/playground/mdx/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@mdx-js/rollup": "^3.1.0",
     "@types/react": "^19.1.11",
-    "@types/react-dom": "^19.1.7",
+    "@types/react-dom": "^19.1.8",
     "@vitejs/plugin-react-swc": "../../dist"
   }
 }

--- a/packages/plugin-react-swc/playground/react-18/package.json
+++ b/packages/plugin-react-swc/playground/react-18/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@types/react": "^18.3.18",
-    "@types/react-dom": "^18.3.5",
+    "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-react-swc": "../../dist"
   }
 }

--- a/packages/plugin-react-swc/playground/shadow-export/package.json
+++ b/packages/plugin-react-swc/playground/shadow-export/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@types/react": "^19.1.11",
-    "@types/react-dom": "^19.1.7",
+    "@types/react-dom": "^19.1.8",
     "@vitejs/plugin-react-swc": "../../dist"
   }
 }

--- a/packages/plugin-react-swc/playground/styled-components/package.json
+++ b/packages/plugin-react-swc/playground/styled-components/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@swc/plugin-styled-components": "^9.0.3",
     "@types/react": "^19.1.11",
-    "@types/react-dom": "^19.1.7",
+    "@types/react-dom": "^19.1.8",
     "@types/styled-components": "^5.1.34",
     "@vitejs/plugin-react-swc": "../../dist"
   }

--- a/packages/plugin-react-swc/playground/ts-lib/package.json
+++ b/packages/plugin-react-swc/playground/ts-lib/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@types/react": "^19.1.11",
-    "@types/react-dom": "^19.1.7",
+    "@types/react-dom": "^19.1.8",
     "@vitejs/plugin-react-swc": "../../dist"
   }
 }

--- a/packages/plugin-react-swc/playground/worker/package.json
+++ b/packages/plugin-react-swc/playground/worker/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@types/react": "^19.1.11",
-    "@types/react-dom": "^19.1.7",
+    "@types/react-dom": "^19.1.8",
     "@vitejs/plugin-react-swc": "../../dist"
   }
 }

--- a/packages/plugin-rsc/examples/basic/package.json
+++ b/packages/plugin-rsc/examples/basic/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.12",
     "@types/react": "^19.1.11",
-    "@types/react-dom": "^19.1.7",
+    "@types/react-dom": "^19.1.8",
     "@vitejs/plugin-react": "latest",
     "@vitejs/plugin-rsc": "latest",
     "@vitejs/test-dep-client-in-server": "file:./test-dep/client-in-server",

--- a/packages/plugin-rsc/examples/basic/src/framework/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/basic/src/framework/entry.ssr.tsx
@@ -39,8 +39,7 @@ export async function renderHTML(
       ? undefined
       : bootstrapScriptContent,
     nonce: options?.nonce,
-    // no types
-    ...{ formState: options?.formState },
+    formState: options?.formState,
   })
 
   let responseStream: ReadableStream<Uint8Array> = htmlStream

--- a/packages/plugin-rsc/examples/browser-mode/package.json
+++ b/packages/plugin-rsc/examples/browser-mode/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@types/react": "^19.1.11",
-    "@types/react-dom": "^19.1.7",
+    "@types/react-dom": "^19.1.8",
     "@vitejs/plugin-react": "latest",
     "@vitejs/plugin-rsc": "latest",
     "vite": "^7.1.3"

--- a/packages/plugin-rsc/examples/no-ssr/package.json
+++ b/packages/plugin-rsc/examples/no-ssr/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@types/react": "^19.1.11",
-    "@types/react-dom": "^19.1.7",
+    "@types/react-dom": "^19.1.8",
     "@vitejs/plugin-react": "latest",
     "@vitejs/plugin-rsc": "latest",
     "vite": "^7.1.3"

--- a/packages/plugin-rsc/examples/react-router/package.json
+++ b/packages/plugin-rsc/examples/react-router/package.json
@@ -22,7 +22,7 @@
     "@tailwindcss/typography": "^0.5.16",
     "@tailwindcss/vite": "^4.1.12",
     "@types/react": "^19.1.11",
-    "@types/react-dom": "^19.1.7",
+    "@types/react-dom": "^19.1.8",
     "@vitejs/plugin-react": "latest",
     "@vitejs/plugin-rsc": "latest",
     "tailwindcss": "^4.1.12",

--- a/packages/plugin-rsc/examples/ssg/package.json
+++ b/packages/plugin-rsc/examples/ssg/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@mdx-js/rollup": "^3.1.0",
     "@types/react": "^19.1.11",
-    "@types/react-dom": "^19.1.7",
+    "@types/react-dom": "^19.1.8",
     "@vitejs/plugin-react": "latest",
     "@vitejs/plugin-rsc": "latest"
   }

--- a/packages/plugin-rsc/examples/starter-cf-single/package.json
+++ b/packages/plugin-rsc/examples/starter-cf-single/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.11.7",
     "@types/react": "^19.1.11",
-    "@types/react-dom": "^19.1.7",
+    "@types/react-dom": "^19.1.8",
     "@vitejs/plugin-react": "latest",
     "@vitejs/plugin-rsc": "latest",
     "rsc-html-stream": "^0.0.7",

--- a/packages/plugin-rsc/examples/starter-cf-single/src/framework/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/starter-cf-single/src/framework/entry.ssr.tsx
@@ -37,8 +37,7 @@ export async function renderHTML(
       ? undefined
       : bootstrapScriptContent,
     nonce: options?.nonce,
-    // no types
-    ...{ formState: options?.formState },
+    formState: options?.formState,
   })
 
   let responseStream: ReadableStream<Uint8Array> = htmlStream

--- a/packages/plugin-rsc/examples/starter/package.json
+++ b/packages/plugin-rsc/examples/starter/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@types/react": "^19.1.11",
-    "@types/react-dom": "^19.1.7",
+    "@types/react-dom": "^19.1.8",
     "@vitejs/plugin-react": "latest",
     "@vitejs/plugin-rsc": "latest",
     "rsc-html-stream": "^0.0.7",

--- a/packages/plugin-rsc/examples/starter/src/framework/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/starter/src/framework/entry.ssr.tsx
@@ -44,8 +44,7 @@ export async function renderHTML(
       ? undefined
       : bootstrapScriptContent,
     nonce: options?.nonce,
-    // no types
-    ...{ formState: options?.formState },
+    formState: options?.formState,
   })
 
   let responseStream: ReadableStream<Uint8Array> = htmlStream

--- a/packages/plugin-rsc/package.json
+++ b/packages/plugin-rsc/package.json
@@ -53,7 +53,7 @@
     "@types/estree": "^1.0.8",
     "@types/node": "^22.18.0",
     "@types/react": "^19.1.11",
-    "@types/react-dom": "^19.1.7",
+    "@types/react-dom": "^19.1.8",
     "@vitejs/plugin-react": "workspace:*",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/packages/plugin-rsc/src/extra/ssr.tsx
+++ b/packages/plugin-rsc/src/extra/ssr.tsx
@@ -36,8 +36,7 @@ export async function renderHtml(
       ? undefined
       : bootstrapScriptContent,
     nonce: options?.nonce,
-    // no types
-    ...{ formState: options?.formState },
+    formState: options?.formState,
   })
 
   let responseStream: ReadableStream<Uint8Array> = htmlStream

--- a/playground/class-components/package.json
+++ b/playground/class-components/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@types/react": "^19.1.11",
-    "@types/react-dom": "^19.1.7",
+    "@types/react-dom": "^19.1.8",
     "@vitejs/plugin-react": "workspace:*"
   }
 }

--- a/playground/compiler-react-18/package.json
+++ b/playground/compiler-react-18/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@babel/plugin-transform-react-jsx-development": "^7.27.1",
     "@types/react": "^18.3.20",
-    "@types/react-dom": "^18.3.6",
+    "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-react": "workspace:*",
     "babel-plugin-react-compiler": "19.1.0-rc.2",
     "typescript": "^5.9.2"

--- a/playground/compiler/package.json
+++ b/playground/compiler/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@babel/plugin-transform-react-jsx-development": "^7.27.1",
     "@types/react": "^19.1.11",
-    "@types/react-dom": "^19.1.7",
+    "@types/react-dom": "^19.1.8",
     "@vitejs/plugin-react": "workspace:*",
     "babel-plugin-react-compiler": "19.1.0-rc.2",
     "typescript": "^5.9.2"

--- a/playground/hmr-false/package.json
+++ b/playground/hmr-false/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@types/react": "^19.1.11",
-    "@types/react-dom": "^19.1.7",
+    "@types/react-dom": "^19.1.8",
     "@vitejs/plugin-react": "workspace:*"
   }
 }

--- a/playground/hook-with-jsx/package.json
+++ b/playground/hook-with-jsx/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@types/react": "^19.1.11",
-    "@types/react-dom": "^19.1.7",
+    "@types/react-dom": "^19.1.8",
     "@vitejs/plugin-react": "workspace:*"
   }
 }

--- a/playground/include-node-modules/package.json
+++ b/playground/include-node-modules/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@types/babel__core": "^7.20.5",
     "@types/react": "^19.1.11",
-    "@types/react-dom": "^19.1.7",
+    "@types/react-dom": "^19.1.8",
     "@vitejs/plugin-react": "workspace:*",
     "@vitejs/test-package": "file:./test-package"
   }

--- a/playground/mdx/package.json
+++ b/playground/mdx/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@mdx-js/rollup": "^3.1.0",
     "@types/react": "^19.1.11",
-    "@types/react-dom": "^19.1.7",
+    "@types/react-dom": "^19.1.8",
     "@vitejs/plugin-react": "workspace:*"
   }
 }

--- a/playground/react-emotion/package.json
+++ b/playground/react-emotion/package.json
@@ -19,7 +19,7 @@
     "@babel/plugin-proposal-pipeline-operator": "^7.27.1",
     "@emotion/babel-plugin": "^11.13.5",
     "@types/react": "^19.1.11",
-    "@types/react-dom": "^19.1.7",
+    "@types/react-dom": "^19.1.8",
     "@vitejs/plugin-react": "workspace:*"
   },
   "babel": {

--- a/playground/tsconfig-jsx-preserve/package.json
+++ b/playground/tsconfig-jsx-preserve/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@types/react": "^19.1.11",
-    "@types/react-dom": "^19.1.7",
+    "@types/react-dom": "^19.1.8",
     "@vitejs/plugin-react": "workspace:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,8 +186,8 @@ importers:
         specifier: ^19.1.11
         version: 19.1.11
       '@types/react-dom':
-        specifier: ^19.1.7
-        version: 19.1.7(@types/react@19.1.11)
+        specifier: ^19.1.8
+        version: 19.1.8(@types/react@19.1.11)
       '@vitejs/plugin-react-swc':
         specifier: ../../dist
         version: link:../../dist
@@ -205,8 +205,8 @@ importers:
         specifier: ^19.1.11
         version: 19.1.11
       '@types/react-dom':
-        specifier: ^19.1.7
-        version: 19.1.7(@types/react@19.1.11)
+        specifier: ^19.1.8
+        version: 19.1.8(@types/react@19.1.11)
       '@vitejs/plugin-react-swc':
         specifier: ../../dist
         version: link:../../dist
@@ -224,8 +224,8 @@ importers:
         specifier: ^19.1.11
         version: 19.1.11
       '@types/react-dom':
-        specifier: ^19.1.7
-        version: 19.1.7(@types/react@19.1.11)
+        specifier: ^19.1.8
+        version: 19.1.8(@types/react@19.1.11)
       '@vitejs/plugin-react-swc':
         specifier: ../../dist
         version: link:../../dist
@@ -249,8 +249,8 @@ importers:
         specifier: ^19.1.11
         version: 19.1.11
       '@types/react-dom':
-        specifier: ^19.1.7
-        version: 19.1.7(@types/react@19.1.11)
+        specifier: ^19.1.8
+        version: 19.1.8(@types/react@19.1.11)
       '@vitejs/plugin-react-swc':
         specifier: ../../dist
         version: link:../../dist
@@ -277,8 +277,8 @@ importers:
         specifier: ^19.1.11
         version: 19.1.11
       '@types/react-dom':
-        specifier: ^19.1.7
-        version: 19.1.7(@types/react@19.1.11)
+        specifier: ^19.1.8
+        version: 19.1.8(@types/react@19.1.11)
       '@vitejs/plugin-react-swc':
         specifier: ../../dist
         version: link:../../dist
@@ -296,8 +296,8 @@ importers:
         specifier: ^19.1.11
         version: 19.1.11
       '@types/react-dom':
-        specifier: ^19.1.7
-        version: 19.1.7(@types/react@19.1.11)
+        specifier: ^19.1.8
+        version: 19.1.8(@types/react@19.1.11)
       '@vitejs/plugin-react-swc':
         specifier: ../../dist
         version: link:../../dist
@@ -318,8 +318,8 @@ importers:
         specifier: ^19.1.11
         version: 19.1.11
       '@types/react-dom':
-        specifier: ^19.1.7
-        version: 19.1.7(@types/react@19.1.11)
+        specifier: ^19.1.8
+        version: 19.1.8(@types/react@19.1.11)
       '@vitejs/plugin-react-swc':
         specifier: ../../dist
         version: link:../../dist
@@ -337,8 +337,8 @@ importers:
         specifier: ^18.3.18
         version: 18.3.20
       '@types/react-dom':
-        specifier: ^18.3.5
-        version: 18.3.6(@types/react@18.3.20)
+        specifier: ^18.3.7
+        version: 18.3.7(@types/react@18.3.20)
       '@vitejs/plugin-react-swc':
         specifier: ../../dist
         version: link:../../dist
@@ -356,8 +356,8 @@ importers:
         specifier: ^19.1.11
         version: 19.1.11
       '@types/react-dom':
-        specifier: ^19.1.7
-        version: 19.1.7(@types/react@19.1.11)
+        specifier: ^19.1.8
+        version: 19.1.8(@types/react@19.1.11)
       '@vitejs/plugin-react-swc':
         specifier: ../../dist
         version: link:../../dist
@@ -384,8 +384,8 @@ importers:
         specifier: ^19.1.11
         version: 19.1.11
       '@types/react-dom':
-        specifier: ^19.1.7
-        version: 19.1.7(@types/react@19.1.11)
+        specifier: ^19.1.8
+        version: 19.1.8(@types/react@19.1.11)
       '@types/styled-components':
         specifier: ^5.1.34
         version: 5.1.34
@@ -409,8 +409,8 @@ importers:
         specifier: ^19.1.11
         version: 19.1.11
       '@types/react-dom':
-        specifier: ^19.1.7
-        version: 19.1.7(@types/react@19.1.11)
+        specifier: ^19.1.8
+        version: 19.1.8(@types/react@19.1.11)
       '@vitejs/plugin-react-swc':
         specifier: ../../dist
         version: link:../../dist
@@ -430,8 +430,8 @@ importers:
         specifier: ^19.1.11
         version: 19.1.11
       '@types/react-dom':
-        specifier: ^19.1.7
-        version: 19.1.7(@types/react@19.1.11)
+        specifier: ^19.1.8
+        version: 19.1.8(@types/react@19.1.11)
       '@vitejs/plugin-react-swc':
         specifier: ../../dist
         version: link:../../dist
@@ -479,8 +479,8 @@ importers:
         specifier: ^19.1.11
         version: 19.1.11
       '@types/react-dom':
-        specifier: ^19.1.7
-        version: 19.1.7(@types/react@19.1.11)
+        specifier: ^19.1.8
+        version: 19.1.8(@types/react@19.1.11)
       '@vitejs/plugin-react':
         specifier: workspace:*
         version: link:../plugin-react
@@ -519,8 +519,8 @@ importers:
         specifier: ^19.1.11
         version: 19.1.11
       '@types/react-dom':
-        specifier: ^19.1.7
-        version: 19.1.7(@types/react@19.1.11)
+        specifier: ^19.1.8
+        version: 19.1.8(@types/react@19.1.11)
       '@vitejs/plugin-react':
         specifier: latest
         version: link:../../../plugin-react
@@ -574,8 +574,8 @@ importers:
         specifier: ^19.1.11
         version: 19.1.11
       '@types/react-dom':
-        specifier: ^19.1.7
-        version: 19.1.7(@types/react@19.1.11)
+        specifier: ^19.1.8
+        version: 19.1.8(@types/react@19.1.11)
       '@vitejs/plugin-react':
         specifier: latest
         version: link:../../../plugin-react
@@ -611,8 +611,8 @@ importers:
         specifier: ^19.1.11
         version: 19.1.11
       '@types/react-dom':
-        specifier: ^19.1.7
-        version: 19.1.7(@types/react@19.1.11)
+        specifier: ^19.1.8
+        version: 19.1.8(@types/react@19.1.11)
       '@vitejs/plugin-react':
         specifier: latest
         version: link:../../../plugin-react
@@ -648,8 +648,8 @@ importers:
         specifier: ^19.1.11
         version: 19.1.11
       '@types/react-dom':
-        specifier: ^19.1.7
-        version: 19.1.7(@types/react@19.1.11)
+        specifier: ^19.1.8
+        version: 19.1.8(@types/react@19.1.11)
       '@vitejs/plugin-react':
         specifier: latest
         version: link:../../../plugin-react
@@ -682,8 +682,8 @@ importers:
         specifier: ^19.1.11
         version: 19.1.11
       '@types/react-dom':
-        specifier: ^19.1.7
-        version: 19.1.7(@types/react@19.1.11)
+        specifier: ^19.1.8
+        version: 19.1.8(@types/react@19.1.11)
       '@vitejs/plugin-react':
         specifier: latest
         version: link:../../../plugin-react
@@ -704,8 +704,8 @@ importers:
         specifier: ^19.1.11
         version: 19.1.11
       '@types/react-dom':
-        specifier: ^19.1.7
-        version: 19.1.7(@types/react@19.1.11)
+        specifier: ^19.1.8
+        version: 19.1.8(@types/react@19.1.11)
       '@vitejs/plugin-react':
         specifier: latest
         version: link:../../../plugin-react
@@ -735,8 +735,8 @@ importers:
         specifier: ^19.1.11
         version: 19.1.11
       '@types/react-dom':
-        specifier: ^19.1.7
-        version: 19.1.7(@types/react@19.1.11)
+        specifier: ^19.1.8
+        version: 19.1.8(@types/react@19.1.11)
       '@vitejs/plugin-react':
         specifier: latest
         version: link:../../../plugin-react
@@ -772,8 +772,8 @@ importers:
         specifier: ^19.1.11
         version: 19.1.11
       '@types/react-dom':
-        specifier: ^19.1.7
-        version: 19.1.7(@types/react@19.1.11)
+        specifier: ^19.1.8
+        version: 19.1.8(@types/react@19.1.11)
       '@vitejs/plugin-react':
         specifier: workspace:*
         version: link:../../packages/plugin-react
@@ -794,8 +794,8 @@ importers:
         specifier: ^19.1.11
         version: 19.1.11
       '@types/react-dom':
-        specifier: ^19.1.7
-        version: 19.1.7(@types/react@19.1.11)
+        specifier: ^19.1.8
+        version: 19.1.8(@types/react@19.1.11)
       '@vitejs/plugin-react':
         specifier: workspace:*
         version: link:../../packages/plugin-react
@@ -825,8 +825,8 @@ importers:
         specifier: ^18.3.20
         version: 18.3.20
       '@types/react-dom':
-        specifier: ^18.3.6
-        version: 18.3.6(@types/react@18.3.20)
+        specifier: ^18.3.7
+        version: 18.3.7(@types/react@18.3.20)
       '@vitejs/plugin-react':
         specifier: workspace:*
         version: link:../../packages/plugin-react
@@ -850,8 +850,8 @@ importers:
         specifier: ^19.1.11
         version: 19.1.11
       '@types/react-dom':
-        specifier: ^19.1.7
-        version: 19.1.7(@types/react@19.1.11)
+        specifier: ^19.1.8
+        version: 19.1.8(@types/react@19.1.11)
       '@vitejs/plugin-react':
         specifier: workspace:*
         version: link:../../packages/plugin-react
@@ -869,8 +869,8 @@ importers:
         specifier: ^19.1.11
         version: 19.1.11
       '@types/react-dom':
-        specifier: ^19.1.7
-        version: 19.1.7(@types/react@19.1.11)
+        specifier: ^19.1.8
+        version: 19.1.8(@types/react@19.1.11)
       '@vitejs/plugin-react':
         specifier: workspace:*
         version: link:../../packages/plugin-react
@@ -891,8 +891,8 @@ importers:
         specifier: ^19.1.11
         version: 19.1.11
       '@types/react-dom':
-        specifier: ^19.1.7
-        version: 19.1.7(@types/react@19.1.11)
+        specifier: ^19.1.8
+        version: 19.1.8(@types/react@19.1.11)
       '@vitejs/plugin-react':
         specifier: workspace:*
         version: link:../../packages/plugin-react
@@ -918,8 +918,8 @@ importers:
         specifier: ^19.1.11
         version: 19.1.11
       '@types/react-dom':
-        specifier: ^19.1.7
-        version: 19.1.7(@types/react@19.1.11)
+        specifier: ^19.1.8
+        version: 19.1.8(@types/react@19.1.11)
       '@vitejs/plugin-react':
         specifier: workspace:*
         version: link:../../packages/plugin-react
@@ -981,8 +981,8 @@ importers:
         specifier: ^19.1.11
         version: 19.1.11
       '@types/react-dom':
-        specifier: ^19.1.7
-        version: 19.1.7(@types/react@19.1.11)
+        specifier: ^19.1.8
+        version: 19.1.8(@types/react@19.1.11)
       '@vitejs/plugin-react':
         specifier: workspace:*
         version: link:../../packages/plugin-react
@@ -1041,8 +1041,8 @@ importers:
         specifier: ^19.1.11
         version: 19.1.11
       '@types/react-dom':
-        specifier: ^19.1.7
-        version: 19.1.7(@types/react@19.1.11)
+        specifier: ^19.1.8
+        version: 19.1.8(@types/react@19.1.11)
       '@vitejs/plugin-react':
         specifier: workspace:*
         version: link:../../packages/plugin-react
@@ -2324,13 +2324,13 @@ packages:
   '@types/prop-types@15.7.11':
     resolution: {integrity: sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==}
 
-  '@types/react-dom@18.3.6':
-    resolution: {integrity: sha512-nf22//wEbKXusP6E9pfOCDwFdHAX4u172eaJI4YkDRQEZiorm6KfYnSC2SWLDMVWUOWPERmJnN0ujeAfTBLvrw==}
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
     peerDependencies:
       '@types/react': ^18.0.0
 
-  '@types/react-dom@19.1.7':
-    resolution: {integrity: sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==}
+  '@types/react-dom@19.1.8':
+    resolution: {integrity: sha512-xG7xaBMJCpcK0RpN8jDbAACQo54ycO6h4dSSmgv8+fu6ZIAdANkx/WsawASUjVXYfy+J9AbUpRMNNEsXCDfDBQ==}
     peerDependencies:
       '@types/react': ^19.0.0
 
@@ -5807,11 +5807,11 @@ snapshots:
 
   '@types/prop-types@15.7.11': {}
 
-  '@types/react-dom@18.3.6(@types/react@18.3.20)':
+  '@types/react-dom@18.3.7(@types/react@18.3.20)':
     dependencies:
       '@types/react': 18.3.20
 
-  '@types/react-dom@19.1.7(@types/react@19.1.11)':
+  '@types/react-dom@19.1.8(@types/react@19.1.11)':
     dependencies:
       '@types/react': 19.1.11
 


### PR DESCRIPTION
### Description

- Related https://github.com/DefinitelyTyped/DefinitelyTyped/pull/73545

The long time type annoyance is finally fixed, so I updated this manually.

Hmm, we still have this one. Probably I should suggest a fix on react-router:

https://github.com/vitejs/vite-plugin-react/blob/d5a2e604c454a620f004bb92d2c6f3d404c1fbf8/packages/plugin-rsc/examples/react-router/react-router-vite/entry.ssr.tsx#L22-L36

- https://github.com/remix-run/react-router/pull/14241