### PR TITLE
perf(react): skip transform hook completely in rolldown-vite in dev if possible

### DIFF
--- a/packages/plugin-react/CHANGELOG.md
+++ b/packages/plugin-react/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### Skip transform hook completely in rolldown-vite in dev if possible ([#783](https://github.com/vitejs/vite-plugin-react/pull/783))
+
 ## 5.0.1 (2025-08-19)
 
 ### Set `optimizeDeps.rollupOptions.transform.jsx` instead of `optimizeDeps.rollupOptions.jsx` for rolldown-vite ([#735](https://github.com/vitejs/vite-plugin-react/pull/735))

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -208,8 +208,8 @@ export default function viteReact(opts: Options = {}): Plugin[] {
         staticBabelOptions = createBabelOptions(opts.babel)
 
         if (
+          (isRolldownVite || skipFastRefresh) &&
           canSkipBabel(staticBabelOptions.plugins, staticBabelOptions) &&
-          skipFastRefresh &&
           (opts.jsxRuntime === 'classic' ? isProduction : true)
         ) {
           delete viteBabel.transform
@@ -269,8 +269,7 @@ export default function viteReact(opts: Options = {}): Plugin[] {
 
         const isJSX = filepath.endsWith('x')
         const useFastRefresh =
-          !isRolldownVite &&
-          !skipFastRefresh &&
+          !(isRolldownVite || skipFastRefresh) &&
           !ssr &&
           (isJSX ||
             (opts.jsxRuntime === 'classic'


### PR DESCRIPTION
### Description

babel's fast refresh transform is not used in dev for rolldown-vite, so we can completely skip the transform hook.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
