### PR TITLE
fix(rsc): inject `AsyncLocalStorage` global via transform

### DIFF
--- a/packages/plugin-rsc/examples/ssg/vite.config.ts
+++ b/packages/plugin-rsc/examples/ssg/vite.config.ts
@@ -25,6 +25,14 @@ export default defineConfig((env) => ({
     }),
     rscSsgPlugin(),
   ],
+  environments: {
+    ssr: {
+      optimizeDeps: {
+        // TODO: move to plugin
+        include: ['react-dom/static.edge'],
+      },
+    },
+  },
 }))
 
 function rscSsgPlugin(): Plugin[] {

--- a/packages/plugin-rsc/examples/ssg/vite.config.ts
+++ b/packages/plugin-rsc/examples/ssg/vite.config.ts
@@ -25,14 +25,6 @@ export default defineConfig((env) => ({
     }),
     rscSsgPlugin(),
   ],
-  environments: {
-    ssr: {
-      optimizeDeps: {
-        // TODO: move to plugin
-        include: ['react-dom/static.edge'],
-      },
-    },
-  },
 }))
 
 function rscSsgPlugin(): Plugin[] {

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -947,7 +947,7 @@ import.meta.hot.on("rsc:update", () => {
       },
     ),
     {
-      // make `AsyncLocalStorage` available globally for React request context on edge build (e.g. React.cache, ssr preload)
+      // make `AsyncLocalStorage` available globally for React edge build (required for React.cache, ssr preload, etc.)
       // https://github.com/facebook/react/blob/f14d7f0d2597ea25da12bcf97772e8803f2a394c/packages/react-server/src/forks/ReactFlightServerConfig.dom-edge.js#L16-L19
       name: 'rsc:inject-async-local-storage',
       transform: {
@@ -970,20 +970,6 @@ import.meta.hot.on("rsc:update", () => {
           }
         },
       },
-      //       banner(chunk) {
-      //         if (
-      //           (this.environment.name === 'ssr' ||
-      //             this.environment.name === 'rsc') &&
-      //           this.environment.mode === 'build' &&
-      //           chunk.isEntry
-      //         ) {
-      //           return `\
-      // import * as __viteRscAyncHooks from "node:async_hooks";
-      // globalThis.AsyncLocalStorage = __viteRscAyncHooks.AsyncLocalStorage;
-      // `
-      //         }
-      //         return ''
-      //       },
     },
     ...vitePluginRscMinimal(rscPluginOptions, manager),
     ...vitePluginFindSourceMapURL(),

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -948,25 +948,40 @@ import.meta.hot.on("rsc:update", () => {
       // make `AsyncLocalStorage` available globally for React request context on edge build (e.g. React.cache, ssr preload)
       // https://github.com/facebook/react/blob/f14d7f0d2597ea25da12bcf97772e8803f2a394c/packages/react-server/src/forks/ReactFlightServerConfig.dom-edge.js#L16-L19
       name: 'rsc:inject-async-local-storage',
-      async configureServer() {
-        const __viteRscAyncHooks = await import('node:async_hooks')
-        ;(globalThis as any).AsyncLocalStorage =
-          __viteRscAyncHooks.AsyncLocalStorage
+      // async configureServer() {
+      //   const __viteRscAyncHooks = await import('node:async_hooks')
+      //   ;(globalThis as any).AsyncLocalStorage =
+      //     __viteRscAyncHooks.AsyncLocalStorage
+      // },
+      transform: {
+        handler(code) {
+          if (
+            this.environment.name !== 'client' &&
+            code.includes('new AsyncLocalStorage()') &&
+            !code.includes('__viteRscAyncHooks')
+          ) {
+            return (
+              `import * as __viteRscAyncHooks from "node:async_hooks";` +
+              `globalThis.AsyncLocalStorage = __viteRscAyncHooks.AsyncLocalStorage;` +
+              code
+            )
+          }
+        },
       },
-      banner(chunk) {
-        if (
-          (this.environment.name === 'ssr' ||
-            this.environment.name === 'rsc') &&
-          this.environment.mode === 'build' &&
-          chunk.isEntry
-        ) {
-          return `\
-import * as __viteRscAyncHooks from "node:async_hooks";
-globalThis.AsyncLocalStorage = __viteRscAyncHooks.AsyncLocalStorage;
-`
-        }
-        return ''
-      },
+      //       banner(chunk) {
+      //         if (
+      //           (this.environment.name === 'ssr' ||
+      //             this.environment.name === 'rsc') &&
+      //           this.environment.mode === 'build' &&
+      //           chunk.isEntry
+      //         ) {
+      //           return `\
+      // import * as __viteRscAyncHooks from "node:async_hooks";
+      // globalThis.AsyncLocalStorage = __viteRscAyncHooks.AsyncLocalStorage;
+      // `
+      //         }
+      //         return ''
+      //       },
     },
     ...vitePluginRscMinimal(rscPluginOptions, manager),
     ...vitePluginFindSourceMapURL(),

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -952,13 +952,14 @@ import.meta.hot.on("rsc:update", () => {
       name: 'rsc:inject-async-local-storage',
       transform: {
         handler(code) {
-          // for build, we cannot use `import` as it seems to confuse rollup commonjs plugin.
           if (
             (this.environment.name === 'ssr' ||
               this.environment.name === 'rsc') &&
+            code.includes('typeof AsyncLocalStorage') &&
             code.includes('new AsyncLocalStorage()') &&
             !code.includes('__viteRscAyncHooks')
           ) {
+            // for build, we cannot use `import` as it confuses rollup commonjs plugin.
             return (
               (this.environment.mode === 'build' && !isRolldownVite
                 ? `const __viteRscAyncHooks = require("node:async_hooks");`


### PR DESCRIPTION
### Description

- Closes https://github.com/vitejs/vite-plugin-react/issues/784

In old days, we have externalized react on `ssr` environment, so it's not possible to inject through transform, but now it's possible.
