### PR TITLE
feat(rsc): add `ModuleInfo.meta` to client references

### DIFF
--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1216,7 +1216,15 @@ function vitePluginUseClient(
               export const export_${meta.referenceKey} = {${exports}};
             `
           }
-          return { code, map: null }
+          return {
+            code,
+            map: null,
+            meta: {
+              rsc: {
+                type: 'client-group',
+              },
+            } satisfies PluginModuleMeta,
+          }
         }
       },
     },

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -52,7 +52,7 @@ import { transformScanBuildStrip } from './plugins/scan'
 import { validateImportPlugin } from './plugins/validate-import'
 import { vitePluginFindSourceMapURL } from './plugins/find-source-map-url'
 import { parseCssVirtual, toCssVirtual, parseIdQuery } from './plugins/shared'
-import type { PluginModuleMeta as RscModuleInfoMeta } from './types'
+import type { PluginModuleMeta } from './types'
 
 const isRolldownVite = 'rolldownVersion' in vite
 
@@ -1134,6 +1134,11 @@ function vitePluginUseClient(
         return {
           code: output.toString(),
           map: { mappings: '' },
+          meta: {
+            rsc: {
+              type: 'client',
+            },
+          } satisfies PluginModuleMeta,
         }
       },
     },
@@ -1211,15 +1216,7 @@ function vitePluginUseClient(
               export const export_${meta.referenceKey} = {${exports}};
             `
           }
-          return {
-            code,
-            map: null,
-            meta: {
-              rsc: {
-                type: 'client',
-              },
-            } satisfies RscModuleInfoMeta,
-          }
+          return { code, map: null }
         }
       },
     },

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -52,7 +52,7 @@ import { transformScanBuildStrip } from './plugins/scan'
 import { validateImportPlugin } from './plugins/validate-import'
 import { vitePluginFindSourceMapURL } from './plugins/find-source-map-url'
 import { parseCssVirtual, toCssVirtual, parseIdQuery } from './plugins/shared'
-import type { PluginModuleMeta } from './types'
+import type { RscModuleInfoMeta } from './types'
 
 const isRolldownVite = 'rolldownVersion' in vite
 
@@ -1138,7 +1138,7 @@ function vitePluginUseClient(
             rsc: {
               type: 'client',
             },
-          } satisfies PluginModuleMeta,
+          } satisfies RscModuleInfoMeta,
         }
       },
     },
@@ -1223,7 +1223,7 @@ function vitePluginUseClient(
               rsc: {
                 type: 'client-group',
               },
-            } satisfies PluginModuleMeta,
+            } satisfies RscModuleInfoMeta,
           }
         }
       },

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -52,7 +52,7 @@ import { transformScanBuildStrip } from './plugins/scan'
 import { validateImportPlugin } from './plugins/validate-import'
 import { vitePluginFindSourceMapURL } from './plugins/find-source-map-url'
 import { parseCssVirtual, toCssVirtual, parseIdQuery } from './plugins/shared'
-import type { PluginModuleMeta } from './types'
+import type { PluginModuleMeta as RscModuleInfoMeta } from './types'
 
 const isRolldownVite = 'rolldownVersion' in vite
 
@@ -1134,11 +1134,6 @@ function vitePluginUseClient(
         return {
           code: output.toString(),
           map: { mappings: '' },
-          meta: {
-            rsc: {
-              type: 'client',
-            },
-          } satisfies PluginModuleMeta,
         }
       },
     },
@@ -1216,7 +1211,15 @@ function vitePluginUseClient(
               export const export_${meta.referenceKey} = {${exports}};
             `
           }
-          return { code, map: null }
+          return {
+            code,
+            map: null,
+            meta: {
+              rsc: {
+                type: 'client',
+              },
+            } satisfies RscModuleInfoMeta,
+          }
         }
       },
     },

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -52,6 +52,7 @@ import { transformScanBuildStrip } from './plugins/scan'
 import { validateImportPlugin } from './plugins/validate-import'
 import { vitePluginFindSourceMapURL } from './plugins/find-source-map-url'
 import { parseCssVirtual, toCssVirtual, parseIdQuery } from './plugins/shared'
+import type { PluginModuleMeta } from './types'
 
 const isRolldownVite = 'rolldownVersion' in vite
 
@@ -1130,7 +1131,15 @@ function vitePluginUseClient(
         }
         const importSource = resolvePackage(`${PKG_NAME}/react/rsc`)
         output.prepend(`import * as $$ReactServer from "${importSource}";\n`)
-        return { code: output.toString(), map: { mappings: '' } }
+        return {
+          code: output.toString(),
+          map: { mappings: '' },
+          meta: {
+            rsc: {
+              type: 'client',
+            },
+          } satisfies PluginModuleMeta,
+        }
       },
     },
     {

--- a/packages/plugin-rsc/src/types/index.ts
+++ b/packages/plugin-rsc/src/types/index.ts
@@ -28,6 +28,6 @@ export type CallServerCallback = (id: string, args: unknown[]) => unknown
 
 export type PluginModuleMeta = {
   rsc: {
-    type: 'client' | 'server'
+    type: 'client' | 'client-group'
   }
 }

--- a/packages/plugin-rsc/src/types/index.ts
+++ b/packages/plugin-rsc/src/types/index.ts
@@ -25,3 +25,9 @@ export interface ServerConsumerManifest {
 }
 
 export type CallServerCallback = (id: string, args: unknown[]) => unknown
+
+export type PluginModuleMeta = {
+  rsc: {
+    type: 'client' | 'server'
+  }
+}

--- a/packages/plugin-rsc/src/types/index.ts
+++ b/packages/plugin-rsc/src/types/index.ts
@@ -26,7 +26,7 @@ export interface ServerConsumerManifest {
 
 export type CallServerCallback = (id: string, args: unknown[]) => unknown
 
-export type PluginModuleMeta = {
+export type RscModuleInfoMeta = {
   rsc: {
     type: 'client' | 'client-group'
   }


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

Porting https://github.com/hi-ogawa/vite-plugins/blob/34b82d6e809dee653f6572778fed0c987d8aad67/packages/react-server/src/features/client-component/plugin.ts#L170-L174. This potentially helps utilizing client reference usage for framework's build pipeline.

Well, we need to expose `clientReferenceDeps` to actually get to the asset url though.