### PR TITLE
fix(rsc): propagate client reference invalidation to server

### DIFF
--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -428,13 +428,23 @@ function defineTest(f: Fixture) {
       editor.edit((s) => s.replace('[ok]', '[ok-edit]'))
       await expect(locator).toHaveText('test-hmr-client-dep: 1[ok-edit]')
 
+      // check next rsc payload includes current client reference and preserves state
+      await page.locator("a[href='?test-hmr-client-dep-re-render']").click()
+      await expect(
+        page.locator("a[href='?test-hmr-client-dep-re-render']"),
+      ).toHaveText('re-render [ok]')
+      await expect(locator).toHaveText('test-hmr-client-dep: 1[ok-edit]')
+
       // check next ssr is also updated
-      const res = await page.reload()
+      const res = await page.request.get(f.url(), {
+        headers: {
+          accept: 'text/html',
+        },
+      })
       expect(await res?.text()).toContain('[ok-edit]')
 
-      await waitForHydration(page)
       editor.reset()
-      await expect(locator).toHaveText('test-hmr-client-dep: 0[ok]')
+      await expect(locator).toHaveText('test-hmr-client-dep: 1[ok]')
     })
 
     test('non-self-accepting client hmr', async ({ page }) => {
@@ -457,7 +467,7 @@ function defineTest(f: Fixture) {
       ).toHaveText('re-render [ok]')
       await expect(locator).toHaveText('test-hmr-client-dep2: 1[ok-edit]')
 
-      // check next ssr is updated
+      // check next ssr is also updated
       const res = await page.request.get(f.url(), {
         headers: {
           accept: 'text/html',

--- a/packages/plugin-rsc/examples/basic/src/routes/hmr-client-dep/client.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/hmr-client-dep/client.tsx
@@ -3,14 +3,22 @@
 import React from 'react'
 import { ClientDep } from './client-dep'
 
-export function TestHmrClientDep() {
+export function TestHmrClientDep(props: { url: Pick<URL, 'search'> }) {
   const [count, setCount] = React.useState(0)
   return (
-    <div data-testid="test-hmr-client-dep">
-      <button onClick={() => setCount((c) => c + 1)}>
-        test-hmr-client-dep: {count}
-      </button>
-      <ClientDep />
+    <div>
+      <span data-testid="test-hmr-client-dep">
+        <button onClick={() => setCount((c) => c + 1)}>
+          test-hmr-client-dep: {count}
+        </button>
+        <ClientDep />
+      </span>{' '}
+      <a href="?test-hmr-client-dep-re-render">
+        re-render
+        {props.url.search.includes('test-hmr-client-dep-re-render')
+          ? ' [ok]'
+          : ''}
+      </a>
     </div>
   )
 }

--- a/packages/plugin-rsc/examples/basic/src/routes/hmr-client-dep2/client-dep.ts
+++ b/packages/plugin-rsc/examples/basic/src/routes/hmr-client-dep2/client-dep.ts
@@ -1,3 +1,3 @@
 export function clientDep() {
-  return '[ok-edit]'
+  return '[ok]'
 }

--- a/packages/plugin-rsc/examples/basic/src/routes/hmr-client-dep2/client-dep.ts
+++ b/packages/plugin-rsc/examples/basic/src/routes/hmr-client-dep2/client-dep.ts
@@ -1,0 +1,3 @@
+export function clientDep() {
+  return '[ok-edit]'
+}

--- a/packages/plugin-rsc/examples/basic/src/routes/hmr-client-dep2/client.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/hmr-client-dep2/client.tsx
@@ -3,14 +3,22 @@
 import React from 'react'
 import { clientDep } from './client-dep'
 
-export function TestHmrClientDep2() {
+export function TestHmrClientDep2(props: { url: Pick<URL, 'search'> }) {
   const [count, setCount] = React.useState(0)
   return (
-    <div data-testid="test-hmr-client-dep2">
-      <button onClick={() => setCount((c) => c + 1)}>
-        test-hmr-client-dep2: {count}
-      </button>
-      {clientDep()} <a href="?test-hmr-client-dep2-re-render">re-render</a>
+    <div>
+      <span data-testid="test-hmr-client-dep2">
+        <button onClick={() => setCount((c) => c + 1)}>
+          test-hmr-client-dep2: {count}
+        </button>
+        {clientDep()}
+      </span>{' '}
+      <a href="?test-hmr-client-dep2-re-render">
+        re-render
+        {props.url.search.includes('test-hmr-client-dep2-re-render')
+          ? ' [ok]'
+          : ''}
+      </a>
     </div>
   )
 }

--- a/packages/plugin-rsc/examples/basic/src/routes/hmr-client-dep2/client.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/hmr-client-dep2/client.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import React from 'react'
+import { clientDep } from './client-dep'
+
+export function TestHmrClientDep2() {
+  const [count, setCount] = React.useState(0)
+  return (
+    <div data-testid="test-hmr-client-dep2">
+      <button onClick={() => setCount((c) => c + 1)}>
+        test-hmr-client-dep2: {count}
+      </button>
+      {clientDep()} <a href="?test-hmr-client-dep2-re-render">re-render</a>
+    </div>
+  )
+}

--- a/packages/plugin-rsc/examples/basic/src/routes/hmr-client-dep3/client-a.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/hmr-client-dep3/client-a.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import React from 'react'
+import { clientDep } from './client-dep'
+import { ClientDepComp } from './client-dep-comp'
+
+export function TestHmrClientDepA() {
+  const [count, setCount] = React.useState(0)
+  return (
+    <>
+      <span data-testid="test-hmr-client-dep3">
+        <button onClick={() => setCount((c) => c + 1)}>
+          test-hmr-client-dep3: {count}
+        </button>
+        {clientDep()}
+        <ClientDepComp />
+      </span>
+    </>
+  )
+}

--- a/packages/plugin-rsc/examples/basic/src/routes/hmr-client-dep3/client-b.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/hmr-client-dep3/client-b.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { TestHmrClientDepA } from './client-a'
+
+export function TestHmrClientDepB() {
+  return <TestHmrClientDepA />
+}

--- a/packages/plugin-rsc/examples/basic/src/routes/hmr-client-dep3/client-dep-comp.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/hmr-client-dep3/client-dep-comp.tsx
@@ -1,0 +1,3 @@
+export function ClientDepComp() {
+  return '[ok]'
+}

--- a/packages/plugin-rsc/examples/basic/src/routes/hmr-client-dep3/client-dep.ts
+++ b/packages/plugin-rsc/examples/basic/src/routes/hmr-client-dep3/client-dep.ts
@@ -1,0 +1,3 @@
+export function clientDep() {
+  return '[ok]'
+}

--- a/packages/plugin-rsc/examples/basic/src/routes/hmr-client-dep3/server.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/hmr-client-dep3/server.tsx
@@ -1,0 +1,23 @@
+import { TestHmrClientDepA } from './client-a'
+import { TestHmrClientDepB } from './client-b'
+
+// example to demonstrate a folowing behavior
+// https://github.com/vitejs/vite-plugin-react/pull/788#issuecomment-3227656612
+/*
+server                       server
+   |                           |
+   v                           v
+client-a   client-a?t=xx <-- client-b
+   |         |
+   v         v
+client-dep-comp?t=xx
+*/
+
+export function TestHmrClientDep3() {
+  return (
+    <div>
+      <TestHmrClientDepA />
+      <TestHmrClientDepB />
+    </div>
+  )
+}

--- a/packages/plugin-rsc/examples/basic/src/routes/root.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/root.tsx
@@ -41,6 +41,7 @@ import { TestHmrSwitchClient } from './hmr-switch/client'
 import { TestTreeShakeServer } from './tree-shake/server'
 import { TestClientChunkServer } from './chunk/server'
 import { TestTailwind } from './tailwind'
+import { TestHmrClientDep2 } from './hmr-client-dep2/client'
 
 export function Root(props: { url: URL }) {
   return (
@@ -64,6 +65,7 @@ export function Root(props: { url: URL }) {
         <TestDepCssInServer />
         <TestHydrationMismatch url={props.url} />
         <TestHmrClientDep />
+        <TestHmrClientDep2 />
         <TestHmrSharedServer />
         <TestHmrSharedClient />
         <TestHmrSharedAtomic />

--- a/packages/plugin-rsc/examples/basic/src/routes/root.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/root.tsx
@@ -64,7 +64,7 @@ export function Root(props: { url: URL }) {
         <TestTailwind />
         <TestDepCssInServer />
         <TestHydrationMismatch url={props.url} />
-        <TestHmrClientDep />
+        <TestHmrClientDep url={{ search: props.url.search }} />
         <TestHmrClientDep2 url={{ search: props.url.search }} />
         <TestHmrSharedServer />
         <TestHmrSharedClient />

--- a/packages/plugin-rsc/examples/basic/src/routes/root.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/root.tsx
@@ -42,6 +42,7 @@ import { TestTreeShakeServer } from './tree-shake/server'
 import { TestClientChunkServer } from './chunk/server'
 import { TestTailwind } from './tailwind'
 import { TestHmrClientDep2 } from './hmr-client-dep2/client'
+import { TestHmrClientDep3 } from './hmr-client-dep3/server'
 
 export function Root(props: { url: URL }) {
   return (
@@ -66,6 +67,7 @@ export function Root(props: { url: URL }) {
         <TestHydrationMismatch url={props.url} />
         <TestHmrClientDep url={{ search: props.url.search }} />
         <TestHmrClientDep2 url={{ search: props.url.search }} />
+        <TestHmrClientDep3 />
         <TestHmrSharedServer />
         <TestHmrSharedClient />
         <TestHmrSharedAtomic />

--- a/packages/plugin-rsc/examples/basic/src/routes/root.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/root.tsx
@@ -65,7 +65,7 @@ export function Root(props: { url: URL }) {
         <TestDepCssInServer />
         <TestHydrationMismatch url={props.url} />
         <TestHmrClientDep />
-        <TestHmrClientDep2 />
+        <TestHmrClientDep2 url={{ search: props.url.search }} />
         <TestHmrSharedServer />
         <TestHmrSharedClient />
         <TestHmrSharedAtomic />

--- a/packages/plugin-rsc/examples/basic/vite.config.ts
+++ b/packages/plugin-rsc/examples/basic/vite.config.ts
@@ -17,24 +17,6 @@ import { fileURLToPath } from 'node:url'
 export default defineConfig({
   clearScreen: false,
   plugins: [
-    // TODO: generalize
-    // {
-    //   name: 'poc',
-    //   async hotUpdate(ctx) {
-    //     // when client only dependencies is changed,
-    //     // need to invalidate the corresponding route's original server module.
-    //     if (ctx.file.includes('/hmr-client-dep2/client-dep.ts')) {
-    //       if (this.environment.name === 'rsc') {
-    //         const routeFile = path.join(ctx.file, '../client.tsx')
-    //         const mods =
-    //           this.environment.moduleGraph.getModulesByFile(routeFile)
-    //         for (const mod of mods ?? []) {
-    //           this.environment.moduleGraph.invalidateModule(mod)
-    //         }
-    //       }
-    //     }
-    //   },
-    // },
     // inspect(),
     tailwindcss(),
     react(),

--- a/packages/plugin-rsc/examples/basic/vite.config.ts
+++ b/packages/plugin-rsc/examples/basic/vite.config.ts
@@ -18,23 +18,23 @@ export default defineConfig({
   clearScreen: false,
   plugins: [
     // TODO: generalize
-    {
-      name: 'poc',
-      async hotUpdate(ctx) {
-        // when client only dependencies is changed,
-        // need to invalidate the corresponding route's original server module.
-        if (ctx.file.includes('/hmr-client-dep2/client-dep.ts')) {
-          if (this.environment.name === 'rsc') {
-            const routeFile = path.join(ctx.file, '../client.tsx')
-            const mods =
-              this.environment.moduleGraph.getModulesByFile(routeFile)
-            for (const mod of mods ?? []) {
-              this.environment.moduleGraph.invalidateModule(mod)
-            }
-          }
-        }
-      },
-    },
+    // {
+    //   name: 'poc',
+    //   async hotUpdate(ctx) {
+    //     // when client only dependencies is changed,
+    //     // need to invalidate the corresponding route's original server module.
+    //     if (ctx.file.includes('/hmr-client-dep2/client-dep.ts')) {
+    //       if (this.environment.name === 'rsc') {
+    //         const routeFile = path.join(ctx.file, '../client.tsx')
+    //         const mods =
+    //           this.environment.moduleGraph.getModulesByFile(routeFile)
+    //         for (const mod of mods ?? []) {
+    //           this.environment.moduleGraph.invalidateModule(mod)
+    //         }
+    //       }
+    //     }
+    //   },
+    // },
     // inspect(),
     tailwindcss(),
     react(),

--- a/packages/plugin-rsc/examples/basic/vite.config.ts
+++ b/packages/plugin-rsc/examples/basic/vite.config.ts
@@ -17,6 +17,24 @@ import { fileURLToPath } from 'node:url'
 export default defineConfig({
   clearScreen: false,
   plugins: [
+    // TODO: generalize
+    {
+      name: 'poc',
+      async hotUpdate(ctx) {
+        // when client only dependencies is changed,
+        // need to invalidate the corresponding route's original server module.
+        if (ctx.file.includes('/hmr-client-dep2/client-dep.ts')) {
+          if (this.environment.name === 'rsc') {
+            const routeFile = path.join(ctx.file, '../client.tsx')
+            const mods =
+              this.environment.moduleGraph.getModulesByFile(routeFile)
+            for (const mod of mods ?? []) {
+              this.environment.moduleGraph.invalidateModule(mod)
+            }
+          }
+        }
+      },
+    },
     // inspect(),
     tailwindcss(),
     react(),

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -415,6 +415,35 @@ export default function vitePluginRsc(
       configureServer(server) {
         ;(globalThis as any).__viteRscDevServer = server
 
+        // intercept client hmr to propagate client boundary invalidation to server environment
+        const oldSend = server.environments.client.hot.send
+        server.environments.client.hot.send = async function (
+          this,
+          ...args: any[]
+        ) {
+          const e = args[0] as vite.UpdatePayload
+          if (e && typeof e === 'object' && e.type === 'update') {
+            for (const update of e.updates) {
+              if (update.type === 'js-update') {
+                const mod =
+                  server.environments.client.moduleGraph.urlToModuleMap.get(
+                    update.path,
+                  )
+                if (mod && mod.id && manager.clientReferenceMetaMap[mod.id]) {
+                  const serverMod =
+                    server.environments.rsc!.moduleGraph.getModuleById(mod.id)
+                  if (serverMod) {
+                    server.environments.rsc!.moduleGraph.invalidateModule(
+                      serverMod,
+                    )
+                  }
+                }
+              }
+            }
+          }
+          return oldSend.apply(this, args as any)
+        }
+
         if (rscPluginOptions.disableServerHandler) return
         if (rscPluginOptions.serverHandler === false) return
         const options = rscPluginOptions.serverHandler ?? {


### PR DESCRIPTION
### Description

- Related https://github.com/remix-run/react-router/pull/14251

Reproduction
- increment counter "test-hmr-client-dep2"
- edit `hmr-client-dep2/client-dep.ts`
- click "re-render"
- counter is reset to 0

This is because when `client-dep.ts` is modified, it invalidates `client.tsx` (on client environment) for hmr, which becomes a new module fetched as `client.tsx?t=xxx`, but `client.tsx` on server environment (which exists as "proxy module" with `registerClientReference`) is not invalidated. When re-rendering RSC, server payload includes a client component with old module reference `client.tsx` instead of new `client.tsx?t=xxx`, which has a different identity as `TestHmrClientDep2` functional component and thus React re-mounts node.

<details>

https://github.com/user-attachments/assets/676cd2f2-226f-44fc-b5e7-32b2ccebb4f0

</details>


TODO
- [x] test
- [x] fix
- [ ] compare with next.js and parcel
  - they use module cache with consistent "module id" in memory (not browser's esm module cache), so they probably don't have an equivalent issue.
- [ ] propose official API on vite instead patching internal
  - ideally we should coordinate `moduleGraph.invalidateModule` from client environment to rsc environment.
