### PR TITLE
perf: remove unnecessary export checks

### DIFF
--- a/packages/common/refresh-runtime.js
+++ b/packages/common/refresh-runtime.js
@@ -653,10 +653,7 @@ export function validateRefreshBoundaryAndEnqueueUpdate(
 
 function predicateOnExport(ignoredExports, moduleExports, predicate) {
   for (const key in moduleExports) {
-    if (key === '__esModule') continue
     if (ignoredExports.includes(key)) continue
-    const desc = Object.getOwnPropertyDescriptor(moduleExports, key)
-    if (desc && desc.get) return key
     if (!predicate(key, moduleExports[key])) return key
   }
   return true


### PR DESCRIPTION
### Description

These checks existed from the first implementation (https://github.com/vitejs/vite/pull/10239), but I think these are not necessary.

This improved the window reload perf a bit. (on the other hand, using `import * as currentExports from 'id'` instead of `RefreshRuntime.__hmr_import(import.meta.url)` degraded the perf, so I'm leaving that as full-bundle mode only)

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
