### PR TITLE
feat(react-swc): set SWC cacheRoot option

### DIFF
--- a/packages/plugin-react-swc/CHANGELOG.md
+++ b/packages/plugin-react-swc/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Set SWC cacheRoot options
+
+This is set to `{viteCacheDir}/swc` and override the default of `.swc`.
+
 ## 4.0.1 (2025-08-19)
 
 ### Set `optimizeDeps.rollupOptions.transform.jsx` instead of `optimizeDeps.rollupOptions.jsx` for rolldown-vite ([#735](https://github.com/vitejs/vite-plugin-react/pull/735))

--- a/packages/plugin-react-swc/tsdown.config.ts
+++ b/packages/plugin-react-swc/tsdown.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   entry: 'src/index.ts',
   dts: true,
   tsconfig: './tsconfig.src.json', // https://github.com/sxzz/rolldown-plugin-dts/issues/55
+  ignoreWatch: ['playground', 'playground-temp', 'test-results'],
   copy: [
     {
       from: 'node_modules/@vitejs/react-common/refresh-runtime.js',


### PR DESCRIPTION
Closes #495

Coming back to this PR, I think using a subpath of the configurable vite cache root option is better than adding an option

cc @RomanHotsiy