### PR TITLE
chore(rsc): add web-streams-polyfill to browser-mode example on webkit

### DIFF
--- a/packages/plugin-rsc/e2e/browser-mode.test.ts
+++ b/packages/plugin-rsc/e2e/browser-mode.test.ts
@@ -5,7 +5,7 @@ import { defineStarterTest } from './starter'
 test.describe('dev-browser-mode', () => {
   // Webkit fails by
   // > TypeError: ReadableByteStreamController is not implemented
-  test.skip(({ browserName }) => browserName === 'webkit')
+  // test.skip(({ browserName }) => browserName === 'webkit')
 
   const f = useFixture({ root: 'examples/browser-mode', mode: 'dev' })
   defineStarterTest(f, 'browser-mode')

--- a/packages/plugin-rsc/examples/browser-mode/index.html
+++ b/packages/plugin-rsc/examples/browser-mode/index.html
@@ -5,9 +5,13 @@
     <title>RSC Browser Mode</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <script async type="module" src="/src/framework/main.tsx"></script>
+    <!-- <script async type="module" src="/src/framework/main.tsx"></script> -->
   </head>
   <body>
     <div id="root"></div>
+    <script type="module">
+      await import('./node_modules/web-streams-polyfill/dist/polyfill.js')
+      await import('./src/framework/main.tsx')
+    </script>
   </body>
 </html>

--- a/packages/plugin-rsc/examples/browser-mode/package.json
+++ b/packages/plugin-rsc/examples/browser-mode/package.json
@@ -18,6 +18,7 @@
     "@types/react-dom": "^19.1.8",
     "@vitejs/plugin-react": "latest",
     "@vitejs/plugin-rsc": "latest",
-    "vite": "^7.1.3"
+    "vite": "^7.1.3",
+    "web-streams-polyfill": "^4.2.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -585,6 +585,9 @@ importers:
       vite:
         specifier: ^7.1.3
         version: 7.1.3(@types/node@22.18.0)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.7.1)
+      web-streams-polyfill:
+        specifier: ^4.2.0
+        version: 4.2.0
 
   packages/plugin-rsc/examples/e2e:
     devDependencies:
@@ -4624,6 +4627,10 @@ packages:
     resolution: {integrity: sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==}
     engines: {node: '>= 8'}
 
+  web-streams-polyfill@4.2.0:
+    resolution: {integrity: sha512-0rYDzGOh9EZpig92umN5g5D/9A1Kff7k0/mzPSSCY8jEQeYkgRMoY7LhbXtUCWzLCMX0TUE9aoHkjFNB7D9pfA==}
+    engines: {node: '>= 8'}
+
   webpack-sources@3.3.3:
     resolution: {integrity: sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==}
     engines: {node: '>=10.13.0'}
@@ -8323,6 +8330,8 @@ snapshots:
   walk-up-path@3.0.1: {}
 
   web-streams-polyfill@3.2.1: {}
+
+  web-streams-polyfill@4.2.0: {}
 
   webpack-sources@3.3.3: {}
 


### PR DESCRIPTION
### Description

I wanted to try this out https://github.com/lazarv/react-server/pull/242, but it looks like it's breaking other things.