### PR TITLE
feat(rsc): support `UserConfig.rsc: RscPluginOptions`

### DIFF
--- a/packages/plugin-rsc/README.md
+++ b/packages/plugin-rsc/README.md
@@ -397,6 +397,7 @@ export default defineConfig({
     }),
   ],
   // the same options can be also specified via top-level `rsc` property.
+  // this allows other plugin to set options via `config` hook.
   rsc: {
     // ...
   },

--- a/packages/plugin-rsc/README.md
+++ b/packages/plugin-rsc/README.md
@@ -355,6 +355,8 @@ import.meta.hot.on('rsc:update', async () => {
 
 ### `@vitejs/plugin-rsc`
 
+- Type: `rsc: (options?: RscPluginOptions) => Plugin[]`;
+
 ```js
 import rsc from '@vitejs/plugin-rsc'
 import { defineConfig } from 'vite'
@@ -390,8 +392,14 @@ export default defineConfig({
       // for example, to obtain a key through environment variable during runtime.
       // cf. https://nextjs.org/docs/app/guides/data-security#overwriting-encryption-keys-advanced
       defineEncryptionKey: 'process.env.MY_ENCRYPTION_KEY',
+
+      // see `RscPluginOptions` for full options ...
     }),
   ],
+  // the same options can be also specified via top-level `rsc` property.
+  rsc: {
+    // ...
+  },
 })
 ```
 

--- a/packages/plugin-rsc/examples/ssg/vite.config.ts
+++ b/packages/plugin-rsc/examples/ssg/vite.config.ts
@@ -9,7 +9,7 @@ import { type Plugin, type ResolvedConfig, defineConfig } from 'vite'
 // import inspect from 'vite-plugin-inspect'
 import { RSC_POSTFIX } from './src/framework/shared'
 
-export default defineConfig((env) => ({
+export default defineConfig({
   plugins: [
     // inspect(),
     mdx(),
@@ -20,23 +20,26 @@ export default defineConfig((env) => ({
         rsc: './src/framework/entry.rsc.tsx',
         ssr: './src/framework/entry.ssr.tsx',
       },
-      serverHandler: env.isPreview ? false : undefined,
-      useBuildAppHook: true,
     }),
     rscSsgPlugin(),
   ],
-}))
+})
 
 function rscSsgPlugin(): Plugin[] {
   return [
     {
       name: 'rsc-ssg',
-      config(_config, env) {
-        if (env.isPreview) {
+      config: {
+        order: 'pre',
+        handler(_config, env) {
           return {
-            appType: 'mpa',
+            appType: env.isPreview ? 'mpa' : undefined,
+            rsc: {
+              useBuildAppHook: true,
+              serverHandler: env.isPreview ? false : undefined,
+            },
           }
-        }
+        },
       },
       buildApp: {
         async handler(builder) {

--- a/packages/plugin-rsc/examples/starter-cf-single/vite.config.ts
+++ b/packages/plugin-rsc/examples/starter-cf-single/vite.config.ts
@@ -55,4 +55,7 @@ export default defineConfig({
     // https://github.com/cloudflare/workers-sdk/blob/19e2aab1d68594c7289d0aa16474544919fd5b9b/packages/vite-plugin-cloudflare/src/index.ts#L183-L186
     buildApp: async () => {},
   },
+  rsc: {
+    serverHandler: false,
+  },
 })

--- a/packages/plugin-rsc/examples/starter-cf-single/vite.config.ts
+++ b/packages/plugin-rsc/examples/starter-cf-single/vite.config.ts
@@ -50,12 +50,4 @@ export default defineConfig({
       },
     },
   },
-  builder: {
-    // empty buildApp to disable cloudflare's buildApp
-    // https://github.com/cloudflare/workers-sdk/blob/19e2aab1d68594c7289d0aa16474544919fd5b9b/packages/vite-plugin-cloudflare/src/index.ts#L183-L186
-    buildApp: async () => {},
-  },
-  rsc: {
-    serverHandler: false,
-  },
 })

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -309,6 +309,12 @@ export default function vitePluginRsc(
     {
       name: 'rsc',
       async config(config, env) {
+        if (config.rsc) {
+          Object.assign(
+            rscPluginOptions,
+            vite.mergeConfig(config.rsc, rscPluginOptions),
+          )
+        }
         // crawl packages with "react" in "peerDependencies" to bundle react deps on server
         // see https://github.com/svitejs/vitefu/blob/d8d82fa121e3b2215ba437107093c77bde51b63b/src/index.js#L95-L101
         const result = await crawlFrameworkPkgs({

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -310,8 +310,10 @@ export default function vitePluginRsc(
       name: 'rsc',
       async config(config, env) {
         if (config.rsc) {
+          // mutate `rscPluginOptions` since internally this object is passed around
           Object.assign(
             rscPluginOptions,
+            // not sure which should win. for now plugin constructor wins.
             vite.mergeConfig(config.rsc, rscPluginOptions),
           )
         }

--- a/packages/plugin-rsc/types/index.d.ts
+++ b/packages/plugin-rsc/types/index.d.ts
@@ -16,4 +16,11 @@ declare global {
   }
 }
 
+declare module 'vite' {
+  interface UserConfig {
+    /** Options for `@vitejs/plugin-rsc` */
+    rsc?: import('@vitejs/plugin-rsc').RscPluginOptions
+  }
+}
+
 export {}


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

- Closes https://github.com/vitejs/vite-plugin-react/issues/806
- Closes https://github.com/vitejs/vite-plugin-react/issues/812

For example, this allows other plugin to control `RscPluginOptions` via its own `config` hook:

```js
import { defineConfig } from "vite";
import rsc from "@vitejs/plugin-rsc";

export default defineConfig({
  plugins: [
    {
       name: 'rsc-ssg',
       config(_config, env) {
          return {
             appType: env.isPreview ? "mpa" : undefined,
             rsc: {
               serverHandler: env.isPreview ? false : undefined,
               ...
             }
          }
       }
    },
    rsc({
       // ... instead of config here ...
    }),
  ],
})
```
