### PR TITLE
feat(rsc): enable `buildApp` plugin hook by default for Vite 7

### DIFF
--- a/packages/plugin-rsc/examples/ssg/vite.config.ts
+++ b/packages/plugin-rsc/examples/ssg/vite.config.ts
@@ -35,7 +35,6 @@ function rscSsgPlugin(): Plugin[] {
           return {
             appType: env.isPreview ? 'mpa' : undefined,
             rsc: {
-              useBuildAppHook: true,
               serverHandler: env.isPreview ? false : undefined,
             },
           }

--- a/packages/plugin-rsc/examples/starter-cf-single/vite.config.ts
+++ b/packages/plugin-rsc/examples/starter-cf-single/vite.config.ts
@@ -17,7 +17,6 @@ export default defineConfig({
       },
       serverHandler: false,
       loadModuleDevProxy: true,
-      useBuildAppHook: true,
     }),
     cloudflare({
       configPath: './wrangler.jsonc',

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -174,7 +174,7 @@ export type RscPluginOptions = {
   /**
    * use `Plugin.buildApp` hook (introduced on Vite 7) instead of `builder.buildApp` configuration
    * for better composability with other plugins.
-   * @default false
+   * @default true since Vite 7
    */
   useBuildAppHook?: boolean
 
@@ -426,6 +426,11 @@ export default function vitePluginRsc(
               }
             },
           },
+        }
+      },
+      configResolved() {
+        if (Number(vite.version.split('.')[0]) >= 7) {
+          rscPluginOptions.useBuildAppHook ??= true
         }
       },
       buildApp: {


### PR DESCRIPTION
### Description

- Closes https://github.com/vitejs/vite-plugin-react/issues/811
