### PR TITLE
test(rsc): test `useId`

### DIFF
--- a/packages/plugin-rsc/examples/basic/src/routes/root.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/root.tsx
@@ -44,6 +44,7 @@ import { TestTailwind } from './tailwind'
 import { TestHmrClientDep2 } from './hmr-client-dep2/client'
 import { TestHmrClientDep3 } from './hmr-client-dep3/server'
 import { TestChunk2 } from './chunk2/server'
+import { TestUseId } from './use-id/server'
 
 export function Root(props: { url: URL }) {
   return (
@@ -101,6 +102,7 @@ export function Root(props: { url: URL }) {
         <TestTreeShakeServer />
         <TestClientChunkServer />
         <TestChunk2 />
+        <TestUseId />
       </body>
     </html>
   )

--- a/packages/plugin-rsc/examples/basic/src/routes/use-id/client.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/use-id/client.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import { useId } from 'react'
+
+export function TestUseIdClient() {
+  const id = useId()
+  return <>test-useId-client: {id}</>
+}

--- a/packages/plugin-rsc/examples/basic/src/routes/use-id/server.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/use-id/server.tsx
@@ -1,0 +1,17 @@
+import { useId } from 'react'
+import { TestUseIdClient } from './client'
+
+export function TestUseId() {
+  return (
+    <div data-testid="use-id">
+      <TestUseIdServer />
+      |
+      <TestUseIdClient />
+    </div>
+  )
+}
+
+function TestUseIdServer() {
+  const id = useId()
+  return <>test-useId-server: {id}</>
+}

--- a/packages/plugin-rsc/examples/starter/src/client.tsx
+++ b/packages/plugin-rsc/examples/starter/src/client.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 
 export function ClientCounter() {
   const [count, setCount] = React.useState(0)
+  console.log('[useId]', React.useId())
 
   return (
     <button onClick={() => setCount((count) => count + 1)}>

--- a/packages/plugin-rsc/examples/starter/src/client.tsx
+++ b/packages/plugin-rsc/examples/starter/src/client.tsx
@@ -4,7 +4,6 @@ import React from 'react'
 
 export function ClientCounter() {
   const [count, setCount] = React.useState(0)
-  console.log('[useId]', React.useId())
 
   return (
     <button onClick={() => setCount((count) => count + 1)}>


### PR DESCRIPTION
### Description

This pull request introduces a new example demonstrating the usage of React's `useId` hook on both in server component and client component. This is to help debug an issue for https://github.com/wakujs/waku/issues/1100. 

This also confirms that `useId`'s format is different between client and server on react 19.1. Here is how it looks in `examples/basic`:

```
test-useId-server: :S1:|test-useId-client: «R3mr»
```

This is reported in https://github.com/vercel/next.js/issues/78691, which is expected to be fixed on canary https://github.com/vercel/next.js/pull/79477.