### PR TITLE
fix(rsc): support `rsc.loadModuleDevProxy` top-level config

### DIFF
--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -770,8 +770,9 @@ export default function vitePluginRsc(
     },
     {
       name: 'vite-rsc-load-module-dev-proxy',
-      apply: () => !!rscPluginOptions.loadModuleDevProxy,
       configureServer(server) {
+        if (!rscPluginOptions.loadModuleDevProxy) return
+
         async function createHandler(url: URL) {
           const { environmentName, entryName } = Object.fromEntries(
             url.searchParams,


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

- follow up to https://github.com/vitejs/vite-plugin-react/pull/810

`apply` cannot be used since `apply` filter runs before `config` hook, which merges top-level `rsc` config. The bug is revealed while testing it on https://github.com/wakujs/waku/pull/1655.

This makes me feel uneasy about the whole `UserConfig.rsc` concept, but it's fine for now. Let's just handle these case by case.