### PR TITLE
refactor(rsc): remove top-level `transformHoistInlineDirective` export in favor of `@vitejs/plugin-rsc/transforms`

### DIFF
--- a/packages/plugin-rsc/examples/basic/vite.config.ts
+++ b/packages/plugin-rsc/examples/basic/vite.config.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert'
-import rsc, { transformHoistInlineDirective } from '@vitejs/plugin-rsc'
+import rsc from '@vitejs/plugin-rsc'
+import { transformHoistInlineDirective } from '@vitejs/plugin-rsc/transforms'
 import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
 import {

--- a/packages/plugin-rsc/src/index.ts
+++ b/packages/plugin-rsc/src/index.ts
@@ -4,4 +4,3 @@ export {
   getPluginApi,
   type PluginApi,
 } from './plugin'
-export { transformHoistInlineDirective } from './transforms'


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

- follow up to https://github.com/vitejs/vite-plugin-react/pull/828

This PR removes export from `@vitejs/plugin-rsc` in favor of the one from `@vitejs/plugin-rsc/transforms`. They aren't meant to be official or stable API, so moving around is fine.