### PR TITLE
perf: avoid sourcemap for refresh wrapper injection

### DIFF
--- a/packages/common/refresh-runtime.js
+++ b/packages/common/refresh-runtime.js
@@ -243,7 +243,7 @@ function performReactRefresh() {
   }
 }
 
-function register(type, id) {
+export function register(type, id) {
   if (type === null) {
     return
   }
@@ -563,10 +563,6 @@ function isPlainObject(obj) {
 /**
  * Plugin utils
  */
-
-export function getRefreshReg(filename) {
-  return (type, id) => register(type, filename + ' ' + id)
-}
 
 // Taken from https://github.com/pmmmwh/react-refresh-webpack-plugin/blob/main/lib/runtime/RefreshUtils.js#L141
 // This allows to resister components not detected by SWC like styled component

--- a/packages/common/refresh-utils.ts
+++ b/packages/common/refresh-utils.ts
@@ -64,7 +64,7 @@ if (import.meta.hot && !inWebWorker) {
 
   if (hasRefresh) {
     const refreshCode = `
-function $RefreshReg$(type, id) { return RefreshRuntime.getRefreshReg(${JSON.stringify(id)})(type, id) }
+function $RefreshReg$(type, id) { return RefreshRuntime.register(type, ${JSON.stringify(id)} + ' ' + id) }
 function $RefreshSig$() { return RefreshRuntime.createSignatureFunctionForTransform(); }
 `
     newCode += refreshCode

--- a/packages/common/refresh-utils.ts
+++ b/packages/common/refresh-utils.ts
@@ -41,6 +41,12 @@ export function addRefreshWrapper<M extends { mappings: string }>(
 import * as RefreshRuntime from "${reactRefreshHost}${runtimePublicPath}";
 const inWebWorker = typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope;
 if (import.meta.hot && !inWebWorker) {
+  if (!window.$RefreshReg$) {
+    throw new Error(
+      "${pluginName} can't detect preamble. Something is wrong."
+    );
+  }
+
   RefreshRuntime.__hmr_import(import.meta.url).then((currentExports) => {
     RefreshRuntime.registerExportsForReactRefresh(${JSON.stringify(
       id,
@@ -60,14 +66,6 @@ if (import.meta.hot && !inWebWorker) {
     const refreshCode = `
 function $RefreshReg$(type, id) { return RefreshRuntime.getRefreshReg(${JSON.stringify(id)})(type, id) }
 function $RefreshSig$() { return RefreshRuntime.createSignatureFunctionForTransform(); }
-
-if (import.meta.hot && !inWebWorker) {
-  if (!window.$RefreshReg$) {
-    throw new Error(
-      "${pluginName} can't detect preamble. Something is wrong."
-    );
-  }
-}
 `
     newCode += refreshCode
   }

--- a/packages/common/refresh-utils.ts
+++ b/packages/common/refresh-utils.ts
@@ -38,8 +38,8 @@ export function addRefreshWrapper<M extends { mappings: string }>(
   let newCode = code
   if (hasRefresh) {
     const refreshHead = removeLineBreaksIfNeeded(
-      `let prevRefreshReg;
-let prevRefreshSig;
+      `let $RefreshReg$;
+let $RefreshSig$;
 
 if (import.meta.hot && !inWebWorker) {
   if (!window.$RefreshReg$) {
@@ -48,23 +48,15 @@ if (import.meta.hot && !inWebWorker) {
     );
   }
 
-  prevRefreshReg = window.$RefreshReg$;
-  prevRefreshSig = window.$RefreshSig$;
-  window.$RefreshReg$ = RefreshRuntime.getRefreshReg(${JSON.stringify(id)});
-  window.$RefreshSig$ = RefreshRuntime.createSignatureFunctionForTransform;
+  $RefreshReg$ = RefreshRuntime.getRefreshReg(${JSON.stringify(id)});
+  $RefreshSig$ = RefreshRuntime.createSignatureFunctionForTransform;
 }
 
 `,
       avoidSourceMap,
     )
 
-    newCode = `${refreshHead}${newCode}
-
-if (import.meta.hot && !inWebWorker) {
-  window.$RefreshReg$ = prevRefreshReg;
-  window.$RefreshSig$ = prevRefreshSig;
-}
-`
+    newCode = `${refreshHead}${newCode}`
     if (newMap) {
       newMap.mappings = ';'.repeat(16) + newMap.mappings
     }

--- a/packages/plugin-react-oxc/CHANGELOG.md
+++ b/packages/plugin-react-oxc/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### Perf: simplify refresh wrapper generation ([#835](https://github.com/vitejs/vite-plugin-react/pull/835))
+
 ## 0.4.1 (2025-08-19)
 
 ### Set `optimizeDeps.rollupOptions.transform.jsx` instead of `optimizeDeps.rollupOptions.jsx` ([#735](https://github.com/vitejs/vite-plugin-react/pull/735))

--- a/packages/plugin-react-oxc/src/index.ts
+++ b/packages/plugin-react-oxc/src/index.ts
@@ -4,7 +4,6 @@ import { readFileSync } from 'node:fs'
 import type { BuildOptions, Plugin } from 'vite'
 import {
   addRefreshWrapper,
-  avoidSourceMapOption,
   getPreambleCode,
   runtimePublicPath,
   silenceUseClientWarning,
@@ -140,13 +139,8 @@ export default function viteReact(opts: Options = {}): Plugin[] {
             code.includes(jsxImportRuntime))
         if (!useFastRefresh) return
 
-        const { code: newCode } = addRefreshWrapper(
-          code,
-          avoidSourceMapOption,
-          '@vitejs/plugin-react-oxc',
-          id,
-        )
-        return { code: newCode, map: null }
+        const newCode = addRefreshWrapper(code, '@vitejs/plugin-react-oxc', id)
+        return newCode ? { code: newCode, map: null } : undefined
       },
     },
     transformIndexHtml(_, config) {

--- a/packages/plugin-react-swc/CHANGELOG.md
+++ b/packages/plugin-react-swc/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 This is set to `{viteCacheDir}/swc` and override the default of `.swc`.
 
+### Perf: simplify refresh wrapper generation ([#835](https://github.com/vitejs/vite-plugin-react/pull/835))
+
 ## 4.0.1 (2025-08-19)
 
 ### Set `optimizeDeps.rollupOptions.transform.jsx` instead of `optimizeDeps.rollupOptions.jsx` for rolldown-vite ([#735](https://github.com/vitejs/vite-plugin-react/pull/735))

--- a/packages/plugin-react-swc/src/index.ts
+++ b/packages/plugin-react-swc/src/index.ts
@@ -1,7 +1,6 @@
 import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import type { SourceMapPayload } from 'node:module'
 import { createRequire } from 'node:module'
 import {
   type JscTarget,
@@ -197,13 +196,13 @@ const react = (_options?: Options): Plugin[] => {
         if (!result) return
         if (!refresh) return result
 
-        return addRefreshWrapper<SourceMapPayload>(
+        const newCode = addRefreshWrapper(
           result.code,
-          result.map!,
           '@vitejs/plugin-react-swc',
           id,
           options.reactRefreshHost,
         )
+        return { code: newCode ?? result.code, map: result.map }
       },
     },
     options.plugins

--- a/packages/plugin-react/CHANGELOG.md
+++ b/packages/plugin-react/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### Perf: simplify refresh wrapper generation ([#835](https://github.com/vitejs/vite-plugin-react/pull/835))
+
 ## 5.0.2 (2025-08-28)
 
 ### Skip transform hook completely in rolldown-vite in dev if possible ([#783](https://github.com/vitejs/vite-plugin-react/pull/783))

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -8,7 +8,6 @@ import * as vite from 'vite'
 import type { Plugin, ResolvedConfig } from 'vite'
 import {
   addRefreshWrapper,
-  avoidSourceMapOption,
   getPreambleCode,
   preambleCode,
   runtimePublicPath,
@@ -340,13 +339,13 @@ export default function viteReact(opts: Options = {}): Plugin[] {
           if (!useFastRefresh) {
             return { code: result.code!, map: result.map }
           }
-          return addRefreshWrapper(
+          const code = addRefreshWrapper(
             result.code!,
-            result.map!,
             '@vitejs/plugin-react',
             id,
             opts.reactRefreshHost,
           )
+          return { code: code ?? result.code!, map: result.map }
         }
       },
     },
@@ -376,14 +375,13 @@ export default function viteReact(opts: Options = {}): Plugin[] {
             code.includes(jsxImportRuntime))
         if (!useFastRefresh) return
 
-        const { code: newCode } = addRefreshWrapper(
+        const newCode = addRefreshWrapper(
           code,
-          avoidSourceMapOption,
           '@vitejs/plugin-react',
           id,
           opts.reactRefreshHost,
         )
-        return { code: newCode, map: null }
+        return newCode ? { code: newCode, map: null } : undefined
       },
     },
   }


### PR DESCRIPTION
### Description

By changing `$RefreshReg$` / `$RefreshSig$` to a local variable and leveraging the function hoisting, we can avoid the sourcemap generation for the refresh wrapper completely. Also this would reduce the code size, which would also improve the perf a bit.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
