### PR TITLE
chore(rsc): remove double `import.meta.hot.accept`

### DIFF
--- a/packages/plugin-rsc/examples/basic/src/framework/entry.rsc.tsx
+++ b/packages/plugin-rsc/examples/basic/src/framework/entry.rsc.tsx
@@ -106,7 +106,3 @@ export async function handleRequest({
     },
   })
 }
-
-if (import.meta.hot) {
-  import.meta.hot.accept()
-}


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

In `examples/basic`, there is already `import.meta.hot.accept` in `src/server.tsx` which is an actual entry https://github.com/vitejs/vite-plugin-react/blob/a7dafe2c43980aeab1a402be89b9292b56719e16/packages/plugin-rsc/examples/basic/src/server.tsx#L41-L43
