### PR TITLE
test(rsc): test adding css import works without reload

### DIFF
--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -866,11 +866,9 @@ function defineTest(f: Fixture) {
       await using _ = await expectNoReload(page)
 
       editor.reset()
-      await page.waitForTimeout(100)
       await expect(page.locator('.test-style-server')).toHaveCSS(
         'color',
         'rgb(255, 165, 0)',
-        { timeout: 10 },
       )
     })
 


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

- Related https://github.com/vitejs/vite-plugin-react/issues/844
- Related https://github.com/vitejs/vite-plugin-react/pull/841

Instead of skipping this test entirely, we can at least verify adding part works as hmr. We also want to ensure that this still works with https://github.com/vitejs/vite-plugin-react/pull/841.