### PR TITLE
docs(rsc): replace degit with create-vite

### DIFF
--- a/packages/plugin-rsc/README.md
+++ b/packages/plugin-rsc/README.md
@@ -14,7 +14,7 @@ This package provides [React Server Components](https://react.dev/reference/rsc/
 You can create a starter project by:
 
 ```sh
-npx degit vitejs/vite-plugin-react/packages/plugin-rsc/examples/starter my-app
+npm create vite@latest -- --template rsc
 ```
 
 ## Examples


### PR DESCRIPTION
### Description

Using `create vite` is probably better since it allows interactive prompts for extra things in the future e.g. rolldown-vite overrides and auto installation etc.