### PR TITLE
refactor(rsc): use `addWatchFile` to invalidate server css virtual

### DIFF
--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -2100,6 +2100,7 @@ function vitePluginRscCss(
         if (parsed?.type === 'rsc') {
           assert(this.environment.name === 'rsc')
           const importer = parsed.id
+          this.addWatchFile(importer)
           if (this.environment.mode === 'dev') {
             const result = collectCss(server.environments.rsc!, importer)
             const cssHrefs = result.hrefs.map((href) => href.slice(1))
@@ -2124,6 +2125,7 @@ function vitePluginRscCss(
         }
       },
       hotUpdate(ctx) {
+        if (1) return
         if (this.environment.name === 'rsc') {
           const { server } = manager
           const mods = collectModuleDependents(ctx.modules)

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -2100,9 +2100,11 @@ function vitePluginRscCss(
         if (parsed?.type === 'rsc') {
           assert(this.environment.name === 'rsc')
           const importer = parsed.id
-          this.addWatchFile(importer)
           if (this.environment.mode === 'dev') {
             const result = collectCss(server.environments.rsc!, importer)
+            for (const file of [importer, ...result.visitedFiles]) {
+              this.addWatchFile(file)
+            }
             const cssHrefs = result.hrefs.map((href) => href.slice(1))
             const deps = assetsURLOfDeps({ css: cssHrefs, js: [] }, manager)
             return generateResourcesCode(
@@ -2121,21 +2123,6 @@ function vitePluginRscCss(
                 manager,
               )}
             `
-          }
-        }
-      },
-      hotUpdate(ctx) {
-        if (1) return
-        if (this.environment.name === 'rsc') {
-          const { server } = manager
-          const mods = collectModuleDependents(ctx.modules)
-          for (const mod of mods) {
-            if (mod.id) {
-              invalidteModuleById(
-                server.environments.rsc!,
-                `\0` + toCssVirtual({ id: mod.id, type: 'rsc' }),
-              )
-            }
           }
         }
       },
@@ -2171,29 +2158,6 @@ export default function RemoveDuplicateServerCss() {
       },
     ),
   ]
-}
-
-function invalidteModuleById(environment: DevEnvironment, id: string) {
-  const mod = environment.moduleGraph.getModuleById(id)
-  if (mod) {
-    environment.moduleGraph.invalidateModule(mod)
-  }
-  return mod
-}
-
-function collectModuleDependents(mods: EnvironmentModuleNode[]) {
-  const visited = new Set<EnvironmentModuleNode>()
-  function recurse(mod: EnvironmentModuleNode) {
-    if (visited.has(mod)) return
-    visited.add(mod)
-    for (const importer of mod.importers) {
-      recurse(importer)
-    }
-  }
-  for (const mod of mods) {
-    recurse(mod)
-  }
-  return [...visited]
 }
 
 function generateResourcesCode(depsCode: string, manager: RscPluginManager) {


### PR DESCRIPTION
### Description

Currently we have different css wrapper virtual invalidation strategies.

`vite-rsc/css?type=ssr&...` is invalidated via multiple `addWatchFile`:

https://github.com/vitejs/vite-plugin-react/blob/10987e0471b8b96d2ed56ba5b5a5ef76a07bfbf9/packages/plugin-rsc/src/plugin.ts#L2020-L2023

`vite-rsc/css?type=rsc&...` is invalidated via `hotUpdate`:

https://github.com/vitejs/vite-plugin-react/blob/10987e0471b8b96d2ed56ba5b5a5ef76a07bfbf9/packages/plugin-rsc/src/plugin.ts#L2134-L2138

This PR changes `type=rsc` invalidation to align with `type=ssr`.

<details><summary>Notes on why single "addWatchFile" isn't enough</summary>

I feel like both should just work with one shot `addWatchFile`. Obviously I tried this before and something wasn't working, but let's try it again and see the issues.

It looks like the issue is that `addWatchFile` doesn't help chaining invalidation e.g.

```
virtual?root.tsx ---(addWatchFile)---> root.tsx --(import)--> other.tsx
                 <--(dynamic import)--
```

Here changing `root.tsx` invalidates `virtual?root.tsx`, but changing `other.tsx` doesn't invalidate `virtual?root.tsx`. Could this be because `addWatchFile` makes cycles? Could this be a Vite bug? 

(EDIT: It looks like this is because of "soft invalidation". technically `virtual` is invalidated but it's only "soft invalidation", so it doesn't trigger load/transform again. When changing `addWatchFile` dep, it causes non-soft invalidation and that's why it works when changing `root.tsx`. See https://github.com/hi-ogawa/reproductions/tree/main/vite-addWatchFile-indirect-invalidate)

---

Note that toggling import in `examples/starter` is working because it toggles `import.meta.viteRsc.loadCss` transform of `root.tsx`. It would still fail if there were multiple css imports and toggling them individually.

https://github.com/vitejs/vite-plugin-react/blob/10987e0471b8b96d2ed56ba5b5a5ef76a07bfbf9/packages/plugin-rsc/examples/starter/src/root.tsx#L1

</details>
