### PR TITLE
fix(rsc): remove server style when css import is removed

### DIFF
--- a/packages/plugin-rsc/examples/basic/src/routes/style-server/server.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/style-server/server.tsx
@@ -27,3 +27,7 @@ export function TestStyleServer() {
     </div>
   )
 }
+
+// add no-op `import.meta.hot` to trigger `prune` event
+// https://github.com/vitejs/vite/blob/84079a84ad94de4c1ef4f1bdb2ab448ff2c01196/packages/vite/src/node/plugins/importAnalysis.ts#L829-L840
+import.meta.hot

--- a/packages/plugin-rsc/examples/basic/src/routes/style-server/server.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/style-server/server.tsx
@@ -28,6 +28,6 @@ export function TestStyleServer() {
   )
 }
 
-// add no-op `import.meta.hot` to trigger `prune` event
-// https://github.com/vitejs/vite/blob/84079a84ad94de4c1ef4f1bdb2ab448ff2c01196/packages/vite/src/node/plugins/importAnalysis.ts#L829-L840
+// add no-op `import.meta.hot` to trigger `prune` event.
+// this is needed until we land https://github.com/vitejs/vite/pull/20768
 import.meta.hot

--- a/packages/plugin-rsc/examples/basic/src/routes/style-server/server2.css
+++ b/packages/plugin-rsc/examples/basic/src/routes/style-server/server2.css
@@ -1,0 +1,3 @@
+.test-style-server {
+  color: rgb(0, 255, 165);
+}

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1027,10 +1027,16 @@ import.meta.hot.on("rsc:update", () => {
 });
 `
         // remove stylesheet links when css import is removed on rsc envrionment
-        const onRscPrune = (e: vite.PrunePayload) => {
-          console.log('[rsc:prune]', e)
-        }
-        code += `import.meta.hot.on("rsc:prune", ${onRscPrune});`
+        code += `import.meta.hot.on("rsc:prune", ${(e: vite.PrunePayload) => {
+          const nodes = document.querySelectorAll<HTMLLinkElement>(
+            "link[rel='stylesheet']",
+          )
+          nodes.forEach((node) => {
+            if (e.paths.includes(node.dataset.rscCssHref!)) {
+              node.remove()
+            }
+          })
+        }});`
         return code
       },
     ),
@@ -2228,6 +2234,7 @@ function generateResourcesCode(depsCode: string, manager: RscPluginManager) {
             rel: 'stylesheet',
             precedence: 'vite-rsc/importer-resources',
             href: href,
+            'data-rsc-css-href': href,
           }),
         ),
         RemoveDuplicateServerCss &&

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1026,6 +1026,11 @@ import.meta.hot.on("rsc:update", () => {
   document.querySelectorAll("vite-error-overlay").forEach((n) => n.close())
 });
 `
+        // remove stylesheet links when css import is removed on rsc envrionment
+        const onRscPrune = (e: vite.PrunePayload) => {
+          console.log('[rsc:prune]', e)
+        }
+        code += `import.meta.hot.on("rsc:prune", ${onRscPrune});`
         return code
       },
     ),
@@ -2036,7 +2041,11 @@ function vitePluginRscCss(
         hot.send = function (this, ...args: any[]) {
           const e = args[0] as vite.PrunePayload
           if (e && typeof e === 'object' && e.type === 'prune') {
-            console.log('[rsc:prune]', e)
+            server.environments.client.hot.send({
+              type: 'custom',
+              event: 'rsc:prune',
+              data: e,
+            })
           }
           return original.apply(this, args as any)
         }

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -2042,6 +2042,7 @@ function vitePluginRscCss(
     {
       name: 'rsc:importer-resources',
       configureServer(server) {
+        // delegate 'prune' event from rsc environment to browser
         const hot = server.environments.rsc!.hot
         const original = hot.send
         hot.send = function (this, ...args: any[]) {

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -2030,6 +2030,17 @@ function vitePluginRscCss(
     },
     {
       name: 'rsc:importer-resources',
+      configureServer(server) {
+        const hot = server.environments.rsc!.hot
+        const original = hot.send
+        hot.send = function (this, ...args: any[]) {
+          const e = args[0] as vite.PrunePayload
+          if (e && typeof e === 'object' && e.type === 'prune') {
+            console.log('[rsc:prune]', e)
+          }
+          return original.apply(this, args as any)
+        }
+      },
       async transform(code, id) {
         if (!code.includes('import.meta.viteRsc.loadCss')) return
 


### PR DESCRIPTION
### Description

- Closes https://github.com/vitejs/vite-plugin-react/issues/844

This allows removing stylesheet link via hmr but it turned out adding that back via `<link />` in server component is not working likely because React tries to avoid re-inserting the same link.

Hmm, it looks like we already intentionally avoid adding `?t=` to link href.

https://github.com/vitejs/vite-plugin-react/blob/5f9aec41e60c6d4eff9ec06eeafdcca10fc458ce/packages/plugin-rsc/src/plugin.ts#L1918-L1921

Created a new issue for now https://github.com/vitejs/vite-plugin-react/issues/850

TODO
- [x] test with `import.meta.hot`
- [x] test with https://github.com/vitejs/vite/pull/20768
- [x] learn React float deduping mechanism
  - https://github.com/facebook/react/blob/78997291302c42b788dafa4c12da246e44be2dda/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js#L4802-L4878
