### PR TITLE
ci: use automatic cache for actions/setup-node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node_version }}
-          cache: "pnpm"
 
       - name: Install deps
         run: pnpm install
@@ -121,7 +120,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 20
-          cache: "pnpm"
 
       - name: Install deps
         run: pnpm install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,6 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
-          cache: "pnpm"
 
       - name: Install deps
         run: pnpm install

--- a/.github/workflows/release-continuous.yml
+++ b/.github/workflows/release-continuous.yml
@@ -26,7 +26,6 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: lts/*
-          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

This PR removes explicit `cache: "pnpm"` since actions/setup-node v5 says `cache` will be picked up automatically based on `packageManger` https://github.com/actions/setup-node/releases/tag/v5.0.0