### PR TITLE
test(rsc): tweak timeout

### DIFF
--- a/packages/plugin-rsc/e2e/helper.ts
+++ b/packages/plugin-rsc/e2e/helper.ts
@@ -15,7 +15,7 @@ export async function waitForHydration(page: Page, locator: string = 'body') {
               el &&
               Object.keys(el).some((key) => key.startsWith('__reactFiber')),
           ),
-      { timeout: 10000 },
+      { timeout: 20000 },
     )
     .toBeTruthy()
 }

--- a/packages/plugin-rsc/playwright.config.ts
+++ b/packages/plugin-rsc/playwright.config.ts
@@ -3,7 +3,8 @@ import { defineConfig, devices } from '@playwright/test'
 export default defineConfig({
   testDir: 'e2e',
   use: {
-    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    trace: 'on-all-retries',
   },
   expect: {
     toPass: { timeout: 10000 },


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->


#### Problem

It has been flaky with rolldown. I'm suspecting this is because it puts more pressure on CI resource and running tests in parallel (currently `workers: 2`) makes browser slower.

#### Solution

This PR tweaks flaky assertion's timeout and also tweaked recording options https://playwright.dev/docs/test-use-options#recording-options to improve debugging.

---

#### After thought

Actually the issue seems different. The error is actually not during `waitForHydration` polling, but it just errors out on first `page.locator(locator).evaluate(...)` call.

```
helper.ts:13
Error: locator.evaluate: Execution context was destroyed, most likely because of a navigation
```

Also "Console" and "Network" trace suggest there's indeed a full reload somehow:

<details><summary>screenshots</summary>

<img width="1048" height="853" alt="image" src="https://github.com/user-attachments/assets/0b4b3572-361c-4bb0-8419-73ea3cc6f9be" />

<img width="1048" height="853" alt="image" src="https://github.com/user-attachments/assets/293a1330-048e-406c-b7e9-5bdf8cdfefca" />

</details>

---

Well, actually this is not the case for the trace from different failures https://github.com/vitejs/vite-plugin-react/actions/runs/17721044144/job/50353326025, so the cause is still unclear. Anyways, let's merge this one for now.