### PR TITLE
docs(rsc): mention `validateImports` option for build time `server-only` and `client-only` validation

### DIFF
--- a/packages/plugin-rsc/README.md
+++ b/packages/plugin-rsc/README.md
@@ -353,7 +353,7 @@ export default defineConfig({
       // this behavior can be customized by `serverHandler` option.
       serverHandler: false,
 
-      // this controls build-time validation of 'server-only' and 'client-only' imports.
+      // the plugin provides build-time validation of 'server-only' and 'client-only' imports.
       // this is enabled by default. See the "server-only and client-only import" section for details.
       validateImports: true,
 
@@ -534,7 +534,7 @@ import { getData } from './server-utils.js' // ❌ This will fail at build time
 the plugin will show an error:
 
 ```sh
-[rsc:validate-imports] 'server-only' cannot be imported in client build (importer: '/.../client.js', ...)
+'server-only' cannot be imported in client build (importer: '/xxx/client.js', ...)
 ```
 
 Similarly, `client-only` import can ensure browser-specific code isn't accidentally imported in server environment. For example,
@@ -564,10 +564,10 @@ export function ServerComponent() {
 the plugin will show an error:
 
 ```sh
-[rsc:virtual-client-package] 'client-only' cannot be imported in server build (importer: '/.../server.js', ...)
+'client-only' cannot be imported in server build (importer: 'xxx/server.js', ...)
 ```
 
-Note that while there are official npm packages [`server-only`](https://www.npmjs.com/package/server-only) and [`client-only`](https://www.npmjs.com/package/client-only) created by React team, they don't need to be installed. The plugin internally overrides these imports and provides build-time validation instead of runtime errors.
+Note that while there are official npm packages [`server-only`](https://www.npmjs.com/package/server-only) and [`client-only`](https://www.npmjs.com/package/client-only) created by React team, they don't need to be installed. The plugin internally overrides these imports and surfaces their runtime errors as build-time errors.
 
 This build-time validation is enabled by default and can be disabled by setting `validateImports: false` in the plugin options.
 

--- a/packages/plugin-rsc/README.md
+++ b/packages/plugin-rsc/README.md
@@ -498,6 +498,72 @@ import.meta.viteRsc.loadModule
 
 See also [Vite documentation](https://vite.dev/guide/api-hmr.html#intellisense-for-typescript) for `vite/client` types.
 
+## `server-only` and `client-only` import
+
+You can use `server-only` import to avoid accidentally leaking certain modules on client build, which becomes public static assets.
+
+For example, ...todo
+
+- server-utils.js
+
+```tsx
+import 'server-only'
+
+export async function getData() {
+  const res = await fetch('https://service-internal-service.com/data', {
+    headers: {
+      authorization: process.env.API_KEY,
+    },
+  })
+  return res.json()
+}
+```
+
+- client.js
+
+```tsx
+'use client'
+import { getData } from './api-utils.js'
+
+export function ClientComponent() {
+  const data = await getData()
+  return <div>{data.message}</div>
+}
+```
+
+The plugin will show a following error ....todo
+
+```sh
+`server-only` cannot be imported in client build
+```
+
+On the other way around, `client-only` import ...todo
+
+- server.js
+
+```tsx
+export function ServerComponent() {
+  todo
+}
+```
+
+- client-utils.js
+
+```tsx
+import 'client-only'
+
+todo
+```
+
+Note that there are official npm packages [`server-only`](https://www.npmjs.com/package/server-only) and [`client-only`](https://www.npmjs.com/package/client-only) created by React team,
+but they don't need to be installed. `@vitejs/plugin-rsc` internally overrides them to provide a better error message during time instead of runtime error provided by the actual packages.
+
+This build time valdiation is enabled by default and it can be disabled by `RscPluginOptions.validateImports: false`.
+
+<!-- Learn more in -->
+<!-- https://nextjs.org/docs/app/getting-started/server-and-client-components#preventing-environment-poisoning -->
+<!-- https://overreacted.io/how-imports-work-in-rsc/ -->
+
 ## Credits
 
 This project builds on fundamental techniques and insights from pioneering Vite RSC implementations.

--- a/packages/plugin-rsc/README.md
+++ b/packages/plugin-rsc/README.md
@@ -506,7 +506,7 @@ See also [Vite documentation](https://vite.dev/guide/api-hmr.html#intellisense-f
 
 You can use `server-only` import to prevent accidentally importing server-only code on client, which can expose sensitive server code to public static assets.
 
-For example, with the following codes:
+For example, the plugin will show an error `'server-only' cannot be imported in client build` for the following codes:
 
 - server-utils.js
 
@@ -527,17 +527,11 @@ export async function getData() {
 
 ```tsx
 'use client'
-import { getData } from './server-utils.js' // ❌ This will fail at build time
+import { getData } from './server-utils.js' // ❌ 'server-only' cannot be imported in client build
 ...
 ```
 
-the plugin will show an error:
-
-```sh
-'server-only' cannot be imported in client build (importer: '/xxx/client.js', ...)
-```
-
-Similarly, `client-only` import can ensure browser-specific code isn't accidentally imported in server environment. For example,
+Similarly, `client-only` import can ensure browser-specific code isn't accidentally imported in server environment. For example, the plugin will show an error `'client-only' cannot be imported in server build` for the following codes:
 
 - client-utils.js
 
@@ -553,18 +547,12 @@ export function getStorage(key) {
 - server.js
 
 ```tsx
-import { getStorage } from './client-utils.js' // ❌ This will fail at build time
+import { getStorage } from './client-utils.js' // ❌ 'client-only' cannot be imported in server build
 
 export function ServerComponent() {
   const data = getStorage("settings")
   ...
 }
-```
-
-the plugin will show an error:
-
-```sh
-'client-only' cannot be imported in server build (importer: 'xxx/server.js', ...)
 ```
 
 Note that while there are official npm packages [`server-only`](https://www.npmjs.com/package/server-only) and [`client-only`](https://www.npmjs.com/package/client-only) created by React team, they don't need to be installed. The plugin internally overrides these imports and surfaces their runtime errors as build-time errors.

--- a/packages/plugin-rsc/README.md
+++ b/packages/plugin-rsc/README.md
@@ -504,7 +504,7 @@ See also [Vite documentation](https://vite.dev/guide/api-hmr.html#intellisense-f
 <!-- https://nextjs.org/docs/app/getting-started/server-and-client-components#preventing-environment-poisoning -->
 <!-- https://overreacted.io/how-imports-work-in-rsc/ -->
 
-You can use `server-only` import to prevent accidentally importing server-only code on client, which can expose sensitive server code to public static assets.
+You can use the `server-only` import to prevent accidentally importing server-only code into client bundles, which can expose sensitive server code in public static assets.
 For example, the plugin will show an error `'server-only' cannot be imported in client build` for the following code:
 
 - server-utils.js
@@ -530,7 +530,7 @@ import { getData } from './server-utils.js' // ❌ 'server-only' cannot be impor
 ...
 ```
 
-Similarly, `client-only` import can ensure browser-specific code isn't accidentally imported in server environment.
+Similarly, the `client-only` import ensures browser-specific code isn't accidentally imported into server environments.
 For example, the plugin will show an error `'client-only' cannot be imported in server build` for the following code:
 
 - client-utils.js

--- a/packages/plugin-rsc/README.md
+++ b/packages/plugin-rsc/README.md
@@ -353,6 +353,17 @@ export default defineConfig({
       // this behavior can be customized by `serverHandler` option.
       serverHandler: false,
 
+      // by default, the plugin uses a build-time generated encryption key for
+      // "use server" closure argument binding.
+      // This can be overwritten by configuring `defineEncryptionKey` option,
+      // for example, to obtain a key through environment variable during runtime.
+      // cf. https://nextjs.org/docs/app/guides/data-security#overwriting-encryption-keys-advanced
+      defineEncryptionKey: 'process.env.MY_ENCRYPTION_KEY',
+
+      // this controls build-time validation of 'client-only' and 'server-only' imports.
+      // this is enabled by default.
+      validateImports: true,
+
       // when `loadModuleDevProxy: true`, `import.meta.viteRsc.loadModule` is implemented
       // through `fetch` based RPC, which allows, for example, rsc environment inside
       // cloudflare workers to communicate with node ssr environment on main Vite process.
@@ -361,13 +372,6 @@ export default defineConfig({
       // by default, `loadCss()` helper is injected based on certain heuristics.
       // if it breaks, it can be opt-out or selectively applied based on files.
       rscCssTransform: { filter: (id) => id.includes('/my-app/') },
-
-      // by default, the plugin uses a build-time generated encryption key for
-      // "use server" closure argument binding.
-      // This can be overwritten by configuring `defineEncryptionKey` option,
-      // for example, to obtain a key through environment variable during runtime.
-      // cf. https://nextjs.org/docs/app/guides/data-security#overwriting-encryption-keys-advanced
-      defineEncryptionKey: 'process.env.MY_ENCRYPTION_KEY',
 
       // see `RscPluginOptions` for full options ...
     }),

--- a/packages/plugin-rsc/README.md
+++ b/packages/plugin-rsc/README.md
@@ -354,7 +354,7 @@ export default defineConfig({
       serverHandler: false,
 
       // the plugin provides build-time validation of 'server-only' and 'client-only' imports.
-      // this is enabled by default. See the "server-only and client-only import" section for details.
+      // this is enabled by default. See the "server-only and client-only import" section below for details.
       validateImports: true,
 
       // by default, the plugin uses a build-time generated encryption key for

--- a/packages/plugin-rsc/README.md
+++ b/packages/plugin-rsc/README.md
@@ -500,7 +500,13 @@ See also [Vite documentation](https://vite.dev/guide/api-hmr.html#intellisense-f
 
 ## `server-only` and `client-only` import
 
+<!-- references? -->
+<!-- https://nextjs.org/docs/app/getting-started/server-and-client-components#preventing-environment-poisoning -->
+<!-- https://overreacted.io/how-imports-work-in-rsc/ -->
+
 You can use `server-only` import to prevent accidentally importing server-only code on client, which can expose sensitive server code to public static assets.
+
+For example, with the following codes:
 
 - server-utils.js
 
@@ -525,17 +531,13 @@ import { getData } from './server-utils.js' // ❌ This will fail at build time
 ...
 ```
 
-When attempting to import server-only modules in client code, the plugin will show an error:
+the plugin will show an error:
 
 ```sh
-✘ [ERROR] "server-only" cannot be imported from a Client Component module. It should only be used from a Server Component.
-
-  client.js:2:25:
-    2 │ import { getData } from './server-utils.js'
-      ╵                         ~~~~~~~~~~~~~~~~~~~
+[rsc:validate-imports] 'server-only' cannot be imported in client build (importer: '/.../client.js', ...)
 ```
 
-Similarly, `client-only` import can ensure browser-specific code isn't accidentally imported in server environment:
+Similarly, `client-only` import can ensure browser-specific code isn't accidentally imported in server environment. For example,
 
 - client-utils.js
 
@@ -559,23 +561,15 @@ export function ServerComponent() {
 }
 ```
 
-This will similarly fail at build time:
+the plugin will show an error:
 
 ```sh
-✘ [ERROR] "client-only" cannot be imported from a Server Component module. It should only be used from a Client Component.
-
-  server.js:1:27:
-    1 │ import { trackEvent } from './client-utils.js'
-      ╵                            ~~~~~~~~~~~~~~~~~~~
+[rsc:virtual-client-package] 'client-only' cannot be imported in server build (importer: '/.../server.js', ...)
 ```
 
-Note that while there are official npm packages [`server-only`](https://www.npmjs.com/package/server-only) and [`client-only`](https://www.npmjs.com/package/client-only) created by React team, they don't need to be installed. The plugin internally handles these imports and provides build-time validation instead of runtime errors.
+Note that while there are official npm packages [`server-only`](https://www.npmjs.com/package/server-only) and [`client-only`](https://www.npmjs.com/package/client-only) created by React team, they don't need to be installed. The plugin internally overrides these imports and provides build-time validation instead of runtime errors.
 
 This build-time validation is enabled by default and can be disabled by setting `validateImports: false` in the plugin options.
-
-<!-- Learn more in -->
-<!-- https://nextjs.org/docs/app/getting-started/server-and-client-components#preventing-environment-poisoning -->
-<!-- https://overreacted.io/how-imports-work-in-rsc/ -->
 
 ## Credits
 

--- a/packages/plugin-rsc/README.md
+++ b/packages/plugin-rsc/README.md
@@ -500,7 +500,7 @@ import.meta.viteRsc.loadModule
 
 See also [Vite documentation](https://vite.dev/guide/api-hmr.html#intellisense-for-typescript) for `vite/client` types.
 
-## `server-only` and `client-only` import
+### `server-only` and `client-only` import
 
 <!-- references? -->
 <!-- https://nextjs.org/docs/app/getting-started/server-and-client-components#preventing-environment-poisoning -->

--- a/packages/plugin-rsc/README.md
+++ b/packages/plugin-rsc/README.md
@@ -353,16 +353,16 @@ export default defineConfig({
       // this behavior can be customized by `serverHandler` option.
       serverHandler: false,
 
+      // this controls build-time validation of 'server-only' and 'client-only' imports.
+      // this is enabled by default.
+      validateImports: true,
+
       // by default, the plugin uses a build-time generated encryption key for
       // "use server" closure argument binding.
       // This can be overwritten by configuring `defineEncryptionKey` option,
       // for example, to obtain a key through environment variable during runtime.
       // cf. https://nextjs.org/docs/app/guides/data-security#overwriting-encryption-keys-advanced
       defineEncryptionKey: 'process.env.MY_ENCRYPTION_KEY',
-
-      // this controls build-time validation of 'client-only' and 'server-only' imports.
-      // this is enabled by default.
-      validateImports: true,
 
       // when `loadModuleDevProxy: true`, `import.meta.viteRsc.loadModule` is implemented
       // through `fetch` based RPC, which allows, for example, rsc environment inside

--- a/packages/plugin-rsc/README.md
+++ b/packages/plugin-rsc/README.md
@@ -500,7 +500,7 @@ See also [Vite documentation](https://vite.dev/guide/api-hmr.html#intellisense-f
 
 ## `server-only` and `client-only` import
 
-You can use `server-only` import to avoid accidentally leaking certain modules on client build, which becomes public static assets.
+You can use `server-only` import to avoid accidentally leaking certain modules to client build static assets.
 
 For example, ...todo
 

--- a/packages/plugin-rsc/README.md
+++ b/packages/plugin-rsc/README.md
@@ -505,8 +505,7 @@ See also [Vite documentation](https://vite.dev/guide/api-hmr.html#intellisense-f
 <!-- https://overreacted.io/how-imports-work-in-rsc/ -->
 
 You can use `server-only` import to prevent accidentally importing server-only code on client, which can expose sensitive server code to public static assets.
-
-For example, the plugin will show an error `'server-only' cannot be imported in client build` for the following codes:
+For example, the plugin will show an error `'server-only' cannot be imported in client build` for the following code:
 
 - server-utils.js
 
@@ -531,7 +530,8 @@ import { getData } from './server-utils.js' // ❌ 'server-only' cannot be impor
 ...
 ```
 
-Similarly, `client-only` import can ensure browser-specific code isn't accidentally imported in server environment. For example, the plugin will show an error `'client-only' cannot be imported in server build` for the following codes:
+Similarly, `client-only` import can ensure browser-specific code isn't accidentally imported in server environment.
+For example, the plugin will show an error `'client-only' cannot be imported in server build` for the following code:
 
 - client-utils.js
 

--- a/packages/plugin-rsc/examples/starter/src/root.tsx
+++ b/packages/plugin-rsc/examples/starter/src/root.tsx
@@ -3,6 +3,7 @@ import viteLogo from '/vite.svg'
 import { getServerCounter, updateServerCounter } from './action.tsx'
 import reactLogo from './assets/react.svg'
 import { ClientCounter } from './client.tsx'
+import 'client-only'
 
 export function Root(props: { url: URL }) {
   return (

--- a/packages/plugin-rsc/examples/starter/src/root.tsx
+++ b/packages/plugin-rsc/examples/starter/src/root.tsx
@@ -3,7 +3,6 @@ import viteLogo from '/vite.svg'
 import { getServerCounter, updateServerCounter } from './action.tsx'
 import reactLogo from './assets/react.svg'
 import { ClientCounter } from './client.tsx'
-import 'client-only'
 
 export function Root(props: { url: URL }) {
   return (


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

React router documentation mentions `client-only` and `server-only` https://github.com/remix-run/react-router/pull/14336. It would be nice to explain what this does on our side too.