### PR TITLE
fix(rsc): fix plugin name in `client-only` error message

### DIFF
--- a/packages/plugin-rsc/e2e/validate-imports.test.ts
+++ b/packages/plugin-rsc/e2e/validate-imports.test.ts
@@ -103,7 +103,7 @@ test.describe('validate imports', () => {
         nodeOptions: { cwd: root },
       })
       expect(result.stderr).toContain(
-        `'server-only' cannot be imported in client build`,
+        `[rsc:validate-imports] 'server-only' cannot be imported in client build`,
       )
       expect(result.exitCode).not.toBe(0)
     })
@@ -152,7 +152,7 @@ test.describe('validate imports', () => {
         nodeOptions: { cwd: root },
       })
       expect(result.stderr).toContain(
-        `'client-only' cannot be imported in server build`,
+        `[rsc:validate-imports] 'client-only' cannot be imported in server build`,
       )
       expect(result.exitCode).not.toBe(0)
     })

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1311,7 +1311,8 @@ function vitePluginUseClient(
         async handler(source, importer, options) {
           if (
             this.environment.name === serverEnvironmentName &&
-            bareImportRE.test(source)
+            bareImportRE.test(source) &&
+            !(source === 'client-only' || source === 'server-only')
           ) {
             const resolved = await this.resolve(source, importer, options)
             if (resolved && resolved.id.includes('/node_modules/')) {


### PR DESCRIPTION
### Description

Currently `client-only` error shows up as `rsc:virtual-client-package`:

```
[rsc:virtual-client-package] 'client-only' cannot be imported in server build (importer: '/home/hiroshi/code/others/vite-plugin-react/packages/plugin-rsc/examples/starter/src/root.tsx', environment: rsc)
```

We can hard-code `server-only/client-only` here to skip this step, so the error gets surfaced as:

```
[rsc:validate-imports] 'client-only' cannot be imported in server build (importer: '/home/hiroshi/code/others/vite-plugin-react/packages/plugin-rsc/examples/starter/src/root.tsx', environment: rsc)
```

This isn't fool proof though since other plugins might use `this.resolve` too. Eventually we should look into to surfacing errors later stage so we have a knowledge of module graph. Tracked in https://github.com/vitejs/vite-plugin-react/issues/863.