### PR TITLE
fix(rsc): show import chain for server-only and client-only import error

### DIFF
--- a/packages/plugin-rsc/src/plugins/validate-import.ts
+++ b/packages/plugin-rsc/src/plugins/validate-import.ts
@@ -67,8 +67,9 @@ export function validateImportPlugin(): Plugin {
         }
       },
     },
-    // for build, use PluginContext.getModuleInfo during generateBundle
-    generateBundle() {
+    // for build, use PluginContext.getModuleInfo during buildEnd.
+    // rollup shows multiple errors if there are other build error from `buildEnd(error)`.
+    buildEnd() {
       if (this.environment.mode === 'build') {
         const serverOnly = getImportChainBuild(
           this,

--- a/packages/plugin-rsc/src/plugins/validate-import.ts
+++ b/packages/plugin-rsc/src/plugins/validate-import.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from 'vite'
+import type { DevEnvironment, Plugin, Rollup } from 'vite'
 
 // https://github.com/vercel/next.js/blob/90f564d376153fe0b5808eab7b83665ee5e08aaf/packages/next/src/build/webpack-config.ts#L1249-L1280
 // https://github.com/pcattori/vite-env-only/blob/68a0cc8546b9a37c181c0b0a025eb9b62dbedd09/src/deny-imports.ts
@@ -8,37 +8,131 @@ export function validateImportPlugin(): Plugin {
     name: 'rsc:validate-imports',
     resolveId: {
       order: 'pre',
-      async handler(source, importer, options) {
+      async handler(source, _importer, options) {
         // optimizer is not aware of server/client boudnary so skip
         if ('scan' in options && options.scan) {
           return
         }
 
         // Validate client-only imports in server environments
-        if (source === 'client-only') {
-          if (this.environment.name === 'rsc') {
-            throw new Error(
-              `'client-only' cannot be imported in server build (importer: '${importer ?? 'unknown'}', environment: ${this.environment.name})`,
-            )
+        if (source === 'client-only' || source === 'server-only') {
+          if (
+            (source === 'client-only' && this.environment.name === 'rsc') ||
+            (source === 'server-only' && this.environment.name !== 'rsc')
+          ) {
+            return {
+              id: `\0virtual:vite-rsc/validate-imports/invalid/${source}`,
+              moduleSideEffects: true,
+            }
           }
-          return { id: `\0virtual:vite-rsc/empty`, moduleSideEffects: false }
-        }
-        if (source === 'server-only') {
-          if (this.environment.name !== 'rsc') {
-            throw new Error(
-              `'server-only' cannot be imported in client build (importer: '${importer ?? 'unknown'}', environment: ${this.environment.name})`,
-            )
+          return {
+            id: `\0virtual:vite-rsc/validate-imports/valid/${source}`,
+            moduleSideEffects: false,
           }
-          return { id: `\0virtual:vite-rsc/empty`, moduleSideEffects: false }
         }
 
         return
       },
     },
     load(id) {
-      if (id.startsWith('\0virtual:vite-rsc/empty')) {
+      if (id.startsWith('\0virtual:vite-rsc/validate-imports/invalid/')) {
+        // it should surface as build error but we make a runtime error just in case.
+        const source = id.slice(id.lastIndexOf('/') + 1)
+        return `throw new Error("invalid import of '${source}'")`
+      }
+      if (id.startsWith('\0virtual:vite-rsc/validate-imports/')) {
         return `export {}`
       }
     },
+    // need a different way to probe module graph for dev and build
+    transform: {
+      order: 'post',
+      async handler(_code, id) {
+        if (this.environment.mode === 'dev') {
+          if (id.startsWith(`\0virtual:vite-rsc/validate-imports/invalid/`)) {
+            const chain = getImportChainDev(this.environment, id)
+            const error = formatError(chain, this.environment.name)
+            if (error) {
+              this.error({
+                id: chain[1],
+                message: error,
+              })
+            }
+          }
+        }
+      },
+    },
+    generateBundle() {
+      if (this.environment.mode === 'build') {
+        const serverOnly = getImportChainBuild(
+          this,
+          '\0virtual:vite-rsc/validate-imports/invalid/server-only',
+        )
+        const serverOnlyError = formatError(serverOnly, this.environment.name)
+        if (serverOnlyError) {
+          throw new Error(serverOnlyError)
+        }
+        const clientOnly = getImportChainBuild(
+          this,
+          '\0virtual:vite-rsc/validate-imports/invalid/client-only',
+        )
+        const clientOnlyError = formatError(clientOnly, this.environment.name)
+        if (clientOnlyError) {
+          throw new Error(clientOnlyError)
+        }
+      }
+    },
   }
+}
+
+function getImportChainDev(environment: DevEnvironment, id: string) {
+  const chain: string[] = []
+  const recurse = (id: string) => {
+    if (chain.includes(id)) return
+    const info = environment.moduleGraph.getModuleById(id)
+    if (!info) return
+    chain.push(id)
+    const next = [...info.importers][0]
+    if (next && next.id) {
+      recurse(next.id)
+    }
+  }
+  recurse(id)
+  return chain
+}
+
+function getImportChainBuild(ctx: Rollup.PluginContext, id: string): string[] {
+  const chain: string[] = []
+  const recurse = (id: string) => {
+    if (chain.includes(id)) return
+    const info = ctx.getModuleInfo(id)
+    if (!info) return
+    chain.push(id)
+    const next = info.importers[0]
+    if (next) {
+      recurse(next)
+    }
+  }
+  recurse(id)
+  return chain
+}
+
+function formatError(
+  chain: string[],
+  environmentName: string,
+): string | undefined {
+  if (chain.length === 0) return
+  const id = chain[0]!
+  const source = id.slice(id.lastIndexOf('/') + 1)
+  let result = `'${source}' cannot be imported in '${environmentName}' environment:\n`
+  result += chain
+    .slice(1, 6)
+    .map(
+      (id, i) => ' '.repeat(i + 1) + `imported by ${id.replaceAll('\0', '')}\n`,
+    )
+    .join('')
+  if (chain.length > 6) {
+    result += ' '.repeat(7) + '...\n'
+  }
+  return result
 }

--- a/packages/plugin-rsc/src/plugins/validate-import.ts
+++ b/packages/plugin-rsc/src/plugins/validate-import.ts
@@ -44,7 +44,7 @@ export function validateImportPlugin(): Plugin {
         return `export {}`
       }
     },
-    // need a different way to probe module graph for dev and build
+    // for dev, use DevEnvironment.moduleGraph during post transform
     transform: {
       order: 'post',
       async handler(_code, id) {
@@ -62,6 +62,7 @@ export function validateImportPlugin(): Plugin {
         }
       },
     },
+    // for build, use PluginContext.getModuleInfo during generateBundle
     generateBundle() {
       if (this.environment.mode === 'build') {
         const serverOnly = getImportChainBuild(

--- a/packages/plugin-rsc/src/plugins/validate-import.ts
+++ b/packages/plugin-rsc/src/plugins/validate-import.ts
@@ -51,7 +51,7 @@ export function validateImportPlugin(): Plugin {
         if (this.environment.mode === 'dev') {
           if (id.startsWith(`\0virtual:vite-rsc/validate-imports/invalid/`)) {
             const chain = getImportChainDev(this.environment, id)
-            const error = formatError(chain, this.environment.name)
+            const error = formatError(chain)
             if (error) {
               this.error({
                 id: chain[1],
@@ -68,7 +68,7 @@ export function validateImportPlugin(): Plugin {
           this,
           '\0virtual:vite-rsc/validate-imports/invalid/server-only',
         )
-        const serverOnlyError = formatError(serverOnly, this.environment.name)
+        const serverOnlyError = formatError(serverOnly)
         if (serverOnlyError) {
           throw new Error(serverOnlyError)
         }
@@ -76,7 +76,7 @@ export function validateImportPlugin(): Plugin {
           this,
           '\0virtual:vite-rsc/validate-imports/invalid/client-only',
         )
-        const clientOnlyError = formatError(clientOnly, this.environment.name)
+        const clientOnlyError = formatError(clientOnly)
         if (clientOnlyError) {
           throw new Error(clientOnlyError)
         }
@@ -117,14 +117,12 @@ function getImportChainBuild(ctx: Rollup.PluginContext, id: string): string[] {
   return chain
 }
 
-function formatError(
-  chain: string[],
-  environmentName: string,
-): string | undefined {
+function formatError(chain: string[]): string | undefined {
   if (chain.length === 0) return
   const id = chain[0]!
   const source = id.slice(id.lastIndexOf('/') + 1)
-  let result = `'${source}' cannot be imported in '${environmentName}' environment:\n`
+  const buildName = source === 'server-only' ? 'client' : 'server'
+  let result = `'${source}' cannot be imported in ${buildName} build:\n`
   result += chain
     .slice(1, 6)
     .map(

--- a/packages/plugin-rsc/src/plugins/validate-import.ts
+++ b/packages/plugin-rsc/src/plugins/validate-import.ts
@@ -51,7 +51,7 @@ export function validateImportPlugin(): Plugin {
         if (this.environment.mode === 'dev') {
           if (id.startsWith(`\0virtual:vite-rsc/validate-imports/invalid/`)) {
             const chain = getImportChainDev(this.environment, id)
-            const error = formatError(chain)
+            const error = formatError(chain, this.environment.name)
             if (error) {
               this.error({
                 id: chain[1],
@@ -68,7 +68,7 @@ export function validateImportPlugin(): Plugin {
           this,
           '\0virtual:vite-rsc/validate-imports/invalid/server-only',
         )
-        const serverOnlyError = formatError(serverOnly)
+        const serverOnlyError = formatError(serverOnly, this.environment.name)
         if (serverOnlyError) {
           throw new Error(serverOnlyError)
         }
@@ -76,7 +76,7 @@ export function validateImportPlugin(): Plugin {
           this,
           '\0virtual:vite-rsc/validate-imports/invalid/client-only',
         )
-        const clientOnlyError = formatError(clientOnly)
+        const clientOnlyError = formatError(clientOnly, this.environment.name)
         if (clientOnlyError) {
           throw new Error(clientOnlyError)
         }
@@ -117,12 +117,15 @@ function getImportChainBuild(ctx: Rollup.PluginContext, id: string): string[] {
   return chain
 }
 
-function formatError(chain: string[]): string | undefined {
+function formatError(
+  chain: string[],
+  environmentName: string,
+): string | undefined {
   if (chain.length === 0) return
   const id = chain[0]!
   const source = id.slice(id.lastIndexOf('/') + 1)
   const buildName = source === 'server-only' ? 'client' : 'server'
-  let result = `'${source}' cannot be imported in ${buildName} build:\n`
+  let result = `'${source}' cannot be imported in ${buildName} build ('${environmentName}' environment):\n`
   result += chain
     .slice(1, 6)
     .map(


### PR DESCRIPTION
### Description

- Closes https://github.com/vitejs/vite-plugin-react/issues/863

I looked at sveltekit https://github.com/sveltejs/kit/pull/14155, but `this.resolve` tracking feels more complicated, so I went with a different approach of probing module graph. It employs a separate technique for dev and build, which isn't something I wanted, but for now this should be fine.

This is how new error message looks like:

Before

```
error during build:
[rsc:validate-imports] 'server-only' cannot be imported in client build
(importer: '/home/hiroshi/code/others/vite-plugin-react/packages/plugin-rsc/examples/e2e/temp/validate-server-only/src/client.tsx', environment: ssr)
```

After

```
error during build:
[rsc:validate-imports] 'server-only' cannot be imported in client build ('ssr' environment):
 imported by src/client.tsx
  imported by virtual:vite-rsc/client-references
   imported by ../../../../dist/ssr-8BA2nj0-.js
    imported by ../../../../dist/ssr.js
     imported by src/framework/entry.ssr.tsx

file: /home/hiroshi/code/others/vite-plugin-react/packages/plugin-rsc/examples/e2e/temp/validate-server-only/src/client.tsx
```

---

TODO
- [ ] share social

Improved the error message for `server-only` and `client-only` imports on Vite RSC plugin. 

<img width="1110" height="473" alt="image" src="https://github.com/user-attachments/assets/6dd49e86-a7eb-4721-a570-f64a3ac5324b" />

These "only" packages provide errors only during runtime on their own, but I didn't see any reason not to surface as build time error, so this has been included as a "plugin feature". Read the updated documentation to learn more! https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-rsc/README.md#server-only-and-client-only-import

It's good to know Next.js also clarifies this as a "framework feature" and not package's own behavior, which I obviously referenced it when adding the doc https://nextjs.org/docs/app/getting-started/server-and-client-components