### PR TITLE
test(rsc): tweak assertions for rolldown-vite

### DIFF
--- a/packages/plugin-rsc/e2e/validate-imports.test.ts
+++ b/packages/plugin-rsc/e2e/validate-imports.test.ts
@@ -102,8 +102,10 @@ test.describe('validate imports', () => {
         throwOnError: false,
         nodeOptions: { cwd: root },
       })
+      // assertion is adjusted for rolldown-vite
+      expect(result.stderr).toContain(`rsc:validate-imports`)
       expect(result.stderr).toContain(
-        `[rsc:validate-imports] 'server-only' cannot be imported in client build`,
+        `'server-only' cannot be imported in client build`,
       )
       expect(result.exitCode).not.toBe(0)
     })
@@ -151,8 +153,9 @@ test.describe('validate imports', () => {
         throwOnError: false,
         nodeOptions: { cwd: root },
       })
+      expect(result.stderr).toContain(`rsc:validate-imports`)
       expect(result.stderr).toContain(
-        `[rsc:validate-imports] 'client-only' cannot be imported in server build`,
+        `'client-only' cannot be imported in server build`,
       )
       expect(result.exitCode).not.toBe(0)
     })


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

- Follow up to https://github.com/vitejs/vite-plugin-react/pull/862

I missed a genuine CI fail on rolldown in https://github.com/vitejs/vite-plugin-react/pull/862. It looks like the error message is slightly different, but it's non essential, so let's just tweak assertions.

```
// rollup
[rsc:validate-imports] 'server-only' cannot be imported in client build

// rolldown
[plugin rsc:validate-imports]
'server-only' cannot be imported in client build
```
