### PR TITLE
refactor(rsc): use inline style for server css during dev

### DIFF
--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -739,13 +739,13 @@ function defineTest(f: Fixture) {
           'link[rel="stylesheet"][data-precedence="vite-rsc/client-reference"]',
         ),
       ).toHaveCount(0)
-      await expect(
-        page
-          .locator(
-            'link[rel="stylesheet"][data-precedence="vite-rsc/importer-resources"]',
-          )
-          .nth(0),
-      ).toBeAttached()
+      // await expect(
+      //   page
+      //     .locator(
+      //       'link[rel="stylesheet"][data-precedence="vite-rsc/importer-resources"]',
+      //     )
+      //     .nth(0),
+      // ).toBeAttached()
       await expect(
         page
           .locator(

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -2264,10 +2264,11 @@ function generateResourcesCode2(
             'style',
             {
               key: 'css:' + id,
-              rel: 'stylesheet',
+              // https://react.dev/reference/react-dom/components/style#rendering-an-inline-css-stylesheet
+              href: 'vite-rsc/importer-resources/' + id,
               precedence: 'vite-rsc/importer-resources',
-              // href: href,
-              // 'data-rsc-css-href': href,
+              // https://github.com/vitejs/vite/blob/dfd8d8aebec412f56346d078bb00170807f0883e/packages/vite/src/client/client.ts#L504
+              'data-vite-dev-id': id,
             },
             content,
           ),

--- a/packages/plugin-rsc/src/plugins/shared.ts
+++ b/packages/plugin-rsc/src/plugins/shared.ts
@@ -1,6 +1,6 @@
 type CssVirtual = {
   id: string
-  type: 'ssr' | 'rsc'
+  type: 'ssr' | 'rsc' | 'rsc-browser'
 }
 
 export function toCssVirtual({ id, type }: CssVirtual) {


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

Exploration for server css primitive.

TODO

- server only css
  - for hmr, client needs to load side effect import.
  - so for us, we need to revive https://github.com/vitejs/vite-plugin-react/pull/841. but this can potentially fix https://github.com/vitejs/vite-plugin-react/issues/850. I also remembered I didn't like this because this would flood css code in rsc payload. Also React's hoisted `<style>` doesn't support arbitrary `data-` tags since React are allowed to merge multiple styles tags with same precedence.
- any negative effect of eager `environment.transformRequest` during ssr
  - `?direct` or `?inline`
  - server environment or client environment
- eager or lazy traverse module graph