### PR TITLE
docs: remove `disableOxcRecommendation` from plugin-react readme

### DIFF
--- a/packages/plugin-react/README.md
+++ b/packages/plugin-react/README.md
@@ -127,10 +127,6 @@ Otherwise, you'll probably get this error:
 Uncaught Error: @vitejs/plugin-react can't detect preamble. Something is wrong.
 ```
 
-### disableOxcRecommendation
-
-If set, disables the recommendation to use `@vitejs/plugin-react-oxc` (which is shown when `rolldown-vite` is detected and `babel` is not configured).
-
 ## Consistent components exports
 
 For React refresh to work correctly, your file should only export React components. You can find a good explanation in the [Gatsby docs](https://www.gatsbyjs.com/docs/reference/local-development/fast-refresh/#how-it-works).


### PR DESCRIPTION
### Description

The option was depreciated in `5.0.0-beta.0 (2025-07-28)`

https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/CHANGELOG.md#500-beta0-2025-07-28

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
