### PR TITLE
fix(rsc): reject inline "use server" inside "use client" module

### DIFF
--- a/packages/plugin-rsc/e2e/error.test.ts
+++ b/packages/plugin-rsc/e2e/error.test.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test'
+import { setupInlineFixture } from './fixture'
+import { x } from 'tinyexec'
+
+test.describe('invalid directives', () => {
+  test.describe('"use server" in "use client"', () => {
+    const root = 'examples/e2e/temp/use-server-in-use-client'
+    test.beforeAll(async () => {
+      await setupInlineFixture({
+        src: 'examples/starter',
+        dest: root,
+        files: {
+          'src/client.tsx': /* tsx */ `
+            "use client";
+            
+            export function TestClient() {
+              return <div>[test-client]</div>
+            }
+
+            function testFn() {
+              "use server";
+              console.log("testFn");
+            }
+          `,
+          'src/root.tsx': /* tsx */ `
+            import { TestClient } from './client.tsx'
+  
+            export function Root() {
+              return (
+                <html lang="en">
+                  <head>
+                    <meta charSet="UTF-8" />
+                  </head>
+                  <body>
+                    <div>[test-server]</div>
+                    <TestClient />
+                  </body>
+                </html>
+              )
+            }
+          `,
+        },
+      })
+    })
+
+    test('build', async () => {
+      const result = await x('pnpm', ['build'], {
+        throwOnError: false,
+        nodeOptions: { cwd: root },
+      })
+      expect(result.stderr).toContain(
+        `'use server' directive is not allowed inside 'use client'`,
+      )
+      expect(result.exitCode).not.toBe(0)
+    })
+  })
+})

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1140,7 +1140,7 @@ function vitePluginUseClient(
           const directives = findDirectives(ast, 'use server')
           if (directives.length > 0) {
             this.error(
-              `'use server' directive is not allowed within 'use client'`,
+              `'use server' directive is not allowed inside 'use client'`,
               directives[0]?.start,
             )
           }

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -29,6 +29,7 @@ import {
   transformDirectiveProxyExport,
   transformServerActionServer,
   transformWrapExport,
+  findDirectives,
 } from './transforms'
 import { generateEncryptionKey, toBase64 } from './utils/encryption-utils'
 import { createRpcServer } from './utils/rpc'
@@ -1133,6 +1134,16 @@ function vitePluginUseClient(
         if (!hasDirective(ast.body, 'use client')) {
           delete manager.clientReferenceMetaMap[id]
           return
+        }
+
+        if (code.includes('use server')) {
+          const directives = findDirectives(ast, 'use server')
+          if (directives.length > 0) {
+            this.error(
+              `'use server' directive is not allowed within 'use client'`,
+              directives[0]?.start,
+            )
+          }
         }
 
         let importId: string


### PR DESCRIPTION
### Description

- Closes https://github.com/vitejs/vite-plugin-react/issues/883

_todo_
- [x] test with react-router client routes

## example

- client.tsx

```tsx
'use client'

import React from 'react'

export function ClientCounter() {
  const [count, setCount] = React.useState(0)

  function someFn() {
    "use server";
    console.log("foo");
  }

  return (
    <button onClick={() => setCount((count) => count + 1)}>
      Client Counter: {count}
    </button>
  )
}
```

This code will cause a build error:

```
error during build:
[rsc:use-client] [plugin rsc:use-client] src/client.tsx (7:4): 'use server' directive is not allowed within 'use client'
file: /home/hiroshi/code/others/vite-plugin-react/packages/plugin-rsc/examples/starter/src/client.tsx:7:4

5:   const [count, setCount] = React.useState(0);
6:   function someFn() {
7:     "use server";
       ^
8:     console.log("foo");
9:   }
```

## example (react router client module)

- route.tsx

```tsx
function serverFnInsideClienRoute() {
  "use server";
  console.log("nooo");
}

export default function Index() {
  return (
    <div>
      <form action={serverFnInsideClienRoute}>foo</form>
    </div>
  );
}
```

- build error

```
vite v7.1.6 building SSR bundle for production...
🧪 Using React Router's RSC Framework Mode (experimental)
✓ 33 modules transformed.
✗ Build failed in 221ms
[rsc:use-client] [plugin rsc:use-client] app/routes/_index/route.tsx?client-route-module (3:2): 'use server' directive is not allowed inside 'use client'
file: /home/hiroshi/Downloads/github-mu2rn18z-rvf27n9w/app/routes/_index/route.tsx?client-route-module:3:2

1: "use client";import { jsx } from "react/jsx-runtime";
2: function serverFnInsideClienRoute() {
3:   "use server";
     ^
4: 
5:   console.log("nooo");
```