### PR TITLE
ci: separate React dependencies in Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,6 +32,7 @@
       "matchPackageNames": ["!actions/{/,}**", "!github/{/,}**"],
     },
     {
+      "groupName": "react",
       "matchPackageNames": [
         "react",
         "react-dom",
@@ -42,7 +43,6 @@
         "react-server-dom-webpack",
         "use-sync-external-store",
       ],
-      "groupName": "react",
     },
   ],
   "ignoreDeps": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -31,6 +31,19 @@
       "pinDigests": true,
       "matchPackageNames": ["!actions/{/,}**", "!github/{/,}**"],
     },
+    {
+      "matchPackageNames": [
+        "react",
+        "react-dom",
+        "@types/react",
+        "@types/react-dom",
+        "react-is",
+        "react-refresh",
+        "react-server-dom-webpack",
+        "use-sync-external-store",
+      ],
+      "groupName": "react",
+    },
   ],
   "ignoreDeps": [
     // manually bumping


### PR DESCRIPTION
### Description

This PR splits react related dependencies from common renovate PRs like https://github.com/vitejs/vite-plugin-react/pull/896. Currently that PR is failing and splitting this makes it easier to analyze and also unblock other deps.
