### PR TITLE
chore(deps): remove unused `react-is`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -38,7 +38,6 @@
         "react-dom",
         "@types/react",
         "@types/react-dom",
-        "react-is",
         "react-refresh",
         "react-server-dom-webpack",
         "use-sync-external-store",

--- a/packages/plugin-react-swc/playground/styled-components/package.json
+++ b/packages/plugin-react-swc/playground/styled-components/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "react-is": "^19.1.1",
     "styled-components": "^6.1.19"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -367,9 +367,6 @@ importers:
       react-dom:
         specifier: ^19.1.1
         version: 19.1.1(react@19.1.1)
-      react-is:
-        specifier: ^19.1.1
-        version: 19.1.1
       styled-components:
         specifier: ^6.1.19
         version: 6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -4019,9 +4016,6 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
-
-  react-is@19.1.1:
-    resolution: {integrity: sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==}
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -7714,8 +7708,6 @@ snapshots:
       scheduler: 0.26.0
 
   react-is@16.13.1: {}
-
-  react-is@19.1.1: {}
 
   react-refresh@0.17.0: {}
 


### PR DESCRIPTION
### Description

It looks like `styled-components` uses it internally (so `react-is@16.13.1` is still inside lockfile), but it can be removed from `dependencies`.

```sh
$ pnpm why -r react-is
Legend: production dependency, optional only, dev only

playground-emotion /home/hiroshi/code/others/vite-plugin-react/packages/plugin-react-swc/playground/emotion (PRIVATE)

dependencies:
@emotion/react 11.14.0
└─┬ hoist-non-react-statics 3.3.2
  └── react-is 16.13.1
@emotion/styled 11.14.1
└─┬ @emotion/react 11.14.0 peer
  └─┬ hoist-non-react-statics 3.3.2
    └── react-is 16.13.1

playground-emotion-plugin /home/hiroshi/code/others/vite-plugin-react/packages/plugin-react-swc/playground/emotion-plugin (PRIVATE)

dependencies:
@emotion/react 11.14.0
└─┬ hoist-non-react-statics 3.3.2
  └── react-is 16.13.1
@emotion/styled 11.14.1
└─┬ @emotion/react 11.14.0 peer
  └─┬ hoist-non-react-statics 3.3.2
    └── react-is 16.13.1

playground-styled-components /home/hiroshi/code/others/vite-plugin-react/packages/plugin-react-swc/playground/styled-components (PRIVATE)

devDependencies:
@types/styled-components 5.1.34
└─┬ @types/hoist-non-react-statics 3.3.6
  └─┬ hoist-non-react-statics 3.3.2
    └── react-is 16.13.1

@vitejs/test-react-emotion /home/hiroshi/code/others/vite-plugin-react/playground/react-emotion (PRIVATE)

dependencies:
@emotion/react 11.14.0
└─┬ hoist-non-react-statics 3.3.2
  └── react-is 16.13.1
@emotion/styled 11.14.1
└─┬ @emotion/react 11.14.0 peer
  └─┬ hoist-non-react-statics 3.3.2
    └── react-is 16.13.1
react-switch 7.1.0
└─┬ prop-types 15.8.1
  └── react-is 16.13.1
```