### PR TITLE
chore(rsc): update `compatibility_date` for `WeakRef`

### DIFF
--- a/packages/plugin-rsc/examples/basic/wrangler.jsonc
+++ b/packages/plugin-rsc/examples/basic/wrangler.jsonc
@@ -6,6 +6,6 @@
     "directory": "dist/client",
   },
   "workers_dev": true,
-  "compatibility_date": "2025-04-01",
+  "compatibility_date": "2025-10-01",
   "compatibility_flags": ["nodejs_als"],
 }

--- a/packages/plugin-rsc/examples/react-router/cf/wrangler.rsc.jsonc
+++ b/packages/plugin-rsc/examples/react-router/cf/wrangler.rsc.jsonc
@@ -3,6 +3,6 @@
   "name": "vite-rsc-react-router-rsc",
   "main": "./entry.rsc.tsx",
   "workers_dev": true,
-  "compatibility_date": "2025-04-01",
+  "compatibility_date": "2025-10-01",
   "compatibility_flags": ["nodejs_als"],
 }

--- a/packages/plugin-rsc/examples/react-router/cf/wrangler.ssr.jsonc
+++ b/packages/plugin-rsc/examples/react-router/cf/wrangler.ssr.jsonc
@@ -4,6 +4,6 @@
   "main": "./entry.ssr.tsx",
   "workers_dev": true,
   "services": [{ "binding": "RSC", "service": "vite-rsc-react-router-rsc" }],
-  "compatibility_date": "2025-04-01",
+  "compatibility_date": "2025-10-01",
   "compatibility_flags": ["nodejs_als"],
 }

--- a/packages/plugin-rsc/examples/starter-cf-single/wrangler.jsonc
+++ b/packages/plugin-rsc/examples/starter-cf-single/wrangler.jsonc
@@ -3,6 +3,6 @@
   "name": "vite-rsc-starter",
   "main": "./src/framework/entry.rsc.tsx",
   "workers_dev": true,
-  "compatibility_date": "2025-04-01",
+  "compatibility_date": "2025-10-01",
   "compatibility_flags": ["nodejs_als"],
 }


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

- Related https://github.com/vitejs/vite-plugin-react/pull/901

It turned out react-router + cloudflare is also failing on 19.2 with different reason. Here is an error:

```
11:17:47 AM [vite] Internal server error: WeakRef is not defined
      at new ResponseInstance (/home/hiroshi/code/others/vite-plugin-react/packages/plugin-rsc/dist/vendor/react-server-dom/cjs/react-server-dom-webpack-client.edge.development.js:2802:40)
      at createResponseFromOptions (/home/hiroshi/code/others/vite-plugin-react/packages/plugin-rsc/dist/vendor/react-server-dom/cjs/react-server-dom-webpack-client.edge.development.js:4508:14)
      at Object.exports.createFromReadableStream (/home/hiroshi/code/others/vite-plugin-react/packages/plugin-rsc/dist/vendor/react-server-dom/cjs/react-server-dom-webpack-client.edge.development.js:4895:22)
      at createFromReadableStream (/home/hiroshi/code/others/vite-plugin-react/packages/plugin-rsc/dist/ssr-Cd4SbAaO.js:6:21)
      at routeRSCServerRequest (/home/hiroshi/code/others/vite-plugin-react/node_modules/.pnpm/react-router@7.9.3_react-dom@19.2.0_react@19.2.0__react@19.2.0/node_modules/react-router/dist/development/chunk-65XJMMLO.mjs:2640:27)
      at generateHTML (/home/hiroshi/code/others/vite-plugin-react/packages/plugin-rsc/examples/react-router/react-router-vite/entry.ssr.tsx:12:10)
      at maybeCaptureError (runner-worker/index.js:39:12)
```

`WeakRef` is available by bumping `compatibility_date` https://github.com/cloudflare/workerd/issues/3053, https://github.com/opennextjs/opennextjs-cloudflare/issues/660.