### PR TITLE
fix(rsc): fix "use server" transform for source file without ending new line

### DIFF
--- a/packages/plugin-rsc/src/transforms/hoist.test.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.test.ts
@@ -447,4 +447,12 @@ export async function kv() {
       "
     `)
   })
+
+  it('no ending new line', async () => {
+    const input = `\
+export async function test() {
+  "use server";
+}`
+    expect(await testTransform(input)).toMatchInlineSnapshot()
+  })
 })

--- a/packages/plugin-rsc/src/transforms/hoist.test.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.test.ts
@@ -453,6 +453,14 @@ export async function kv() {
 export async function test() {
   "use server";
 }`
-    expect(await testTransform(input)).toMatchInlineSnapshot()
+    expect(await testTransform(input)).toMatchInlineSnapshot(`
+      "export const test = /* #__PURE__ */ $$register($$hoist_0_test, "<id>", "$$hoist_0_test");
+
+      ;export async function $$hoist_0_test() {
+        "use server";
+      };
+      /* #__PURE__ */ Object.defineProperty($$hoist_0_test, "name", { value: "test" });
+      "
+    `)
   })
 })

--- a/packages/plugin-rsc/src/transforms/hoist.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.ts
@@ -27,6 +27,7 @@ export function transformHoistInlineDirective(
   output: MagicString
   names: string[]
 } {
+  // ensure ending space so we can move node at the end without breaking magic-string
   if (!input.endsWith('\n')) {
     input += '\n'
   }

--- a/packages/plugin-rsc/src/transforms/hoist.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.ts
@@ -27,6 +27,9 @@ export function transformHoistInlineDirective(
   output: MagicString
   names: string[]
 } {
+  if (!input.endsWith('\n')) {
+    input += '\n'
+  }
   const output = new MagicString(input)
   const directive =
     typeof options.directive === 'string'


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

This is found when swapping `useCachePlugin` and `rsc` plugin order in https://github.com/jacob-ebey/vite-plugin-react-use-cache/pull/2.

Not exactly sure why, but for now, we can just artificially ensure new line at the end on transform side.