### PR TITLE
chore(rsc): use websocket for browser module runner transport

### DIFF
--- a/packages/plugin-rsc/examples/browser-mode/package.json
+++ b/packages/plugin-rsc/examples/browser-mode/package.json
@@ -18,6 +18,7 @@
     "@types/react-dom": "^19.2.2",
     "@vitejs/plugin-react": "latest",
     "@vitejs/plugin-rsc": "latest",
-    "vite": "^7.1.10"
+    "vite": "^7.1.10",
+    "vite-dev-rpc": "^1.1.0"
   }
 }

--- a/packages/plugin-rsc/examples/browser-mode/src/framework/load-client-dev.tsx
+++ b/packages/plugin-rsc/examples/browser-mode/src/framework/load-client-dev.tsx
@@ -1,19 +1,17 @@
 import { ESModulesEvaluator, ModuleRunner } from 'vite/module-runner'
+import { createRPCClient } from 'vite-dev-rpc'
+
+const rpcClient = createRPCClient<{ invoke: Function }, {}>(
+  'transport-proxy',
+  import.meta.hot!,
+)
 
 export default async function loadClient() {
   const runner = new ModuleRunner(
     {
       sourcemapInterceptor: false,
       transport: {
-        invoke: async (payload) => {
-          const response = await fetch(
-            '/@vite/invoke-react-client?' +
-              new URLSearchParams({
-                data: JSON.stringify(payload),
-              }),
-          )
-          return response.json()
-        },
+        invoke: (payload) => rpcClient.invoke(payload),
       },
       hmr: false,
     },

--- a/packages/plugin-rsc/examples/browser/lib/dev-proxy.ts
+++ b/packages/plugin-rsc/examples/browser/lib/dev-proxy.ts
@@ -1,19 +1,30 @@
-import { ESModulesEvaluator, ModuleRunner } from 'vite/module-runner'
+import {
+  ESModulesEvaluator,
+  ModuleRunner,
+  createWebSocketModuleRunnerTransport,
+} from 'vite/module-runner'
 
 const runner = new ModuleRunner(
   {
     sourcemapInterceptor: false,
-    transport: {
-      invoke: async (payload) => {
-        const response = await fetch(
-          '/@vite/invoke-rsc?' +
-            new URLSearchParams({
-              data: JSON.stringify(payload),
-            }),
+    // transport: {
+    //   invoke: async (payload) => {
+    //     const response = await fetch(
+    //       '/@vite/invoke-rsc?' +
+    //         new URLSearchParams({
+    //           data: JSON.stringify(payload),
+    //         }),
+    //     )
+    //     return response.json()
+    //   },
+    // },
+    transport: createWebSocketModuleRunnerTransport({
+      createConnection() {
+        return new WebSocket(
+          `ws://${location.host}/@vite/module-runner-transport/rsc`,
         )
-        return response.json()
       },
-    },
+    }),
     hmr: false,
   },
   new ESModulesEvaluator(),

--- a/packages/plugin-rsc/examples/browser/lib/dev-proxy.ts
+++ b/packages/plugin-rsc/examples/browser/lib/dev-proxy.ts
@@ -1,17 +1,16 @@
 import { ESModulesEvaluator, ModuleRunner } from 'vite/module-runner'
+import { createRPCClient } from 'vite-dev-rpc'
+
+const rpcClient = createRPCClient<{ invoke: Function }, {}>(
+  'rsc:transport-proxy',
+  import.meta.hot!,
+)
 
 const runner = new ModuleRunner(
   {
     sourcemapInterceptor: false,
     transport: {
-      connect(handlers) {
-        import.meta.hot!.on('transport-proxy:onMessage', (payload) => {
-          handlers.onMessage(payload)
-        })
-      },
-      send(payload) {
-        import.meta.hot!.send('transport-proxy:send', payload)
-      },
+      invoke: (payload) => rpcClient.invoke(payload),
     },
     hmr: false,
   },

--- a/packages/plugin-rsc/examples/browser/lib/dev-proxy.ts
+++ b/packages/plugin-rsc/examples/browser/lib/dev-proxy.ts
@@ -1,30 +1,18 @@
-import {
-  ESModulesEvaluator,
-  ModuleRunner,
-  createWebSocketModuleRunnerTransport,
-} from 'vite/module-runner'
+import { ESModulesEvaluator, ModuleRunner } from 'vite/module-runner'
 
 const runner = new ModuleRunner(
   {
     sourcemapInterceptor: false,
-    // transport: {
-    //   invoke: async (payload) => {
-    //     const response = await fetch(
-    //       '/@vite/invoke-rsc?' +
-    //         new URLSearchParams({
-    //           data: JSON.stringify(payload),
-    //         }),
-    //     )
-    //     return response.json()
-    //   },
-    // },
-    transport: createWebSocketModuleRunnerTransport({
-      createConnection() {
-        return new WebSocket(
-          `ws://${location.host}/@vite/module-runner-transport/rsc`,
-        )
+    transport: {
+      connect(handlers) {
+        import.meta.hot!.on('transport-proxy:onMessage', (payload) => {
+          handlers.onMessage(payload)
+        })
       },
-    }),
+      send(payload) {
+        import.meta.hot!.send('transport-proxy:send', payload)
+      },
+    },
     hmr: false,
   },
   new ESModulesEvaluator(),

--- a/packages/plugin-rsc/examples/browser/package.json
+++ b/packages/plugin-rsc/examples/browser/package.json
@@ -18,6 +18,7 @@
     "@types/react-dom": "^19.2.2",
     "@vitejs/plugin-react": "latest",
     "@vitejs/plugin-rsc": "latest",
-    "vite": "^7.1.10"
+    "vite": "^7.1.10",
+    "vite-dev-rpc": "^1.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -589,6 +589,9 @@ importers:
       vite:
         specifier: ^7.1.10
         version: 7.1.10(@types/node@22.18.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1)
+      vite-dev-rpc:
+        specifier: ^1.1.0
+        version: 1.1.0(vite@7.1.10(@types/node@22.18.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1))
 
   packages/plugin-rsc/examples/browser-mode:
     dependencies:
@@ -2679,9 +2682,6 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
-  birpc@2.5.0:
-    resolution: {integrity: sha512-VSWO/W6nNQdyP520F1mhf+Lc2f8pjGQOtoHHm7Ze8Go1kX7akpVIrtTa0fn+HB0QJEDVacl6aO08YE0PgXfdnQ==}
 
   birpc@2.6.1:
     resolution: {integrity: sha512-LPnFhlDpdSH6FJhJyn4M0kFO7vtQ5iPw24FnG0y21q09xC7e8+1LeR31S1MAIrDAHp4m7aas4bEkTDTvMAtebQ==}
@@ -6220,8 +6220,6 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  birpc@2.5.0: {}
-
   birpc@2.6.1: {}
 
   blake3-wasm@2.1.5: {}
@@ -8348,7 +8346,7 @@ snapshots:
 
   vite-dev-rpc@1.1.0(vite@7.1.10(@types/node@22.18.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1)):
     dependencies:
-      birpc: 2.5.0
+      birpc: 2.6.1
       vite: 7.1.10(@types/node@22.18.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1)
       vite-hot-client: 2.1.0(vite@7.1.10(@types/node@22.18.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1))
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -617,6 +617,9 @@ importers:
       vite:
         specifier: ^7.1.10
         version: 7.1.10(@types/node@22.18.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1)
+      vite-dev-rpc:
+        specifier: ^1.1.0
+        version: 1.1.0(vite@7.1.10(@types/node@22.18.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1))
 
   packages/plugin-rsc/examples/e2e:
     devDependencies:


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

- supersedes https://github.com/vitejs/vite-plugin-react/pull/943

Or isn't it possible to reuse `import.meta.hot` of the actual client environment?

Indeed, we can just proxy `invoke` through vite-dep-rpc https://github.com/antfu/vite-dev-rpc/
