### PR TITLE
fix(plugin-swc): use SWC when `useAtYourOwnRisk_mutateSwcOptions` is provided

### DIFF
--- a/packages/plugin-react-swc/CHANGELOG.md
+++ b/packages/plugin-react-swc/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 SSR applications can now initialize HMR runtime by importing `@vitejs/plugin-react-swc/preamble` at the top of their client entry instead of manually calling `transformIndexHtml`. This simplifies SSR setup for applications that don't use the `transformIndexHtml` API.
 
+### Use SWC when useAtYourOwnRisk_mutateSwcOptions is provided ([#951](https://github.com/vitejs/vite-plugin-react/pull/951))
+
+Previously, this plugin did not use SWC if plugins were not provided even if `useAtYourOwnRisk_mutateSwcOptions` was provided. This is now fixed.
+
 ## 4.1.0 (2025-09-17)
 
 ### Set SWC cacheRoot options

--- a/packages/plugin-react-swc/src/index.ts
+++ b/packages/plugin-react-swc/src/index.ts
@@ -198,7 +198,7 @@ const react = (_options?: Options): Plugin[] => {
         return { code: newCode ?? result.code, map: result.map }
       },
     },
-    options.plugins
+    options.plugins || options.useAtYourOwnRisk_mutateSwcOptions
       ? {
           name: 'vite:react-swc',
           apply: 'build',


### PR DESCRIPTION
### Description

When `useAtYourOwnRisk_mutateSwcOptions` is provided, Vite's React SWC plugin should opt into the SWC code path, rather than using esbuild.

The current workaround when changing SWC options while not specifying SWC plugins is to provide an empty `plugins` array.

Lost quite a few hours playing with configurations to reach my end-goal of preserving JSDoc comments in the produced output (something not supported by esbuild), not understanding why overriding SWC options seemingly had no effect.

_I.e._, the following currently has **no** effect when building:

```ts
react({
  useAtYourOwnRisk_mutateSwcOptions: (options) => {
    options.jsc.preserveAllComments = true;
  }
})
```

The current workaround is to specify an empty plugins array:

```ts
react({
  plugins: [],
  useAtYourOwnRisk_mutateSwcOptions: (options) => {
    options.jsc.preserveAllComments = true;
  }
}),
```

I understand that my use-case is quite unique, but I still found the current behaviour unexpected.

**Note:** This commit only touches the SWC plugin. The Babel-backed plugin has a similar issue where the provided Babel configuration is sometimes completely ignored (this seemed intentional due to the `canSkipBabel` function, so I decided not to touch that plugin).