### PR TITLE
fix(react-swc): fix `@vitejs/plugin-react-swc/preamble` on build

### DIFF
--- a/packages/plugin-react-swc/src/index.ts
+++ b/packages/plugin-react-swc/src/index.ts
@@ -75,7 +75,7 @@ type Options = {
 }
 
 const react = (_options?: Options): Plugin[] => {
-  let hmrDisabled = false
+  let hmrDisabled = true
   let viteCacheRoot: string | undefined
   const options = {
     jsxImportSource: _options?.jsxImportSource ?? 'react',
@@ -239,14 +239,6 @@ const react = (_options?: Options): Plugin[] => {
             viteCacheRoot = config.cacheDir
           },
         },
-    {
-			name: "vite:react-swc:force-disable-hmr",
-			apply: "build",
-			enforce: "pre",
-			configResolved() {
-				hmrDisabled = true;
-			}
-		},
     virtualPreamblePlugin({
       name: '@vitejs/plugin-react-swc/preamble',
       isEnabled: () => !hmrDisabled,

--- a/packages/plugin-react-swc/src/index.ts
+++ b/packages/plugin-react-swc/src/index.ts
@@ -239,6 +239,14 @@ const react = (_options?: Options): Plugin[] => {
             viteCacheRoot = config.cacheDir
           },
         },
+    {
+			name: "vite:react-swc:force-disable-hmr",
+			apply: "build",
+			enforce: "pre",
+			configResolved() {
+				hmrDisabled = true;
+			}
+		},
     virtualPreamblePlugin({
       name: '@vitejs/plugin-react-swc/preamble',
       isEnabled: () => !hmrDisabled,

--- a/packages/plugin-react-swc/src/index.ts
+++ b/packages/plugin-react-swc/src/index.ts
@@ -133,7 +133,7 @@ const react = (_options?: Options): Plugin[] => {
       }),
       configResolved(config) {
         viteCacheRoot = config.cacheDir
-        if (config.server.hmr === false) hmrDisabled = true
+        hmrDisabled = config.server.hmr === false
         const mdxIndex = config.plugins.findIndex(
           (p) => p.name === '@mdx-js/rollup',
         )


### PR DESCRIPTION
### Description

Should ensure hmrDisabled is set to true during build, preventing React refresh runtime from being included in production bundles.

Otherwise:

```✗ Build failed in 20ms
error during build:
[vite]: Rollup failed to resolve import "/@react-refresh" from "@vitejs/plugin-react-swc/preamble".
This is most likely unintended because it can break your application at runtime.
If you do want to externalize this module explicitly add it to
`build.rollupOptions.external`
```

