### PR TITLE
chore(rsc): remove `use(payload)` workaround

### DIFF
--- a/packages/plugin-rsc/examples/basic/src/framework/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/basic/src/framework/entry.ssr.tsx
@@ -24,11 +24,7 @@ export async function renderHTML(
     // deserialization needs to be kicked off inside ReactDOMServer context
     // for ReactDomServer preinit/preloading to work
     payload ??= createFromReadableStream<RscPayload>(rscStream1)
-    return <FixSsrThenable>{React.use(payload).root}</FixSsrThenable>
-  }
-
-  function FixSsrThenable(props: React.PropsWithChildren) {
-    return props.children
+    return React.use(payload).root
   }
 
   // render html (traditional SSR)

--- a/packages/plugin-rsc/examples/starter/src/framework/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/starter/src/framework/entry.ssr.tsx
@@ -24,16 +24,7 @@ export async function renderHTML(
     // deserialization needs to be kicked off inside ReactDOMServer context
     // for ReactDomServer preinit/preloading to work
     payload ??= createFromReadableStream<RscPayload>(rscStream1)
-    return <FixSsrThenable>{React.use(payload).root}</FixSsrThenable>
-  }
-
-  // Add an empty component in between `SsrRoot` and user `root` to avoid React SSR bugs.
-  //   SsrRoot (use)
-  //     => FixSsrThenable
-  //       => root (which potentially has `lazy` + `use`)
-  // https://github.com/facebook/react/issues/33937#issuecomment-3091349011
-  function FixSsrThenable(props: React.PropsWithChildren) {
-    return props.children
+    return React.use(payload).root
   }
 
   // render html (traditional SSR)


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

The workaround can be removed since the fix is included in React 19.2 https://github.com/facebook/react/pull/33941
