### PR TITLE
Add support for Vite 8.0.0-beta.0 in peerDependencies

### DIFF
--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -52,7 +52,7 @@
     "react-refresh": "^0.18.0"
   },
   "peerDependencies": {
-    "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+    "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-beta.0"
   },
   "devDependencies": {
     "@vitejs/react-common": "workspace:*",


### PR DESCRIPTION
Hi everyone. I'd like to deploy my app with Vite 8, but npm complains about a peer-dependency issue.

Add support for Vite 8.0.0-beta.0 in peerDependencies

### Description

I'd like to deploy my app with Vite 8 beta, but npm complains about a peer-dependency issue.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
