### PR TITLE
refactor(rsc): simplify proxy get access

### DIFF
--- a/packages/plugin-rsc/src/core/rsc.ts
+++ b/packages/plugin-rsc/src/core/rsc.ts
@@ -47,11 +47,6 @@ export function setRequireModule(options: {
           ))
         }
         return new Proxy(target, {
-          get(_target, name, _receiver) {
-            // not thennable
-            if (typeof name !== 'string' || name === 'then') return
-            return getOrCreateClientReference(name)
-          },
           // React 19.2.1+ uses hasOwnProperty.call() to check for exports
           // https://github.com/facebook/react/pull/35277
           getOwnPropertyDescriptor(_target, name) {


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

- Follow up to https://github.com/vitejs/vite-plugin-react/pull/1000#issuecomment-3609823730

React 19.2.1 checks `hasOwnProperty` first and triggers `getOwnPropertyDescriptor` trap. This then mutates `target[name]` own property, so `get` handler doesn't need to be explicitly implemented to return client reference.