### PR TITLE
feat(rsc): support serialization of Request and Response with `loadModuleDevProxy`

### DIFF
--- a/packages/plugin-rsc/README.md
+++ b/packages/plugin-rsc/README.md
@@ -228,7 +228,7 @@ The plugin provides an additional helper for multi environment interaction.
 
 This allows importing `ssr` environment module specified by `environments.ssr.build.rollupOptions.input[entryName]` inside `rsc` environment and vice versa.
 
-During development, by default, this API assumes both `rsc` and `ssr` environments execute under the main Vite process. When enabling `rsc({ loadModuleDevProxy: true })` plugin option, the loaded module is implemented as a proxy with `fetch`-based RPC to call in node environment on the main Vite process, which for example, allows `rsc` environment inside cloudflare workers to access `ssr` environment on the main Vite process.
+During development, by default, this API assumes both `rsc` and `ssr` environments execute under the main Vite process. When enabling `rsc({ loadModuleDevProxy: true })` plugin option, the loaded module is implemented as a proxy with `fetch`-based RPC to call in node environment on the main Vite process, which for example, allows `rsc` environment inside cloudflare workers to access `ssr` environment on the main Vite process. This proxy mechanism uses [turbo-stream](https://github.com/jacob-ebey/turbo-stream) for serializing data types beyond JSON, with custom encoders/decoders to additionally support `Request` and `Response` instances.
 
 During production build, this API will be rewritten into a static import of the specified entry of other environment build and the modules are executed inside the same runtime.
 

--- a/packages/plugin-rsc/examples/starter-cf-single/src/framework/entry.rsc.tsx
+++ b/packages/plugin-rsc/examples/starter-cf-single/src/framework/entry.rsc.tsx
@@ -82,18 +82,11 @@ async function handler(request: Request): Promise<Response> {
   const { renderHTML } = await import.meta.viteRsc.loadModule<
     typeof import('./entry.ssr.tsx')
   >('ssr', 'index')
-  const ssrResult = await renderHTML(rscStream, {
+  return await renderHTML(rscStream, {
+    request,
     formState,
     // allow quick simulation of javascript disabled browser
     debugNojs: renderRequest.url.searchParams.has('__nojs'),
-  })
-
-  // respond html
-  return new Response(ssrResult.stream, {
-    status: ssrResult.status,
-    headers: {
-      'Content-type': 'text/html',
-    },
   })
 }
 

--- a/packages/plugin-rsc/examples/starter-cf-single/src/framework/entry.rsc.tsx
+++ b/packages/plugin-rsc/examples/starter-cf-single/src/framework/entry.rsc.tsx
@@ -29,9 +29,10 @@ async function handler(request: Request): Promise<Response> {
     if (renderRequest.actionId) {
       // action is called via `ReactClient.setServerCallback`.
       const contentType = request.headers.get('content-type')
+      const clone = request.clone()
       const body = contentType?.startsWith('multipart/form-data')
-        ? await request.formData()
-        : await request.text()
+        ? await clone.formData()
+        : await clone.text()
       temporaryReferences = createTemporaryReferenceSet()
       const args = await decodeReply(body, { temporaryReferences })
       const action = await loadServerAction(renderRequest.actionId)
@@ -46,7 +47,8 @@ async function handler(request: Request): Promise<Response> {
       // otherwise server function is called via `<form action={...}>`
       // before hydration (e.g. when javascript is disabled).
       // aka progressive enhancement.
-      const formData = await request.formData()
+      const clone = request.clone()
+      const formData = await clone.formData()
       const decodedAction = await decodeAction(formData)
       try {
         const result = await decodedAction()

--- a/packages/plugin-rsc/examples/starter-cf-single/src/framework/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/starter-cf-single/src/framework/entry.ssr.tsx
@@ -10,11 +10,12 @@ export type RenderHTML = typeof renderHTML
 export async function renderHTML(
   rscStream: ReadableStream<Uint8Array>,
   options?: {
+    request: Request
     formState?: ReactFormState
     nonce?: string
     debugNojs?: boolean
   },
-): Promise<{ stream: ReadableStream<Uint8Array>; status?: number }> {
+): Promise<Response> {
   // duplicate one RSC stream into two.
   // - one for SSR (ReactClient.createFromReadableStream below)
   // - another for browser hydration payload by injecting <script>...FLIGHT_DATA...</script>.
@@ -71,5 +72,5 @@ export async function renderHTML(
     )
   }
 
-  return { stream: responseStream, status }
+  return new Response(responseStream, { status })
 }


### PR DESCRIPTION
fix(rsc): allow error traces as it is server -> server communication

### Description

Allows for Request and Response classes to be sent through the RSC x-environment RPC mechanism to support more real-world setups such as react-router RSC in environments such as Cloudflare.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
