### PR TITLE
fix(rsc): fix `findSourceMapURL` on Windows

### DIFF
--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -21,7 +21,7 @@ test.describe('dev-default', () => {
   const f = useFixture({ root: 'examples/basic', mode: 'dev' })
   defineTest(f)
 
-  test('validate findSourceMapURL', async () => {
+  test('validate findSourceMapURL - reject', async () => {
     const requestUrl = new URL(f.url('__vite_rsc_findSourceMapURL'))
     requestUrl.searchParams.set(
       'filename',
@@ -30,6 +30,20 @@ test.describe('dev-default', () => {
     requestUrl.searchParams.set('environmentName', 'Server')
     const response = await fetch(requestUrl)
     expect(response.status).toBe(404)
+  })
+
+  test('validate findSourceMapURL - pass', async () => {
+    const requestUrl = new URL(f.url('__vite_rsc_findSourceMapURL'))
+    requestUrl.searchParams.set(
+      'filename',
+      new URL('../examples/basic/package.json', import.meta.url).href,
+    )
+    requestUrl.searchParams.set('environmentName', 'Server')
+    const response = await fetch(requestUrl)
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      version: 3,
+    })
   })
 })
 

--- a/packages/plugin-rsc/src/plugins/find-source-map-url.ts
+++ b/packages/plugin-rsc/src/plugins/find-source-map-url.ts
@@ -6,6 +6,7 @@ import {
   type ViteDevServer,
 } from 'vite'
 import fs from 'node:fs'
+import { slash } from './vite-utils'
 
 //
 // support findSourceMapURL
@@ -52,7 +53,7 @@ async function findSourceMapURL(
 ): Promise<object | undefined> {
   // this is likely server external (i.e. outside of Vite processing)
   if (filename.startsWith('file://')) {
-    filename = fileURLToPath(filename)
+    filename = slash(fileURLToPath(filename))
     if (
       isFileLoadingAllowed(server.config, filename) &&
       fs.existsSync(filename)

--- a/packages/plugin-rsc/src/plugins/find-source-map-url.ts
+++ b/packages/plugin-rsc/src/plugins/find-source-map-url.ts
@@ -6,7 +6,6 @@ import {
   type ViteDevServer,
 } from 'vite'
 import fs from 'node:fs'
-import { slash } from './vite-utils'
 
 //
 // support findSourceMapURL
@@ -53,7 +52,7 @@ async function findSourceMapURL(
 ): Promise<object | undefined> {
   // this is likely server external (i.e. outside of Vite processing)
   if (filename.startsWith('file://')) {
-    filename = slash(fileURLToPath(filename))
+    filename = fileURLToPath(filename)
     if (
       isFileLoadingAllowed(server.config, filename) &&
       fs.existsSync(filename)


### PR DESCRIPTION
### Description

- Follow up to https://github.com/vitejs/vite-plugin-react/pull/1024

Vite's `isFileLoadingAllowed` assumes posix path (forward slash seperator), but Node's `fileURLToPath` returns backslash one on Windows. This is not a vulnerability since it just rejects everything on Windows.