### PR TITLE
fix(rsc): use proper origin for source map lookup

### DIFF
--- a/packages/plugin-rsc/src/react/browser.ts
+++ b/packages/plugin-rsc/src/react/browser.ts
@@ -54,8 +54,11 @@ export function findSourceMapURL(
   filename: string,
   environmentName: string,
 ): string | null {
-  // TODO: respect config.server.origin and config.base?
-  const url = new URL('/__vite_rsc_findSourceMapURL', window.location.origin)
+  // TODO: respect config.base?
+  const url = new URL(
+    /* @vite-ignore */ '/__vite_rsc_findSourceMapURL',
+    import.meta.url,
+  )
   url.searchParams.set('filename', filename)
   url.searchParams.set('environmentName', environmentName)
   return url.toString()


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

When using RSCs inside of an `<iframe srcdoc="..."` environment, the origin is `null` and cannot be used as the 2nd argument to `new URL`. This causes an exception that completely breaks the page. This is far from a common setup but happens to be the environment for MCP Apps / ChatGPT Apps.

Using `import.meta.url` both fixes that immediate issue but also ensures that the URL properly respects `server.origin` if set in the configuration. Updated the existing TODO to focus on `BASE_URL` only.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
