### PR TITLE
feat(rsc): use `__VITE_ENVIRONMENT_RUNNER_IMPORT__` for `import.meta.viteRsc.loadModule` global

### DIFF
--- a/packages/plugin-rsc/README.md
+++ b/packages/plugin-rsc/README.md
@@ -334,7 +334,6 @@ import.meta.hot.on('rsc:update', async () => {
 #### `__VITE_ENVIRONMENT_RUNNER_IMPORT__`
 
 - Type: `(environmentName: string, id: string) => Promise<any>`
-- Availability: Development only (set by `configureServer`)
 
 This global function provides a standardized way to import a module in a given environment during development. It is used internally by `import.meta.viteRsc.loadModule` to execute modules in the target environment.
 
@@ -351,9 +350,9 @@ globalThis.__VITE_ENVIRONMENT_RUNNER_IMPORT__ = async (environmentName, id) => {
 Frameworks with custom environment setups (e.g., environments running in separate workers or with custom module loading) can override this global to provide their own module import logic.
 
 ```js
-// Custom logic to import module, e.g., via RPC to a worker
+// Custom logic to import module between multiple environments inside worker
 globalThis.__VITE_ENVIRONMENT_RUNNER_IMPORT__ = async (environmentName, id) => {
-  return myWorkerRpc.import(environmentName, id)
+  return myWorkerRunners[environmentname].import(id)
 }
 ```
 

--- a/packages/plugin-rsc/README.md
+++ b/packages/plugin-rsc/README.md
@@ -351,9 +351,8 @@ globalThis.__VITE_GET_MODULE_RUNNER__ = async (environmentName) => {
 Frameworks with custom environment setups (e.g., environments running in separate workers) can override this global to provide their own module runner resolution.
 
 ```js
-// worker-entry.js
+// Custom logic to get the runner, e.g., from a worker runtime
 globalThis.__VITE_GET_MODULE_RUNNER__ = async (environmentName) => {
-  // Custom logic to get the runner, e.g., from a worker
   return myWorkerModuleRunners[environmentName]
 }
 ```

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -303,7 +303,7 @@ export function vitePluginRscMinimal(
 }
 
 declare global {
-  function __VITE_EXPERIMENTAL_GET_MODULE_RUNNER__(
+  function __VITE_GET_MODULE_RUNNER__(
     environmentName: string,
   ): Promise<ModuleRunner>
 }
@@ -523,7 +523,7 @@ export default function vitePluginRsc(
         },
       },
       configureServer(server) {
-        globalThis.__VITE_EXPERIMENTAL_GET_MODULE_RUNNER__ = async function (
+        globalThis.__VITE_GET_MODULE_RUNNER__ = async function (
           environmentName,
         ) {
           const environment = server.environments[environmentName]
@@ -790,9 +790,9 @@ export default function vitePluginRsc(
             const source = getEntrySource(environment.config, entryName)
             const resolved = await environment.pluginContainer.resolveId(source)
             assert(resolved, `[vite-rsc] failed to resolve entry '${source}'`)
-            const environmentNameEscaped = JSON.stringify(environmentName)
-            const resolveIdEscaped = JSON.stringify(resolved.id)
-            replacement = `globalThis.__VITE_EXPERIMENTAL_GET_MODULE_RUNNER__(${environmentNameEscaped}).then(runner => runner.import(${resolveIdEscaped}))`
+            const environmentNameJson = JSON.stringify(environmentName)
+            const resolvedIdJson = JSON.stringify(resolved.id)
+            replacement = `globalThis.__VITE_GET_MODULE_RUNNER__(${environmentNameJson}).then(runner => runner.import(${resolvedIdJson}))`
           } else {
             replacement = JSON.stringify(
               `__vite_rsc_load_module:${this.environment.name}:${environmentName}:${entryName}`,

--- a/packages/plugin-rsc/src/plugins/utils.ts
+++ b/packages/plugin-rsc/src/plugins/utils.ts
@@ -65,11 +65,6 @@ export function getEntrySource(
   name: string = 'index',
 ): string {
   const input = config.build.rollupOptions.input
-  // TODO: not documented feature yet, but for now,
-  // this is for Nitro's single entry convention.
-  if (typeof input === 'string') {
-    return input
-  }
   assert(
     typeof input === 'object' &&
       !Array.isArray(input) &&

--- a/packages/plugin-rsc/src/plugins/utils.ts
+++ b/packages/plugin-rsc/src/plugins/utils.ts
@@ -65,6 +65,11 @@ export function getEntrySource(
   name: string = 'index',
 ): string {
   const input = config.build.rollupOptions.input
+  // TODO: not documented feature yet, but for now,
+  // this is for Nitro's single entry convention.
+  if (typeof input === 'string') {
+    return input
+  }
   assert(
     typeof input === 'object' &&
       !Array.isArray(input) &&


### PR DESCRIPTION
### Description

Establishes `__VITE_ENVIRONMENT_RUNNER_IMPORT__` as a convention for frameworks to integrate custom environment setups with `import.meta.viteRsc.loadModule`.

```typescript
declare global {
  function __VITE_ENVIRONMENT_RUNNER_IMPORT__(
    environmentName: string,
    id: string,
  ): Promise<any>
}
```

**The problem:**

`import.meta.viteRsc.loadModule` allows importing modules across environments (e.g., RSC → SSR). By default, both environments run in the main Vite process as `RunnableDevEnvironment`. However, frameworks like Nitro run environments in separate workers where they can communicate internally but not from the main Vite process.

**The convention:**

Frameworks with custom environment setups can override this global to provide their own module import logic:

```js
// Default (set by plugin)
globalThis.__VITE_ENVIRONMENT_RUNNER_IMPORT__ = async (env, id) => {
  return server.environments[env].runner.import(id)
}

// Custom (e.g., worker-based environments)
globalThis.__VITE_ENVIRONMENT_RUNNER_IMPORT__ = async (env, id) => {
  return myWorkerRunners[environmentname].import(id)
}
```

This allows `import.meta.viteRsc.loadModule` to work seamlessly across different runtime configurations without changes to user code.

---

- Closes https://github.com/vitejs/vite-plugin-react/pull/924 (supersedes)