### PR TITLE
chore: remove `esbuild.target: 'node14'` from vitest config

### DIFF
--- a/playground/vitest.config.e2e.ts
+++ b/playground/vitest.config.e2e.ts
@@ -23,7 +23,4 @@ export default defineConfig({
       },
     },
   },
-  esbuild: {
-    target: 'node14',
-  },
 })


### PR DESCRIPTION
This shouldn't be needed anymore
