### PR TITLE
feat(rsc): add resolved-id proxy for virtual modules + document ?direct limitation

### DIFF
--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -1635,38 +1635,25 @@ function defineTest(f: Fixture) {
     )
   })
 
-  test('virtual css module in server component', async ({ page }) => {
+  test('virtual css module', async ({ page }) => {
     await page.goto(f.url())
     await waitForHydration(page)
+    await testVirtualCss(page)
+  })
 
-    // Test that the virtual CSS imported in server component is applied
-    await expect(page.locator('.test-virtual-style')).toHaveCSS(
-      'color',
-      'rgb(100, 200, 50)',
-    )
+  testNoJs('virtual css module @nojs', async ({ page }) => {
+    await page.goto(f.url())
+    await testVirtualCss(page)
+  })
+
+  async function testVirtualCss(page: Page) {
     await expect(page.locator('.test-virtual-style-server')).toHaveCSS(
       'color',
       'rgb(50, 100, 200)',
     )
-  })
-
-  test('virtual css module in client component', async ({ page }) => {
-    await page.goto(f.url())
-    await waitForHydration(page)
-
-    // Test that the real "use client" component with virtual CSS works
-    await expect(page.getByTestId('test-client-with-virtual-css')).toHaveText(
-      'test-client-with-virtual-css: not-clicked',
-    )
-    await page.getByTestId('test-client-with-virtual-css').click()
-    await expect(page.getByTestId('test-client-with-virtual-css')).toHaveText(
-      'test-client-with-virtual-css: clicked',
-    )
-
-    // Test that the virtual CSS imported in client component is applied
     await expect(page.locator('.test-virtual-style-client')).toHaveCSS(
       'color',
       'rgb(200, 50, 100)',
     )
-  })
+  }
 }

--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -1638,22 +1638,28 @@ function defineTest(f: Fixture) {
   test('virtual css module', async ({ page }) => {
     await page.goto(f.url())
     await waitForHydration(page)
-    await testVirtualCss(page)
-  })
-
-  testNoJs('virtual css module @nojs', async ({ page }) => {
-    await page.goto(f.url())
-    await testVirtualCss(page)
-  })
-
-  async function testVirtualCss(page: Page) {
     await expect(page.locator('.test-virtual-style-server')).toHaveCSS(
       'color',
-      'rgb(50, 100, 200)',
+      // TODO: server virtual CSS doesn't work in dev (returns JS wrapper instead of raw CSS)
+      f.mode === 'dev' ? 'rgb(0, 0, 0)' : 'rgb(50, 100, 200)',
     )
     await expect(page.locator('.test-virtual-style-client')).toHaveCSS(
       'color',
       'rgb(200, 50, 100)',
     )
-  }
+  })
+
+  testNoJs('virtual css module @nojs', async ({ page }) => {
+    await page.goto(f.url())
+    await expect(page.locator('.test-virtual-style-server')).toHaveCSS(
+      'color',
+      // TODO: virtual CSS doesn't work in dev (returns JS wrapper instead of raw CSS)
+      f.mode === 'dev' ? 'rgb(0, 0, 0)' : 'rgb(50, 100, 200)',
+    )
+    await expect(page.locator('.test-virtual-style-client')).toHaveCSS(
+      'color',
+      // TODO: virtual CSS doesn't work in dev (returns JS wrapper instead of raw CSS)
+      f.mode === 'dev' ? 'rgb(0, 0, 0)' : 'rgb(200, 50, 100)',
+    )
+  })
 }

--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -1638,12 +1638,13 @@ function defineTest(f: Fixture) {
   test('virtual css module', async ({ page }) => {
     await page.goto(f.url())
     await waitForHydration(page)
-    await expect(page.locator('.test-virtual-style-server')).toHaveCSS(
+    // Query-aware virtual CSS: works in both dev and build
+    await expect(page.locator('.test-virtual-style-query-aware')).toHaveCSS(
       'color',
-      // TODO: server virtual CSS doesn't work in dev (returns JS wrapper instead of raw CSS)
-      f.mode === 'dev' ? 'rgb(0, 0, 0)' : 'rgb(50, 100, 200)',
+      'rgb(50, 100, 200)',
     )
-    await expect(page.locator('.test-virtual-style-client')).toHaveCSS(
+    // Exact-match virtual CSS: works via JS import (HMR injects styles)
+    await expect(page.locator('.test-virtual-style-exact')).toHaveCSS(
       'color',
       'rgb(200, 50, 100)',
     )
@@ -1651,14 +1652,15 @@ function defineTest(f: Fixture) {
 
   testNoJs('virtual css module @nojs', async ({ page }) => {
     await page.goto(f.url())
-    await expect(page.locator('.test-virtual-style-server')).toHaveCSS(
+    // Query-aware virtual CSS: works via <link> in both dev and build
+    await expect(page.locator('.test-virtual-style-query-aware')).toHaveCSS(
       'color',
-      // TODO: virtual CSS doesn't work in dev (returns JS wrapper instead of raw CSS)
-      f.mode === 'dev' ? 'rgb(0, 0, 0)' : 'rgb(50, 100, 200)',
+      'rgb(50, 100, 200)',
     )
-    await expect(page.locator('.test-virtual-style-client')).toHaveCSS(
+    // Exact-match virtual CSS: fails via <link> in dev (Vite limitation)
+    // Standard virtual module pattern doesn't handle ?direct query injection
+    await expect(page.locator('.test-virtual-style-exact')).toHaveCSS(
       'color',
-      // TODO: virtual CSS doesn't work in dev (returns JS wrapper instead of raw CSS)
       f.mode === 'dev' ? 'rgb(0, 0, 0)' : 'rgb(200, 50, 100)',
     )
   })

--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -1620,4 +1620,53 @@ function defineTest(f: Fixture) {
       'test-tree-shake2:lib-client1|lib-server1',
     )
   })
+
+  test('virtual module with use client', async ({ page }) => {
+    await page.goto(f.url())
+    await waitForHydration(page)
+
+    // Test that the virtual client component renders and works
+    await expect(page.getByTestId('test-virtual-client')).toHaveText(
+      'test-virtual-client: not-clicked',
+    )
+    await page.getByTestId('test-virtual-client').click()
+    await expect(page.getByTestId('test-virtual-client')).toHaveText(
+      'test-virtual-client: clicked',
+    )
+  })
+
+  test('virtual css module in server component', async ({ page }) => {
+    await page.goto(f.url())
+    await waitForHydration(page)
+
+    // Test that the virtual CSS imported in server component is applied
+    await expect(page.locator('.test-virtual-style')).toHaveCSS(
+      'color',
+      'rgb(100, 200, 50)',
+    )
+    await expect(page.locator('.test-virtual-style-server')).toHaveCSS(
+      'color',
+      'rgb(50, 100, 200)',
+    )
+  })
+
+  test('virtual css module in client component', async ({ page }) => {
+    await page.goto(f.url())
+    await waitForHydration(page)
+
+    // Test that the real "use client" component with virtual CSS works
+    await expect(page.getByTestId('test-client-with-virtual-css')).toHaveText(
+      'test-client-with-virtual-css: not-clicked',
+    )
+    await page.getByTestId('test-client-with-virtual-css').click()
+    await expect(page.getByTestId('test-client-with-virtual-css')).toHaveText(
+      'test-client-with-virtual-css: clicked',
+    )
+
+    // Test that the virtual CSS imported in client component is applied
+    await expect(page.locator('.test-virtual-style-client')).toHaveCSS(
+      'color',
+      'rgb(200, 50, 100)',
+    )
+  })
 }

--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -1638,13 +1638,26 @@ function defineTest(f: Fixture) {
   test('virtual css module', async ({ page }) => {
     await page.goto(f.url())
     await waitForHydration(page)
-    // Query-aware virtual CSS: works in both dev and build
-    await expect(page.locator('.test-virtual-style-query-aware')).toHaveCSS(
+
+    // Server CSS (loaded via <link>)
+    // Query-aware: works in both dev and build
+    await expect(page.locator('.test-virtual-style-server-query')).toHaveCSS(
       'color',
-      'rgb(50, 100, 200)',
+      'rgb(50, 100, 150)',
     )
-    // Exact-match virtual CSS: works via JS import (HMR injects styles)
-    await expect(page.locator('.test-virtual-style-exact')).toHaveCSS(
+    // Exact-match: fails via <link> in dev (Vite limitation), works in build
+    await expect(page.locator('.test-virtual-style-server-exact')).toHaveCSS(
+      'color',
+      f.mode === 'dev' ? 'rgb(0, 0, 0)' : 'rgb(200, 100, 50)',
+    )
+
+    // Client CSS (loaded via JS import, HMR injects styles)
+    // Both patterns work because no ?direct is involved in JS imports
+    await expect(page.locator('.test-virtual-style-client-query')).toHaveCSS(
+      'color',
+      'rgb(50, 150, 100)',
+    )
+    await expect(page.locator('.test-virtual-style-client-exact')).toHaveCSS(
       'color',
       'rgb(200, 50, 100)',
     )
@@ -1652,14 +1665,27 @@ function defineTest(f: Fixture) {
 
   testNoJs('virtual css module @nojs', async ({ page }) => {
     await page.goto(f.url())
-    // Query-aware virtual CSS: works via <link> in both dev and build
-    await expect(page.locator('.test-virtual-style-query-aware')).toHaveCSS(
+
+    // Server CSS (loaded via <link>)
+    // Query-aware: works in both dev and build
+    await expect(page.locator('.test-virtual-style-server-query')).toHaveCSS(
       'color',
-      'rgb(50, 100, 200)',
+      'rgb(50, 100, 150)',
     )
-    // Exact-match virtual CSS: fails via <link> in dev (Vite limitation)
-    // Standard virtual module pattern doesn't handle ?direct query injection
-    await expect(page.locator('.test-virtual-style-exact')).toHaveCSS(
+    // Exact-match: fails via <link> in dev (Vite limitation)
+    await expect(page.locator('.test-virtual-style-server-exact')).toHaveCSS(
+      'color',
+      f.mode === 'dev' ? 'rgb(0, 0, 0)' : 'rgb(200, 100, 50)',
+    )
+
+    // Client CSS (loaded via <link> in noJS mode)
+    // Query-aware: works in both dev and build
+    await expect(page.locator('.test-virtual-style-client-query')).toHaveCSS(
+      'color',
+      'rgb(50, 150, 100)',
+    )
+    // Exact-match: fails via <link> in dev (Vite limitation)
+    await expect(page.locator('.test-virtual-style-client-exact')).toHaveCSS(
       'color',
       f.mode === 'dev' ? 'rgb(0, 0, 0)' : 'rgb(200, 50, 100)',
     )

--- a/packages/plugin-rsc/examples/basic/src/routes/root.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/root.tsx
@@ -48,6 +48,7 @@ import { TestTreeShakeServer } from './tree-shake/server'
 import { TestTreeShake2 } from './tree-shake2/server'
 import { TestUseCache } from './use-cache/server'
 import { TestUseId } from './use-id/server'
+import { TestVirtualModule } from './virtual-module/server'
 
 export function Root(props: { url: URL }) {
   return (
@@ -70,6 +71,7 @@ export function Root(props: { url: URL }) {
         <TestTailwind />
         <TestDepCssInServer />
         <TestHydrationMismatch url={props.url} />
+        <TestVirtualModule />
         <TestHmrClientDep url={{ search: props.url.search }} />
         <TestHmrClientDep2 url={{ search: props.url.search }} />
         <TestHmrClientDep3 />

--- a/packages/plugin-rsc/examples/basic/src/routes/virtual-module/client.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/virtual-module/client.tsx
@@ -1,9 +1,11 @@
 'use client'
 
-import 'virtual:test-style-client.css'
+// Exact-match virtual CSS: works via JS import (no ?direct issue)
+// Would fail if loaded via <link> tag in dev mode
+import 'virtual:test-style-exact.css'
 
 export function TestClientWithVirtualCss() {
   return (
-    <div className="test-virtual-style-client">test-virtual-style-client</div>
+    <div className="test-virtual-style-exact">test-virtual-style-exact</div>
   )
 }

--- a/packages/plugin-rsc/examples/basic/src/routes/virtual-module/client.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/virtual-module/client.tsx
@@ -1,11 +1,19 @@
 'use client'
 
-// Exact-match virtual CSS: works via JS import (no ?direct issue)
-// Would fail if loaded via <link> tag in dev mode
-import 'virtual:test-style-exact.css'
+// Client CSS is loaded via JS import (HMR injects styles)
+// Both patterns work because no ?direct is involved
+import 'virtual:test-style-client-query.css'
+import 'virtual:test-style-client-exact.css'
 
 export function TestClientWithVirtualCss() {
   return (
-    <div className="test-virtual-style-exact">test-virtual-style-exact</div>
+    <>
+      <div className="test-virtual-style-client-query">
+        test-virtual-style-client-query
+      </div>
+      <div className="test-virtual-style-client-exact">
+        test-virtual-style-client-exact
+      </div>
+    </>
   )
 }

--- a/packages/plugin-rsc/examples/basic/src/routes/virtual-module/client.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/virtual-module/client.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import React from 'react'
+import 'virtual:test-style-client.css'
+
+export function TestClientWithVirtualCss() {
+  const [clicked, setClicked] = React.useState(false)
+  return (
+    <div>
+      <button
+        type="button"
+        data-testid="test-client-with-virtual-css"
+        onClick={() => setClicked(true)}
+      >
+        test-client-with-virtual-css: {clicked ? 'clicked' : 'not-clicked'}
+      </button>
+      <div className="test-virtual-style-client">test-virtual-style-client</div>
+    </div>
+  )
+}

--- a/packages/plugin-rsc/examples/basic/src/routes/virtual-module/client.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/virtual-module/client.tsx
@@ -1,20 +1,9 @@
 'use client'
 
-import React from 'react'
 import 'virtual:test-style-client.css'
 
 export function TestClientWithVirtualCss() {
-  const [clicked, setClicked] = React.useState(false)
   return (
-    <div>
-      <button
-        type="button"
-        data-testid="test-client-with-virtual-css"
-        onClick={() => setClicked(true)}
-      >
-        test-client-with-virtual-css: {clicked ? 'clicked' : 'not-clicked'}
-      </button>
-      <div className="test-virtual-style-client">test-virtual-style-client</div>
-    </div>
+    <div className="test-virtual-style-client">test-virtual-style-client</div>
   )
 }

--- a/packages/plugin-rsc/examples/basic/src/routes/virtual-module/server.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/virtual-module/server.tsx
@@ -1,15 +1,21 @@
 // @ts-expect-error virtual module
 import { TestVirtualClient } from 'virtual:test-virtual-client'
 import { TestClientWithVirtualCss } from './client'
-// Query-aware virtual CSS: works with <link> in dev mode
-// See vite.config.ts for the query-stripping pattern
-import 'virtual:test-style-query-aware.css'
+
+// Server CSS is loaded via <link> tag in RSC
+// Query-aware: works in dev (handles ?direct)
+import 'virtual:test-style-server-query.css'
+// Exact-match: fails in dev (Vite limitation), works in build
+import 'virtual:test-style-server-exact.css'
 
 export function TestVirtualModule() {
   return (
     <div data-testid="test-virtual-module">
-      <div className="test-virtual-style-query-aware">
-        test-virtual-style-query-aware
+      <div className="test-virtual-style-server-query">
+        test-virtual-style-server-query
+      </div>
+      <div className="test-virtual-style-server-exact">
+        test-virtual-style-server-exact
       </div>
       <TestClientWithVirtualCss />
       <TestVirtualClient />

--- a/packages/plugin-rsc/examples/basic/src/routes/virtual-module/server.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/virtual-module/server.tsx
@@ -1,0 +1,16 @@
+// @ts-expect-error virtual module
+import { TestVirtualClient } from 'virtual:test-virtual-client'
+import { TestClientWithVirtualCss } from './client'
+import 'virtual:test-style.css'
+import 'virtual:test-style-server.css'
+
+export function TestVirtualModule() {
+  return (
+    <div data-testid="test-virtual-module">
+      <div className="test-virtual-style">test-virtual-style</div>
+      <div className="test-virtual-style-server">test-virtual-style-server</div>
+      <TestVirtualClient />
+      <TestClientWithVirtualCss />
+    </div>
+  )
+}

--- a/packages/plugin-rsc/examples/basic/src/routes/virtual-module/server.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/virtual-module/server.tsx
@@ -1,16 +1,14 @@
 // @ts-expect-error virtual module
 import { TestVirtualClient } from 'virtual:test-virtual-client'
 import { TestClientWithVirtualCss } from './client'
-import 'virtual:test-style.css'
 import 'virtual:test-style-server.css'
 
 export function TestVirtualModule() {
   return (
     <div data-testid="test-virtual-module">
-      <div className="test-virtual-style">test-virtual-style</div>
       <div className="test-virtual-style-server">test-virtual-style-server</div>
-      <TestVirtualClient />
       <TestClientWithVirtualCss />
+      <TestVirtualClient />
     </div>
   )
 }

--- a/packages/plugin-rsc/examples/basic/src/routes/virtual-module/server.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/virtual-module/server.tsx
@@ -1,12 +1,16 @@
 // @ts-expect-error virtual module
 import { TestVirtualClient } from 'virtual:test-virtual-client'
 import { TestClientWithVirtualCss } from './client'
-import 'virtual:test-style-server.css'
+// Query-aware virtual CSS: works with <link> in dev mode
+// See vite.config.ts for the query-stripping pattern
+import 'virtual:test-style-query-aware.css'
 
 export function TestVirtualModule() {
   return (
     <div data-testid="test-virtual-module">
-      <div className="test-virtual-style-server">test-virtual-style-server</div>
+      <div className="test-virtual-style-query-aware">
+        test-virtual-style-query-aware
+      </div>
       <TestClientWithVirtualCss />
       <TestVirtualClient />
     </div>

--- a/packages/plugin-rsc/examples/basic/vite.config.ts
+++ b/packages/plugin-rsc/examples/basic/vite.config.ts
@@ -373,7 +373,10 @@ export function TestVirtualClient() {
       name: 'test-virtual-css-query-aware',
       resolveId(source) {
         const clean = source.split('?')[0]
-        if (clean === 'virtual:test-style-query-aware.css') {
+        if (
+          clean === 'virtual:test-style-server-query.css' ||
+          clean === 'virtual:test-style-client-query.css'
+        ) {
           // Preserve query in resolved id for Vite's CSS plugin to see ?direct
           const query = source.includes('?')
             ? source.slice(source.indexOf('?'))
@@ -383,12 +386,11 @@ export function TestVirtualClient() {
       },
       load(id) {
         const clean = id.split('?')[0]
-        if (clean === '\0virtual:test-style-query-aware.css') {
-          return `
-.test-virtual-style-query-aware {
-  color: rgb(50, 100, 200);
-}
-`
+        if (clean === '\0virtual:test-style-server-query.css') {
+          return `.test-virtual-style-server-query { color: rgb(50, 100, 150); }`
+        }
+        if (clean === '\0virtual:test-style-client-query.css') {
+          return `.test-virtual-style-client-query { color: rgb(50, 150, 100); }`
         }
       },
     },
@@ -397,17 +399,19 @@ export function TestVirtualClient() {
     {
       name: 'test-virtual-css-exact',
       resolveId(source) {
-        if (source === 'virtual:test-style-exact.css') {
+        if (source === 'virtual:test-style-server-exact.css') {
+          return `\0${source}`
+        }
+        if (source === 'virtual:test-style-client-exact.css') {
           return `\0${source}`
         }
       },
       load(id) {
-        if (id === '\0virtual:test-style-exact.css') {
-          return `
-.test-virtual-style-exact {
-  color: rgb(200, 50, 100);
-}
-`
+        if (id === '\0virtual:test-style-server-exact.css') {
+          return `.test-virtual-style-server-exact { color: rgb(200, 100, 50); }`
+        }
+        if (id === '\0virtual:test-style-client-exact.css') {
+          return `.test-virtual-style-client-exact { color: rgb(200, 50, 100); }`
         }
       },
     },

--- a/packages/plugin-rsc/examples/basic/vite.config.ts
+++ b/packages/plugin-rsc/examples/basic/vite.config.ts
@@ -368,27 +368,43 @@ export function TestVirtualClient() {
         }
       },
     },
+    // Query-aware virtual CSS: handles ?direct query, works with <link> in dev
     {
-      name: 'test-virtual-css',
+      name: 'test-virtual-css-query-aware',
       resolveId(source) {
-        if (source === 'virtual:test-style-server.css') {
-          return `\0${source}`
-        }
-        if (source === 'virtual:test-style-client.css') {
-          return `\0${source}`
+        const clean = source.split('?')[0]
+        if (clean === 'virtual:test-style-query-aware.css') {
+          // Preserve query in resolved id for Vite's CSS plugin to see ?direct
+          const query = source.includes('?')
+            ? source.slice(source.indexOf('?'))
+            : ''
+          return `\0${clean}${query}`
         }
       },
       load(id) {
-        if (id === '\0virtual:test-style-server.css') {
+        const clean = id.split('?')[0]
+        if (clean === '\0virtual:test-style-query-aware.css') {
           return `
-.test-virtual-style-server {
+.test-virtual-style-query-aware {
   color: rgb(50, 100, 200);
 }
 `
         }
-        if (id === '\0virtual:test-style-client.css') {
+      },
+    },
+    // Exact-match virtual CSS: standard pattern, does NOT work with <link> in dev
+    // (works fine when imported via JS)
+    {
+      name: 'test-virtual-css-exact',
+      resolveId(source) {
+        if (source === 'virtual:test-style-exact.css') {
+          return `\0${source}`
+        }
+      },
+      load(id) {
+        if (id === '\0virtual:test-style-exact.css') {
           return `
-.test-virtual-style-client {
+.test-virtual-style-exact {
   color: rgb(200, 50, 100);
 }
 `

--- a/packages/plugin-rsc/examples/basic/vite.config.ts
+++ b/packages/plugin-rsc/examples/basic/vite.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
     tailwindcss(),
     react(),
     vitePluginUseCache(),
+    vitePluginVirtualModuleTest(),
     rsc({
       entries: {
         client: './src/framework/entry.browser.tsx',
@@ -329,6 +330,78 @@ function vitePluginUseCache(): Plugin[] {
         return {
           code: result.output.toString(),
           map: result.output.generateMap({ hires: 'boundary' }),
+        }
+      },
+    },
+  ]
+}
+
+function vitePluginVirtualModuleTest(): Plugin[] {
+  return [
+    {
+      name: 'test-virtual-client',
+      resolveId(source) {
+        if (source === 'virtual:test-virtual-client') {
+          return `\0${source}`
+        }
+      },
+      load(id) {
+        if (id === '\0virtual:test-virtual-client') {
+          return `
+'use client'
+
+import React from 'react'
+
+export function TestVirtualClient() {
+  const [clicked, setClicked] = React.useState(false)
+  return React.createElement(
+    'button',
+    {
+      type: 'button',
+      'data-testid': 'test-virtual-client',
+      onClick: () => setClicked(true),
+    },
+    'test-virtual-client: ' + (clicked ? 'clicked' : 'not-clicked')
+  )
+}
+`
+        }
+      },
+    },
+    {
+      name: 'test-virtual-css',
+      resolveId(source) {
+        if (source === 'virtual:test-style.css') {
+          return `\0${source}`
+        }
+        if (source === 'virtual:test-style-server.css') {
+          return `\0${source}`
+        }
+        if (source === 'virtual:test-style-client.css') {
+          return `\0${source}`
+        }
+      },
+      load(id) {
+        if (id === '\0virtual:test-style.css') {
+          return `
+.test-virtual-style {
+  color: rgb(100, 200, 50);
+}
+`
+        }
+        if (id === '\0virtual:test-style-server.css') {
+          return `
+.test-virtual-style-server {
+  color: rgb(50, 100, 200);
+}
+`
+        }
+        if (id === '\0virtual:test-style-client.css') {
+          return `
+.test-virtual-style-client {
+  color: rgb(200, 50, 100);
+}
+`
         }
       },
     },

--- a/packages/plugin-rsc/examples/basic/vite.config.ts
+++ b/packages/plugin-rsc/examples/basic/vite.config.ts
@@ -371,9 +371,6 @@ export function TestVirtualClient() {
     {
       name: 'test-virtual-css',
       resolveId(source) {
-        if (source === 'virtual:test-style.css') {
-          return `\0${source}`
-        }
         if (source === 'virtual:test-style-server.css') {
           return `\0${source}`
         }
@@ -382,13 +379,6 @@ export function TestVirtualClient() {
         }
       },
       load(id) {
-        if (id === '\0virtual:test-style.css') {
-          return `
-.test-virtual-style {
-  color: rgb(100, 200, 50);
-}
-`
-        }
         if (id === '\0virtual:test-style-server.css') {
           return `
 .test-virtual-style-server {

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -30,6 +30,7 @@ import { vitePluginFindSourceMapURL } from './plugins/find-source-map-url'
 import {
   vitePluginResolvedIdProxy,
   toResolvedIdProxy,
+  withResolvedIdProxy,
 } from './plugins/resolved-id-proxy'
 import { scanBuildStripPlugin } from './plugins/scan'
 import {
@@ -1362,11 +1363,7 @@ function vitePluginUseClient(
           if (manager.isScanBuild) {
             let code = ``
             for (const meta of Object.values(manager.clientReferenceMetaMap)) {
-              // Use resolved-id proxy for virtual modules (\0 prefix)
-              const importId = meta.importId.startsWith('\0')
-                ? toResolvedIdProxy(meta.importId)
-                : meta.importId
-              code += `import ${JSON.stringify(importId)};\n`
+              code += `import ${JSON.stringify(withResolvedIdProxy(meta.importId))};\n`
             }
             return { code, map: null }
           }
@@ -1419,12 +1416,8 @@ function vitePluginUseClient(
               .map((name) => `${name}: import_${meta.referenceKey}.${name},\n`)
               .sort()
               .join('')
-            // Use resolved-id proxy for virtual modules (\0 prefix)
-            const importId = meta.importId.startsWith('\0')
-              ? toResolvedIdProxy(meta.importId)
-              : meta.importId
             code += `
-              import * as import_${meta.referenceKey} from ${JSON.stringify(importId)};
+              import * as import_${meta.referenceKey} from ${JSON.stringify(withResolvedIdProxy(meta.importId))};
               export const export_${meta.referenceKey} = {${exports}};
             `
           }

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -29,7 +29,6 @@ import { cjsModuleRunnerPlugin } from './plugins/cjs'
 import { vitePluginFindSourceMapURL } from './plugins/find-source-map-url'
 import {
   vitePluginResolvedIdProxy,
-  toResolvedIdProxy,
   withResolvedIdProxy,
 } from './plugins/resolved-id-proxy'
 import { scanBuildStripPlugin } from './plugins/scan'
@@ -2049,13 +2048,9 @@ function vitePluginRscCss(
     recurse(entryId)
 
     // this doesn't include ?t= query so that RSC <link /> won't keep adding styles.
-    // Use resolved-id proxy for virtual CSS modules to handle ?direct query
-    const hrefs = [...cssIds].map((id) => {
-      if (id.startsWith('\0')) {
-        return `/@id/${toResolvedIdProxy(id)}`
-      }
-      return normalizeViteImportAnalysisUrl(environment, id)
-    })
+    const hrefs = [...cssIds].map((id) =>
+      normalizeViteImportAnalysisUrl(environment, id),
+    )
     return { ids: [...cssIds], hrefs, visitedFiles: [...visitedFiles] }
   }
 

--- a/packages/plugin-rsc/src/plugins/resolved-id-proxy.ts
+++ b/packages/plugin-rsc/src/plugins/resolved-id-proxy.ts
@@ -1,0 +1,50 @@
+import type { Plugin } from 'vite'
+
+// Resolved ID proxy plugin
+// This enables virtual modules (with \0 prefix) to be used in import specifiers
+// and handles ?direct query for CSS requests in dev mode.
+// See .dev-notes/dist/virtual-module-e2e-test-plan.md for details.
+//
+// Input/Output examples:
+//
+//   toResolvedIdProxy("\0virtual:test.css")
+//     => "virtual:vite-rsc/resolved-id/__x00__virtual:test.css"
+//
+//   fromResolvedIdProxy("virtual:vite-rsc/resolved-id/__x00__virtual:test.css")
+//     => "\0virtual:test.css"
+//
+//   fromResolvedIdProxy("virtual:vite-rsc/resolved-id/__x00__virtual:test.css?direct")
+//     => "\0virtual:test.css"
+
+const RESOLVED_ID_PROXY_PREFIX = 'virtual:vite-rsc/resolved-id/'
+const NULL_BYTE_PLACEHOLDER = '__x00__'
+
+export function toResolvedIdProxy(resolvedId: string): string {
+  const encoded = resolvedId.replace(/\0/g, NULL_BYTE_PLACEHOLDER)
+  return RESOLVED_ID_PROXY_PREFIX + encoded
+}
+
+export function fromResolvedIdProxy(source: string): string | undefined {
+  // Strip query params (e.g., ?direct added by Vite for CSS)
+  const clean = source.split('?')[0]!
+  if (!clean.startsWith(RESOLVED_ID_PROXY_PREFIX)) {
+    return undefined
+  }
+  const encoded = clean.slice(RESOLVED_ID_PROXY_PREFIX.length)
+  return encoded.replace(new RegExp(NULL_BYTE_PLACEHOLDER, 'g'), '\0')
+}
+
+/**
+ * Vite plugin that resolves proxy import specifiers to the original resolved IDs.
+ */
+export function vitePluginResolvedIdProxy(): Plugin {
+  return {
+    name: 'rsc:resolved-id-proxy',
+    resolveId(source) {
+      const originalId = fromResolvedIdProxy(source)
+      if (originalId !== undefined) {
+        return originalId
+      }
+    },
+  }
+}

--- a/packages/plugin-rsc/src/plugins/resolved-id-proxy.ts
+++ b/packages/plugin-rsc/src/plugins/resolved-id-proxy.ts
@@ -103,11 +103,9 @@ resolveId and load hooks. See examples/basic/vite.config.ts for patterns.
 */
 
 const RESOLVED_ID_PROXY_PREFIX = 'virtual:vite-rsc/resolved-id/'
-const NULL_BYTE_PLACEHOLDER = '__x00__'
 
 export function toResolvedIdProxy(resolvedId: string): string {
-  const encoded = resolvedId.replace(/\0/g, NULL_BYTE_PLACEHOLDER)
-  return RESOLVED_ID_PROXY_PREFIX + encoded
+  return RESOLVED_ID_PROXY_PREFIX + encodeURIComponent(resolvedId)
 }
 
 export function withResolvedIdProxy(resolvedId: string): string {
@@ -117,13 +115,12 @@ export function withResolvedIdProxy(resolvedId: string): string {
 }
 
 export function fromResolvedIdProxy(source: string): string | undefined {
-  // Strip query params (e.g., ?direct added by Vite for CSS)
-  const clean = source.split('?')[0]!
-  if (!clean.startsWith(RESOLVED_ID_PROXY_PREFIX)) {
+  if (!source.startsWith(RESOLVED_ID_PROXY_PREFIX)) {
     return undefined
   }
-  const encoded = clean.slice(RESOLVED_ID_PROXY_PREFIX.length)
-  return encoded.replace(new RegExp(NULL_BYTE_PLACEHOLDER, 'g'), '\0')
+  // Strip query params (e.g., ?direct added by Vite for CSS)
+  const clean = source.split('?')[0]!
+  return decodeURIComponent(clean.slice(RESOLVED_ID_PROXY_PREFIX.length))
 }
 
 /**

--- a/packages/plugin-rsc/src/plugins/resolved-id-proxy.ts
+++ b/packages/plugin-rsc/src/plugins/resolved-id-proxy.ts
@@ -132,11 +132,14 @@ export function fromResolvedIdProxy(source: string): string | undefined {
 export function vitePluginResolvedIdProxy(): Plugin {
   return {
     name: 'rsc:resolved-id-proxy',
-    resolveId(source) {
-      const originalId = fromResolvedIdProxy(source)
-      if (originalId !== undefined) {
-        return originalId
-      }
+    resolveId: {
+      // TODO: filter
+      handler(source) {
+        const originalId = fromResolvedIdProxy(source)
+        if (originalId !== undefined) {
+          return originalId
+        }
+      },
     },
   }
 }

--- a/packages/plugin-rsc/src/plugins/resolved-id-proxy.ts
+++ b/packages/plugin-rsc/src/plugins/resolved-id-proxy.ts
@@ -14,9 +14,93 @@ import type { Plugin } from 'vite'
 //   fromResolvedIdProxy("virtual:vite-rsc/resolved-id/__x00__virtual:test.css?direct")
 //     => "\0virtual:test.css"
 //
-// TODO: ?direct query handling for virtual CSS doesn't work yet.
-// Vite adds ?direct for text/css requests, but the query is lost during resolution,
-// causing JS wrapper to be returned instead of raw CSS.
+/*
+Known Vite limitation: Virtual CSS modules don't work with ?direct or ?inline queries.
+
+## Standard virtual module pattern
+
+Vite/Rollup virtual modules use a \0 prefix to indicate resolved IDs that
+don't correspond to real files. Example from examples/basic/vite.config.ts:
+
+  resolveId(source) {
+    if (source === 'virtual:test-style-server.css') {
+      return `\0${source}`  // → \0virtual:test-style-server.css
+    }
+  },
+  load(id) {
+    if (id === '\0virtual:test-style-server.css') {
+      return `.test { color: red; }`
+    }
+  }
+
+Browsers can't use \0 (null byte) in URLs, so Vite encodes it as __x00__:
+  <link href="/@id/__x00__virtual:test-style-server.css">
+
+Vite's dev server maps /@id/__x00__... back to \0... internally.
+
+## How Vite's ?direct CSS mechanism works
+
+When a browser requests CSS via <link href="xxx.css">, Vite's dev server
+middleware (transform.ts) detects the Accept: text/css header and injects
+a ?direct query parameter:
+
+  Browser: <link href="xxx.css" />
+           ↓
+  Middleware: xxx.css -> xxx.css?direct (based on Accept: text/css header)
+           ↓
+  transformRequest(url) where url = "xxx.css?direct"
+           ↓
+  Plugin Pipeline: resolveId → load → transform
+
+In the CSS plugin's transform hook (css.ts:577-579), the ?direct query
+signals that raw CSS should be returned instead of a JS wrapper:
+
+  transform(code, id) {
+    if (isDirectCSSRequest(id)) {
+      return null  // Let CSS pass through unchanged
+    }
+    // Otherwise, wrap CSS in JS with HMR code
+  }
+
+## Why virtual modules break with ?direct (and ?inline)
+
+Standard virtual module plugins use exact string matching:
+
+  resolveId(source) {
+    if (source === 'virtual:test-style-server.css') {  // exact match
+      return `\0${source}`
+    }
+  }
+
+When Vite middleware adds ?direct (or user imports with ?inline), the source
+becomes 'virtual:test-style-server.css?direct' which doesn't match.
+
+For virtual CSS modules, the flow becomes:
+
+  1. Browser: <link href="/@id/__x00__virtual:test-style-server.css">
+  2. Vite maps /@id/__x00__... → \0...
+  3. Middleware: injects ?direct → "\0virtual:test-style-server.css?direct"
+  4. resolveId("\0virtual:test-style-server.css?direct") → no match, unresolved!
+  5. Load fails or returns wrong content
+
+## Why regular CSS files work
+
+For actual files like /src/style.css?direct, Vite/Rolldown has a fallback:
+when resolveId/load fails with query params, it retries with query stripped.
+So /src/style.css?direct eventually resolves to the file /src/style.css.
+
+Virtual modules don't benefit from this fallback because they rely on
+exact string matching in user plugins, not filesystem resolution.
+
+## Conclusion
+
+This is a Vite limitation. The fix would require Vite to either:
+1. Provide a query-aware virtual module resolution helper, OR
+2. Apply the query-stripping fallback to virtual modules too
+
+Workaround: User plugins can manually handle queries by stripping them in
+resolveId and load hooks. See examples/basic/vite.config.ts for patterns.
+*/
 
 const RESOLVED_ID_PROXY_PREFIX = 'virtual:vite-rsc/resolved-id/'
 const NULL_BYTE_PLACEHOLDER = '__x00__'

--- a/packages/plugin-rsc/src/plugins/resolved-id-proxy.ts
+++ b/packages/plugin-rsc/src/plugins/resolved-id-proxy.ts
@@ -3,7 +3,6 @@ import type { Plugin } from 'vite'
 // Resolved ID proxy plugin
 // This enables virtual modules (with \0 prefix) to be used in import specifiers
 // and handles ?direct query for CSS requests in dev mode.
-// See .dev-notes/dist/virtual-module-e2e-test-plan.md for details.
 //
 // Input/Output examples:
 //
@@ -22,6 +21,12 @@ const NULL_BYTE_PLACEHOLDER = '__x00__'
 export function toResolvedIdProxy(resolvedId: string): string {
   const encoded = resolvedId.replace(/\0/g, NULL_BYTE_PLACEHOLDER)
   return RESOLVED_ID_PROXY_PREFIX + encoded
+}
+
+export function withResolvedIdProxy(resolvedId: string): string {
+  return resolvedId.startsWith('\0')
+    ? toResolvedIdProxy(resolvedId)
+    : resolvedId
 }
 
 export function fromResolvedIdProxy(source: string): string | undefined {

--- a/packages/plugin-rsc/src/plugins/resolved-id-proxy.ts
+++ b/packages/plugin-rsc/src/plugins/resolved-id-proxy.ts
@@ -1,8 +1,7 @@
 import type { Plugin } from 'vite'
 
 // Resolved ID proxy plugin
-// This enables virtual modules (with \0 prefix) to be used in import specifiers
-// and handles ?direct query for CSS requests in dev mode.
+// This enables virtual modules (with \0 prefix) to be used in import specifiers.
 //
 // Input/Output examples:
 //
@@ -14,6 +13,10 @@ import type { Plugin } from 'vite'
 //
 //   fromResolvedIdProxy("virtual:vite-rsc/resolved-id/__x00__virtual:test.css?direct")
 //     => "\0virtual:test.css"
+//
+// TODO: ?direct query handling for virtual CSS doesn't work yet.
+// Vite adds ?direct for text/css requests, but the query is lost during resolution,
+// causing JS wrapper to be returned instead of raw CSS.
 
 const RESOLVED_ID_PROXY_PREFIX = 'virtual:vite-rsc/resolved-id/'
 const NULL_BYTE_PLACEHOLDER = '__x00__'


### PR DESCRIPTION
## Summary

- Add `vitePluginResolvedIdProxy()` to enable virtual `use client` modules
- Add e2e tests for virtual modules (`use client`, CSS)
- Document Vite's `?direct` query limitation for virtual CSS modules

## The problem

Virtual modules in Vite use `\0` prefix for resolved IDs (e.g., `\0virtual:test-virtual-client`). However, when RSC generates client reference imports, these `\0`-prefixed IDs cannot be used directly in import specifiers.

## The fix

The resolved-id proxy encodes `\0` so it can be used in import specifiers:

```ts
withResolvedIdProxy("\0virtual:test-virtual-client")
  => "virtual:vite-rsc/resolved-id/%00virtual%3Atest-virtual-client"
```

The `vitePluginResolvedIdProxy()` then resolves these back to the original `\0`-prefixed IDs. This enables virtual `use client` modules to work correctly in RSC.

---

## Side note: Virtual CSS and `?direct` limitation

During this work, we investigated why virtual CSS modules don't work with SSR `<link>` tags in dev mode.

### How Vite's `?direct` works

When a browser requests `<link href="xxx.css">`, Vite middleware injects `?direct` query. The CSS plugin checks this to return raw CSS instead of a JS wrapper.

### Why virtual CSS breaks

Standard virtual module plugins use exact string matching:

```ts
resolveId(source) {
  if (source === 'virtual:my.css') return `\0${source}`  // won't match "virtual:my.css?direct"
}
```

For real files, Vite retries with query stripped. Virtual modules don't benefit from this fallback.

### Workaround for users

Make virtual CSS plugins query-aware:

```ts
resolveId(source) {
  const clean = source.split('?')[0]
  if (clean === 'virtual:my.css') {
    return `\0${clean}${source.slice(clean.length)}`  // preserve ?direct
  }
}
load(id) {
  const clean = id.split('?')[0]
  if (clean === '\0virtual:my.css') return `.my { color: red; }`
}
```

### E2E test matrix

| | Query-aware | Exact-match |
|---|---|---|
| **Server CSS** (via `<link>`) | ✅ works | ❌ dev fails |
| **Client CSS** (via JS import) | ✅ works | ✅ works |

This is a Vite limitation. Proper fix would require Vite to provide query-aware virtual module helpers or apply query-stripping fallback to virtual modules.

---

🤖 Generated with [Claude Code](https://claude.ai/code)