### PR TITLE
ci(rsc): use vite@beta instead of rolldown-vite

### DIFF
--- a/.github/workflows/ci-rsc.yml
+++ b/.github/workflows/ci-rsc.yml
@@ -78,7 +78,7 @@ jobs:
       - name: install rolldown
         if: ${{ matrix.rolldown }}
         run: |
-          sed -i '/^overrides:/a\  vite: "npm:rolldown-vite@latest"' pnpm-workspace.yaml
+          yq -i '.overrides.vite = "beta"' pnpm-workspace.yaml
           pnpm i --no-frozen-lockfile
       - run: pnpm -C packages/plugin-rsc exec playwright install "$BROWSER_NAME"
         shell: bash


### PR DESCRIPTION
## Summary
- Replace `rolldown-vite@latest` with `vite@beta` for rolldown CI testing
- Use `yq` for more robust YAML manipulation