### PR TITLE
feat(rsc): add `customBuildApp` option 

### DIFF
--- a/packages/plugin-rsc/examples/no-ssr/vite.config.ts
+++ b/packages/plugin-rsc/examples/no-ssr/vite.config.ts
@@ -20,19 +20,20 @@ export default defineConfig({
     async buildApp(builder) {
       const { manager } = getPluginApi(builder.config)!
 
-      // ssr build (scan)
+      // Scan
       manager.isScanBuild = true
-      builder.environments.rsc.config.build.write = false
+      builder.environments.rsc!.config.build.write = false
+      builder.environments.client!.config.build.write = false
       await builder.build(builder.environments.rsc!)
-      builder.environments.rsc.config.build.write = true
+      await builder.build(builder.environments.client!)
+      builder.environments.rsc!.config.build.write = true
+      builder.environments.client!.config.build.write = true
       manager.isScanBuild = false
       manager.stabilize()
 
-      // clien build
-      await builder.build(builder.environments.client!)
-
-      // rsc build
+      // Build
       await builder.build(builder.environments.rsc!)
+      await builder.build(builder.environments.client!)
 
       // write manifest
       manager.writeAssetsManifest(['rsc'])

--- a/packages/plugin-rsc/examples/no-ssr/vite.config.ts
+++ b/packages/plugin-rsc/examples/no-ssr/vite.config.ts
@@ -1,6 +1,6 @@
 import fsp from 'node:fs/promises'
 import react from '@vitejs/plugin-react'
-import rsc from '@vitejs/plugin-rsc'
+import rsc, { getPluginApi } from '@vitejs/plugin-rsc'
 import { defineConfig, type Plugin } from 'vite'
 
 export default defineConfig({
@@ -11,8 +11,21 @@ export default defineConfig({
       entries: {
         rsc: './src/framework/entry.rsc.tsx',
       },
+      customBuildApp: true,
     }),
   ],
+  builder: {
+    sharedPlugins: true,
+    sharedConfigBuild: true,
+    async buildApp(builder) {
+      const { manager } = getPluginApi(builder.config)!
+      await builder.build(builder.environments.rsc!)
+      manager.stabilize()
+      await builder.build(builder.environments.client!)
+      await builder.build(builder.environments.rsc!)
+      manager.writeAssetsManifest(['rsc'])
+    },
+  },
 })
 
 function spaPlugin(): Plugin[] {

--- a/packages/plugin-rsc/examples/no-ssr/vite.config.ts
+++ b/packages/plugin-rsc/examples/no-ssr/vite.config.ts
@@ -19,10 +19,22 @@ export default defineConfig({
     sharedConfigBuild: true,
     async buildApp(builder) {
       const { manager } = getPluginApi(builder.config)!
+
+      // ssr build (scan)
+      manager.isScanBuild = true
+      builder.environments.rsc.config.build.write = false
       await builder.build(builder.environments.rsc!)
+      builder.environments.rsc.config.build.write = true
+      manager.isScanBuild = false
       manager.stabilize()
+
+      // clien build
       await builder.build(builder.environments.client!)
+
+      // rsc build
       await builder.build(builder.environments.rsc!)
+
+      // write manifest
       manager.writeAssetsManifest(['rsc'])
     },
   },

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -535,18 +535,17 @@ export default function vitePluginRsc(
               },
             },
           },
-          builder: {
-            sharedPlugins: true,
-            sharedConfigBuild: true,
-            async buildApp(builder) {
-              if (rscPluginOptions.customBuildApp) {
-                return
-              }
-              if (!rscPluginOptions.useBuildAppHook) {
-                await buildApp(builder)
-              }
-            },
-          },
+          builder: rscPluginOptions.customBuildApp
+            ? undefined
+            : {
+                sharedPlugins: true,
+                sharedConfigBuild: true,
+                async buildApp(builder) {
+                  if (!rscPluginOptions.useBuildAppHook) {
+                    await buildApp(builder)
+                  }
+                },
+              },
         }
       },
       configResolved() {

--- a/packages/plugin-rsc/types/index.d.ts
+++ b/packages/plugin-rsc/types/index.d.ts
@@ -17,6 +17,20 @@ declare module 'vite' {
     /** Options for `@vitejs/plugin-rsc` */
     rsc?: import('@vitejs/plugin-rsc').RscPluginOptions
   }
+
+  interface ViteBuilder {
+    /**
+     * RSC plugin API exposed for custom build pipelines.
+     * Available when using `rsc({ customBuildApp: true })`.
+     * @experimental
+     */
+    rsc: {
+      /** Access to internal RscPluginManager for controlling build phases */
+      manager: import('@vitejs/plugin-rsc').RscPluginManager
+      /** Write assets manifest to appropriate environments (ssr, rsc) */
+      writeAssetsManifest(): Promise<void>
+    }
+  }
 }
 
 export {}

--- a/packages/plugin-rsc/types/index.d.ts
+++ b/packages/plugin-rsc/types/index.d.ts
@@ -27,8 +27,6 @@ declare module 'vite' {
     rsc: {
       /** Access to internal RscPluginManager for controlling build phases */
       manager: import('@vitejs/plugin-rsc').RscPluginManager
-      /** Write assets manifest to appropriate environments (ssr, rsc) */
-      writeAssetsManifest(): Promise<void>
     }
   }
 }


### PR DESCRIPTION
(Sorry if anyone got pinged by this PR. It wasn't intended and AI did it :sweat:)

## Summary

This PR adds a `customBuildApp` option that allows downstream frameworks to skip the default `buildApp` orchestration and implement their own build order.

### Motivation

The RSC plugin currently has a hardcoded build pipeline:
- `rsc -> ssr -> rsc -> client -> ssr` (5 steps with 2 scan build)

With a new API, it allows taking over build pipeline to match framework's need. For example, following is from [No SSR example](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-rsc/examples/no-ssr/vite.config.ts):

```typescript
// vite.config.ts
import rsc, { getPluginApi } from '@vitejs/plugin-rsc'

export default defineConfig({
  plugins: [
    rsc({
      entries: {
        rsc: './src/framework/entry.rsc.tsx',
      },
      customBuildApp: true,
    }),
  ],
  builder: {
    sharedPlugins: true,
    sharedConfigBuild: true,
    async buildApp(builder) {
      const { manager } = getPluginApi(builder.config)!

      // Scan
      manager.isScanBuild = true
      builder.environments.rsc!.config.build.write = false
      builder.environments.client!.config.build.write = false
      await builder.build(builder.environments.rsc!)
      await builder.build(builder.environments.client!)
      builder.environments.rsc!.config.build.write = true
      builder.environments.client!.config.build.write = true
      manager.isScanBuild = false
      manager.stabilize()

      // Build
      await builder.build(builder.environments.rsc!)
      await builder.build(builder.environments.client!)

      // write manifest
      manager.writeAssetsManifest(['rsc'])
    },
  },
})
```
---

🤖 Generated with [Claude Code](https://claude.ai/code)