### PR TITLE
fix(rsc): support nested RSC outDir inside SSR outDir

### DIFF
--- a/packages/plugin-rsc/e2e/nested-outdir.test.ts
+++ b/packages/plugin-rsc/e2e/nested-outdir.test.ts
@@ -1,0 +1,54 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { expect, test } from '@playwright/test'
+import { setupInlineFixture, useFixture } from './fixture'
+import { defineStarterTest } from './starter'
+
+test.describe(() => {
+  const root = 'examples/e2e/temp/nested-outDir'
+
+  test.beforeAll(async () => {
+    await setupInlineFixture({
+      src: 'examples/starter',
+      dest: root,
+      files: {
+        'vite.config.base.ts': { cp: 'vite.config.ts' },
+        'vite.config.ts': /* js */ `
+import baseConfig from './vite.config.base.ts'
+
+// Modify baseConfig to use nested outDir (rsc inside ssr)
+baseConfig.environments.rsc.build.outDir = './dist/server/rsc'
+baseConfig.environments.ssr.build.outDir = './dist/server'
+
+export default baseConfig
+`,
+      },
+    })
+  })
+
+  test.describe('build-nested-outDir', () => {
+    const f = useFixture({ root, mode: 'build' })
+    defineStarterTest(f)
+
+    test('verify nested outDir structure', () => {
+      // RSC output exists inside SSR outDir
+      expect(fs.existsSync(path.join(f.root, 'dist/server/rsc/index.js'))).toBe(
+        true,
+      )
+      expect(
+        fs.existsSync(
+          path.join(f.root, 'dist/server/rsc/__vite_rsc_assets_manifest.js'),
+        ),
+      ).toBe(true)
+      // SSR output exists
+      expect(fs.existsSync(path.join(f.root, 'dist/server/index.js'))).toBe(
+        true,
+      )
+      expect(
+        fs.existsSync(
+          path.join(f.root, 'dist/server/__vite_rsc_assets_manifest.js'),
+        ),
+      ).toBe(true)
+    })
+  })
+})

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -380,6 +380,7 @@ export default function vitePluginRsc(
       if (fs.existsSync(tempRscOutDir)) {
         fs.rmSync(tempRscOutDir, { recursive: true })
       }
+      fs.mkdirSync(path.dirname(tempRscOutDir), { recursive: true })
       fs.renameSync(rscOutDir, tempRscOutDir)
     }
 

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -347,6 +347,20 @@ export default function vitePluginRsc(
       return
     }
 
+    // Check if RSC outDir is inside SSR outDir to avoid SSR build overwriting RSC output
+    const rscOutDir = builder.environments.rsc!.config.build.outDir
+    const ssrOutDir = builder.environments.ssr!.config.build.outDir
+    const rscInsideSsr = path
+      .normalize(rscOutDir)
+      .startsWith(path.normalize(ssrOutDir) + path.sep)
+
+    const tempRscOutDir = path.join(
+      builder.config.root,
+      'node_modules',
+      '.vite-rsc-temp',
+      'rsc',
+    )
+
     // rsc -> ssr -> rsc -> client -> ssr
     manager.isScanBuild = true
     builder.environments.rsc!.config.build.write = false
@@ -360,11 +374,30 @@ export default function vitePluginRsc(
     builder.environments.ssr!.config.build.write = true
     logStep('[3/5] build rsc environment...')
     await builder.build(builder.environments.rsc!)
+
+    // Evacuate RSC output to temp before SSR build overwrites it
+    if (rscInsideSsr) {
+      if (fs.existsSync(tempRscOutDir)) {
+        fs.rmSync(tempRscOutDir, { recursive: true })
+      }
+      fs.renameSync(rscOutDir, tempRscOutDir)
+    }
+
     manager.stabilize()
     logStep('[4/5] build client environment...')
     await builder.build(builder.environments.client!)
     logStep('[5/5] build ssr environment...')
     await builder.build(builder.environments.ssr!)
+
+    // Restore RSC output from temp after SSR build
+    if (rscInsideSsr) {
+      if (fs.existsSync(rscOutDir)) {
+        fs.rmSync(rscOutDir, { recursive: true })
+      }
+      fs.mkdirSync(path.dirname(rscOutDir), { recursive: true })
+      fs.renameSync(tempRscOutDir, rscOutDir)
+    }
+
     writeAssetsManifest(['ssr', 'rsc'])
   }
 


### PR DESCRIPTION
## Summary
- Support configuring `rsc.build.outDir` as a subdirectory of `ssr.build.outDir` (e.g., `dist/server/rsc` inside `dist/server`)
- When detected, evacuates RSC output to a temp directory after build, then restores it after SSR build completes
- This enables frameworks like TanStack Start to use a unified server output structure

## Test plan
- [ ] Add e2e test with nested outDir configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)