### PR TITLE
test: lazy css reproduction

### DIFF
--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -549,6 +549,23 @@ function defineTest(f: Fixture) {
     )
   })
 
+  test('lazy client css @js', async ({ page }) => {
+    await page.goto(f.url())
+    await waitForHydration(page)
+    await expect(page.locator('.test-lazy-client-css')).toHaveCSS(
+      'color',
+      'rgb(255, 165, 0)',
+    )
+  })
+
+  testNoJs('lazy client css @nojs', async ({ page }) => {
+    await page.goto(f.url())
+    await expect(page.locator('.test-lazy-client-css')).toHaveCSS(
+      'color',
+      'rgb(255, 165, 0)',
+    )
+  })
+
   test('tailwind @js', async ({ page }) => {
     await page.goto(f.url())
     await waitForHydration(page)

--- a/packages/plugin-rsc/examples/basic/src/routes/lazy-client-css/client.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/lazy-client-css/client.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import * as React from 'react'
+
+// React.lazy for SSR-ing lazy client component
+const LazyDep = React.lazy(() => import('./lazy-dep'))
+
+export function TestLazyClientCss() {
+  return (
+    <div data-testid="test-lazy-client-css">
+      <React.Suspense fallback={<span>lazy-loading...</span>}>
+        <LazyDep />
+      </React.Suspense>
+    </div>
+  )
+}

--- a/packages/plugin-rsc/examples/basic/src/routes/lazy-client-css/lazy-dep.css
+++ b/packages/plugin-rsc/examples/basic/src/routes/lazy-client-css/lazy-dep.css
@@ -1,0 +1,5 @@
+/* css imported by lazy client component */
+
+.test-lazy-client-css {
+  color: rgb(255, 165, 0);
+}

--- a/packages/plugin-rsc/examples/basic/src/routes/lazy-client-css/lazy-dep.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/lazy-client-css/lazy-dep.tsx
@@ -1,0 +1,5 @@
+import './lazy-dep.css'
+
+export default function LazyDep() {
+  return <span className="test-lazy-client-css">lazy-client-css</span>
+}

--- a/packages/plugin-rsc/examples/basic/src/routes/root.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/root.tsx
@@ -30,6 +30,7 @@ import { TestUseCache } from './use-cache/server'
 import { TestHydrationMismatch } from './hydration-mismatch/server'
 import { TestBrowserOnly } from './browser-only/client'
 import { TestTransitiveCjsClient } from './deps/transitive-cjs/client'
+import { TestLazyClientCss } from './lazy-client-css/client'
 
 export function Root(props: { url: URL }) {
   return (
@@ -72,6 +73,7 @@ export function Root(props: { url: URL }) {
         <TestActionStateServer />
         <TestModuleInvalidationServer />
         <TestBrowserOnly />
+        <TestLazyClientCss />
         <TestUseCache />
       </body>
     </html>


### PR DESCRIPTION
Add reproduction for SSR-ing lazy client component which imports CSS. This is a test case for investigating FOUC (flash of unstyled content) when lazy-loaded client components import CSS files.

Ref: https://github.com/wakujs/waku/issues/1911#issuecomment-3752539573

### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
