### PR TITLE
fix(rsc): remove redundant `builder.rsc` injection

### DIFF
--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -205,8 +205,8 @@ export type RscPluginOptions = {
   useBuildAppHook?: boolean
 
   /**
-   * Skip the default buildApp orchestration and expose utilities on `builder.rsc`
-   * for downstream frameworks to implement custom build pipelines.
+   * Skip the default buildApp orchestration for downstream frameworks
+   * to implement custom build pipelines using `getPluginApi()`.
    * @experimental
    * @default false
    */
@@ -431,17 +431,6 @@ export default function vitePluginRsc(
   let hasReactServerDomWebpack = false
 
   return [
-    {
-      name: 'rsc:builder-api',
-      buildApp: {
-        order: 'pre' as const,
-        async handler(builder) {
-          builder.rsc = {
-            manager,
-          }
-        },
-      },
-    },
     {
       name: 'rsc',
       async config(config, env) {

--- a/packages/plugin-rsc/types/index.d.ts
+++ b/packages/plugin-rsc/types/index.d.ts
@@ -17,18 +17,6 @@ declare module 'vite' {
     /** Options for `@vitejs/plugin-rsc` */
     rsc?: import('@vitejs/plugin-rsc').RscPluginOptions
   }
-
-  interface ViteBuilder {
-    /**
-     * RSC plugin API exposed for custom build pipelines.
-     * Available when using `rsc({ customBuildApp: true })`.
-     * @experimental
-     */
-    rsc: {
-      /** Access to internal RscPluginManager for controlling build phases */
-      manager: import('@vitejs/plugin-rsc').RscPluginManager
-    }
-  }
 }
 
 export {}


### PR DESCRIPTION
### Description

- Follow up to https://github.com/vitejs/vite-plugin-react/pull/1052

Since getPluginApi() is already exposed, there wasn't need to inject the rsc property onto the builder object.
