### PR TITLE
fix(rsc): correctly select entry chunk when multiple chunks are named "index" (fix #1060)

### DIFF
--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1060,7 +1060,7 @@ export function createRpcClient(params) {
 
           const assetDeps = collectAssetDeps(bundle)
           const entry = Object.values(assetDeps).find(
-            (v) => v.chunk.name === 'index',
+            (v) => v.chunk.name === 'index' && v.chunk.isEntry,
           )
           assert(entry)
           const entryUrl = assetsURL(entry.chunk.fileName, manager)


### PR DESCRIPTION
 Fixes #1060

This PR fixes a bug in `@vitejs/plugin-rsc` where the plugin incorrectly selects the wrong JavaScript bundle when multiple Vite chunks share the name `"index"`. This commonly occurs in monorepo structures or projects with component libraries that export from `index.ts`/`index.js` files.

**Problem:**
  The current entry chunk selection logic uses:
 ```js
const entry = Object.values(assetDeps).find((v) => v.chunk.name === 'index',)
```

  This returns the first chunk with the name "index" rather than the actual entry point, causing React client hydration to fail because the wrong bundle gets imported into the HTML.

**Solution**:
Added an isEntry property check to ensure only the actual entry point is selected:
```js
const entry = Object.values(assetDeps).find((v) => v.chunk.name === 'index' && v.chunk.isEntry)
```
 
This ensures the correct bootstrap script loads when there are multiple chunks with the same name, allowing hydration to succeed.