### PR TITLE
feat(plugin-rsc): add callback to be notified when client reference dependencies are loaded

### DIFF
--- a/packages/plugin-rsc/src/core/ssr.ts
+++ b/packages/plugin-rsc/src/core/ssr.ts
@@ -6,6 +6,10 @@ let init = false
 
 export function setRequireModule(options: {
   load: (id: string) => unknown
+  /**
+   * Called EVERY time a module is requested
+   */
+  onLoad?: (id: string) => void
 }): void {
   if (init) return
   init = true
@@ -15,6 +19,8 @@ export function setRequireModule(options: {
   })
 
   const clientRequire = (id: string) => {
+    const cleanId = removeReferenceCacheTag(id)
+    options.onLoad?.(cleanId)
     return requireModule(id)
   }
   ;(globalThis as any).__vite_rsc_client_require__ = clientRequire

--- a/packages/plugin-rsc/src/core/ssr.ts
+++ b/packages/plugin-rsc/src/core/ssr.ts
@@ -8,6 +8,7 @@ export function setRequireModule(options: {
   load: (id: string) => unknown
   /**
    * Called EVERY time a module is requested
+   * @experimental
    */
   onLoad?: (id: string) => void
 }): void {

--- a/packages/plugin-rsc/src/ssr.tsx
+++ b/packages/plugin-rsc/src/ssr.tsx
@@ -12,24 +12,25 @@ export * from './react/ssr'
 /**
  * Callback type for client reference dependency notifications.
  * Called during SSR when a client component's dependencies are loaded.
+ * @experimental
  */
-export type OnClientReferenceDeps = (deps: {
-  js: readonly string[]
-  css: readonly string[]
+export type OnClientReference = (reference: {
+  id: string
+  deps: ResolvedAssetDeps
 }) => void
 
 // Registered callback for client reference deps
-let onClientReferenceDepsCallback: OnClientReferenceDeps | undefined
+let onClientReference: OnClientReference | undefined
 
 /**
  * Register a callback to be notified when client reference dependencies are loaded.
  * Called during SSR when a client component is accessed.
- *
+ * @experimental
  */
-export function setOnClientReferenceDeps(
-  callback: OnClientReferenceDeps | undefined,
+export function setOnClientReference(
+  callback: OnClientReference | undefined,
 ): void {
-  onClientReferenceDepsCallback = callback
+  onClientReference = callback
 }
 
 initialize()
@@ -65,10 +66,10 @@ function initialize(): void {
     // Notify framework callback for per-request asset collection.
     onLoad: (id) => {
       if (!import.meta.env.__vite_rsc_build__) return
-      if (onClientReferenceDepsCallback) {
+      if (onClientReference) {
         const deps = assetsManifest.clientReferenceDeps[id]
         if (deps) {
-          onClientReferenceDepsCallback({ js: deps.js, css: deps.css })
+          onClientReference({ id, deps: { js: deps.js, css: deps.css } })
         }
       }
     },


### PR DESCRIPTION
## Summary

Add a callback mechanism to notify frameworks when client reference dependencies are loaded during SSR.

### New API

```ts
import { setOnClientReference, type OnClientReference } from '@vitejs/plugin-rsc/ssr'

const callback: OnClientReference = ({ id, deps }) => {
  // id: client reference module id
  // deps: { js: string[], css: string[] }
}

setOnClientReference(callback)
```

### Use case

During SSR, frameworks need to track which client components are actually rendered in order to collect their asset dependencies (JS and CSS) for the response. This callback is invoked every time a client reference is accessed, allowing per-request asset collection.

Note: The callback is called on every access (not memoized), so frameworks should handle deduplication if needed.

### Changes

- `setRequireModule` now accepts an optional `onLoad` callback
- New `setOnClientReference` function to register a framework-level callback
- New `OnClientReference` type export

All new APIs are marked `@experimental`.