### PR TITLE
feat(plugin-rsc): add `customClientEntry` option to opt out of "index" entry convention

### DIFF
--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1100,10 +1100,11 @@ export function createRpcClient(params) {
             const entry = Object.values(assetDeps).find(
               (v) => v.chunk.name === 'index' && v.chunk.isEntry,
             )
-            assert(
-              entry,
-              `[vite-rsc] Client build must have an entry chunk named "index". Use 'customClientEntry' option to disable this requirement.`,
-            )
+            if (!entry) {
+              throw new Error(
+                `[vite-rsc] Client build must have an entry chunk named "index". Use 'customClientEntry' option to disable this requirement.`,
+              )
+            }
             const entryDeps = assetsURLOfDeps(entry.deps, manager)
             for (const [key, deps] of Object.entries(clientReferenceDeps)) {
               clientReferenceDeps[key] = mergeAssetDeps(deps, entryDeps)


### PR DESCRIPTION
## Summary

- Add experimental `customClientEntry` option to allow frameworks to opt out of the default "index" client entry convention
- When enabled, the plugin no longer requires an entry chunk named "index" and won't auto-merge client entry deps into client references
- Bans `loadBootstrapScriptContent` usage with this option (throws clear error)

This is useful for frameworks like start-rsc that manually handle client entry setup and preloading.

## Test plan

- [ ] Verify build works with `customClientEntry: true` and non-index entry name
- [ ] Verify error is thrown when using `loadBootstrapScriptContent` with `customClientEntry: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)