### PR TITLE
feat(plugin-rsc): add `import.meta.viteRsc.importAsset` API

### DIFF
--- a/packages/plugin-rsc/e2e/import-asset.test.ts
+++ b/packages/plugin-rsc/e2e/import-asset.test.ts
@@ -22,6 +22,13 @@ test.describe('viteRsc.importAsset', () => {
 `,
             ),
         },
+        // Remove "index" client entry to test importAsset replacing the convention
+        'vite.config.base.ts': { cp: 'vite.config.ts' },
+        'vite.config.ts': /* js */ `
+          import baseConfig from './vite.config.base.ts'
+          delete baseConfig.environments.client.build.rollupOptions.input;
+          export default baseConfig;
+        `,
       },
     })
   })

--- a/packages/plugin-rsc/e2e/import-asset.test.ts
+++ b/packages/plugin-rsc/e2e/import-asset.test.ts
@@ -1,0 +1,38 @@
+import { test } from '@playwright/test'
+import { setupInlineFixture, useFixture } from './fixture'
+import { defineStarterTest } from './starter'
+
+test.describe('viteRsc.importAsset', () => {
+  const root = 'examples/e2e/temp/import-asset'
+  test.beforeAll(async () => {
+    await setupInlineFixture({
+      src: 'examples/starter',
+      dest: root,
+      files: {
+        'src/framework/entry.ssr.tsx': {
+          edit: (s) =>
+            s.replace(
+              `\
+  const bootstrapScriptContent =
+    await import.meta.viteRsc.loadBootstrapScriptContent('index')
+`,
+              `\
+  const asset = await import.meta.viteRsc.importAsset('./entry.browser.tsx', { entry: true })
+  const bootstrapScriptContent = \`import(\${JSON.stringify(asset.url)})\`
+`,
+            ),
+        },
+      },
+    })
+  })
+
+  test.describe('dev', () => {
+    const f = useFixture({ root, mode: 'dev' })
+    defineStarterTest(f)
+  })
+
+  test.describe('build', () => {
+    const f = useFixture({ root, mode: 'build' })
+    defineStarterTest(f)
+  })
+})

--- a/packages/plugin-rsc/examples/basic/src/framework/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/basic/src/framework/entry.ssr.tsx
@@ -27,14 +27,11 @@ export async function renderHTML(
     return React.use(payload).root
   }
 
+  // render html (traditional SSR)
   const asset = await import.meta.viteRsc.importAsset('./entry.browser.tsx', {
     entry: true,
   })
-  console.log('[importAsset]', asset.url)
-
-  // render html (traditional SSR)
-  const bootstrapScriptContent =
-    await import.meta.viteRsc.loadBootstrapScriptContent('index')
+  const bootstrapScriptContent = `import(${JSON.stringify(asset.url)})`
   let htmlStream: ReadableStream<Uint8Array>
   let status: number | undefined
   try {

--- a/packages/plugin-rsc/examples/basic/src/framework/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/basic/src/framework/entry.ssr.tsx
@@ -27,6 +27,11 @@ export async function renderHTML(
     return React.use(payload).root
   }
 
+  const asset = await import.meta.viteRsc.importAsset('./entry.browser.tsx', {
+    entry: true,
+  })
+  console.log('[importAsset]', asset.url)
+
   // render html (traditional SSR)
   const bootstrapScriptContent =
     await import.meta.viteRsc.loadBootstrapScriptContent('index')

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -28,6 +28,7 @@ import vitePluginRscCore from './core/plugin'
 import { cjsModuleRunnerPlugin } from './plugins/cjs'
 import { vitePluginFindSourceMapURL } from './plugins/find-source-map-url'
 import {
+  ensureAssetImportsClientEntry,
   vitePluginImportAsset,
   type AssetImportMeta,
 } from './plugins/import-asset'
@@ -405,6 +406,7 @@ export default function vitePluginRsc(
 
     // rsc -> ssr -> rsc -> client -> ssr
     ensureEnvironmentImportsEntryFallback(builder.config)
+    ensureAssetImportsClientEntry(builder.config)
     manager.isScanBuild = true
     builder.environments.rsc!.config.build.write = false
     builder.environments.ssr!.config.build.write = false

--- a/packages/plugin-rsc/src/plugins/import-asset.ts
+++ b/packages/plugin-rsc/src/plugins/import-asset.ts
@@ -1,0 +1,245 @@
+import assert from 'node:assert'
+import fs from 'node:fs'
+import path from 'node:path'
+import MagicString from 'magic-string'
+import { stripLiteral } from 'strip-literal'
+import { normalizePath, type Plugin } from 'vite'
+import type { RscPluginManager } from '../plugin'
+import { normalizeRelativePath } from './utils'
+import { evalValue } from './vite-utils'
+
+export const ASSET_IMPORTS_MANIFEST_NAME =
+  '__vite_rsc_asset_imports_manifest.js'
+
+const ASSET_IMPORTS_MANIFEST_PLACEHOLDER =
+  'virtual:vite-rsc/asset-imports-manifest'
+
+// Virtual module prefix for entry asset wrappers in dev mode
+const ASSET_ENTRY_VIRTUAL_PREFIX = 'virtual:vite-rsc/asset-entry/'
+
+export type AssetImportMeta = {
+  resolvedId: string
+  sourceEnv: string
+  specifier: string
+  isEntry: boolean
+}
+
+export function vitePluginImportAsset(manager: RscPluginManager): Plugin[] {
+  return [
+    {
+      name: 'rsc:import-asset',
+      resolveId(source) {
+        // Use placeholder as external, renderChunk will replace with correct relative path
+        if (source === ASSET_IMPORTS_MANIFEST_PLACEHOLDER) {
+          return { id: ASSET_IMPORTS_MANIFEST_PLACEHOLDER, external: true }
+        }
+        // Handle virtual asset entry modules
+        if (source.startsWith(ASSET_ENTRY_VIRTUAL_PREFIX)) {
+          return '\0' + source
+        }
+      },
+      async load(id) {
+        // Handle virtual asset entry modules in dev mode
+        if (id.startsWith('\0' + ASSET_ENTRY_VIRTUAL_PREFIX)) {
+          assert(this.environment.mode === 'dev')
+          const resolvedId = id.slice(
+            ('\0' + ASSET_ENTRY_VIRTUAL_PREFIX).length,
+          )
+
+          let code = ''
+          // Enable HMR only when react plugin is available
+          const resolved = await this.resolve('/@react-refresh')
+          if (resolved) {
+            code += `
+import RefreshRuntime from "/@react-refresh";
+RefreshRuntime.injectIntoGlobalHook(window);
+window.$RefreshReg$ = () => {};
+window.$RefreshSig$ = () => (type) => type;
+window.__vite_plugin_react_preamble_installed__ = true;
+`
+          }
+          code += `await import(${JSON.stringify(resolvedId)});`
+          // Server CSS cleanup on HMR
+          code += /* js */ `
+const ssrCss = document.querySelectorAll("link[rel='stylesheet']");
+import.meta.hot.on("vite:beforeUpdate", () => {
+  ssrCss.forEach(node => {
+    if (node.dataset.precedence?.startsWith("vite-rsc/client-references")) {
+      node.remove();
+    }
+  });
+});
+`
+          // Close error overlay after syntax error is fixed
+          code += `
+import.meta.hot.on("rsc:update", () => {
+  document.querySelectorAll("vite-error-overlay").forEach((n) => n.close())
+});
+`
+          return code
+        }
+      },
+      buildStart() {
+        // Emit discovered entries during build
+        if (this.environment.mode !== 'build') return
+        if (this.environment.name !== 'client') return
+
+        // Collect unique entries targeting client environment
+        const emitted = new Set<string>()
+        for (const metas of Object.values(manager.assetImportMetaMap)) {
+          for (const meta of Object.values(metas)) {
+            if (meta.isEntry && !emitted.has(meta.resolvedId)) {
+              emitted.add(meta.resolvedId)
+              this.emitFile({
+                type: 'chunk',
+                id: meta.resolvedId,
+              })
+            }
+          }
+        }
+      },
+      transform: {
+        async handler(code, id) {
+          if (!code.includes('import.meta.viteRsc.importAsset')) return
+
+          const { server, config } = manager
+          const s = new MagicString(code)
+
+          for (const match of stripLiteral(code).matchAll(
+            /import\.meta\.viteRsc\.importAsset\s*\(([\s\S]*?)\)/dg,
+          )) {
+            const [argStart, argEnd] = match.indices![1]!
+            const argCode = code.slice(argStart, argEnd).trim()
+
+            // Parse: ('./entry.browser.tsx', { entry: true })
+            const [specifier, options]: [string, { entry?: boolean }?] =
+              evalValue(`[${argCode}]`)
+            const isEntry = options?.entry ?? false
+
+            // Resolve specifier relative to importer against client environment
+            let resolvedId: string
+            if (this.environment.mode === 'dev') {
+              const clientEnv = server.environments.client
+              assert(clientEnv, `[vite-rsc] client environment not found`)
+              const resolved = await clientEnv.pluginContainer.resolveId(
+                specifier,
+                id,
+              )
+              assert(
+                resolved,
+                `[vite-rsc] failed to resolve '${specifier}' for client environment`,
+              )
+              resolvedId = resolved.id
+            } else {
+              // Build mode: resolve in client environment config
+              const clientEnvConfig = config.environments.client
+              assert(clientEnvConfig, `[vite-rsc] client environment not found`)
+              // Use this environment's resolver for now
+              const resolved = await this.resolve(specifier, id)
+              assert(
+                resolved,
+                `[vite-rsc] failed to resolve '${specifier}' for client environment`,
+              )
+              resolvedId = resolved.id
+            }
+
+            // Track discovered asset, keyed by [sourceEnv][resolvedId]
+            const sourceEnv = this.environment.name
+            manager.assetImportMetaMap[sourceEnv] ??= {}
+            manager.assetImportMetaMap[sourceEnv]![resolvedId] = {
+              resolvedId,
+              sourceEnv,
+              specifier,
+              isEntry,
+            }
+
+            let replacement: string
+            if (this.environment.mode === 'dev') {
+              if (isEntry) {
+                // Dev + entry: use virtual wrapper with HMR support
+                const virtualId = ASSET_ENTRY_VIRTUAL_PREFIX + resolvedId
+                const url = config.base + '@id/__x00__' + virtualId
+                replacement = `Promise.resolve({ url: ${JSON.stringify(url)} })`
+              } else {
+                // Dev + non-entry: compute URL directly
+                const relativePath = normalizePath(
+                  path.relative(config.root, resolvedId),
+                )
+                const url = config.base + relativePath
+                replacement = `Promise.resolve({ url: ${JSON.stringify(url)} })`
+              }
+            } else {
+              // Build: emit manifest lookup with static import
+              // Use relative ID for stable builds across different machines
+              const relativeId = manager.toRelativeId(resolvedId)
+              replacement = `(await import(${JSON.stringify(ASSET_IMPORTS_MANIFEST_PLACEHOLDER)})).default[${JSON.stringify(relativeId)}]`
+            }
+
+            const [start, end] = match.indices![0]!
+            s.overwrite(start, end, replacement)
+          }
+
+          if (s.hasChanged()) {
+            return {
+              code: s.toString(),
+              map: s.generateMap({ hires: 'boundary' }),
+            }
+          }
+        },
+      },
+
+      renderChunk(code, chunk) {
+        if (code.includes(ASSET_IMPORTS_MANIFEST_PLACEHOLDER)) {
+          const replacement = normalizeRelativePath(
+            path.relative(
+              path.join(chunk.fileName, '..'),
+              ASSET_IMPORTS_MANIFEST_NAME,
+            ),
+          )
+          code = code.replaceAll(
+            ASSET_IMPORTS_MANIFEST_PLACEHOLDER,
+            () => replacement,
+          )
+          return { code }
+        }
+        return
+      },
+    },
+  ]
+}
+
+export function writeAssetImportsManifest(manager: RscPluginManager): void {
+  if (Object.keys(manager.assetImportMetaMap).length === 0) {
+    return
+  }
+
+  const clientBundle = manager.bundles['client']
+  if (!clientBundle) {
+    throw new Error(`[vite-rsc] missing client bundle for asset imports`)
+  }
+
+  // Write manifest to each source environment's output
+  for (const [sourceEnv, metas] of Object.entries(manager.assetImportMetaMap)) {
+    const sourceOutDir = manager.config.environments[sourceEnv]!.build.outDir
+    const manifestPath = path.join(sourceOutDir, ASSET_IMPORTS_MANIFEST_NAME)
+
+    let code = 'export default {\n'
+    for (const resolvedId of Object.keys(metas)) {
+      const chunk = Object.values(clientBundle).find(
+        (c) => c.type === 'chunk' && c.facadeModuleId === resolvedId,
+      )
+      if (!chunk) {
+        throw new Error(
+          `[vite-rsc] missing output for asset import: ${resolvedId}`,
+        )
+      }
+
+      const relativeId = manager.toRelativeId(resolvedId)
+      const url = manager.assetsURL(chunk.fileName)
+      code += `  ${JSON.stringify(relativeId)}: ${manager.serializeValueWithRuntime({ url })},\n`
+    }
+    code += '}\n'
+
+    fs.writeFileSync(manifestPath, code)
+  }
+}

--- a/packages/plugin-rsc/types/index.d.ts
+++ b/packages/plugin-rsc/types/index.d.ts
@@ -27,6 +27,29 @@ declare global {
         specifier: string,
         options: { environment: string },
       ) => Promise<T>
+
+      /**
+       * Import a client asset from a server environment (SSR/RSC) and get its URL.
+       *
+       * This is useful for loading client-side scripts and obtaining their URLs
+       * for bootstrap scripts or other dynamic imports.
+       *
+       * @example
+       * ```ts
+       * const asset = await import.meta.viteRsc.importAsset('./entry.browser.tsx', { entry: true });
+       * const bootstrapScriptContent = `import(${JSON.stringify(asset.url)})`;
+       * ```
+       *
+       * @param specifier - Relative path to the client asset (e.g., './entry.browser.tsx')
+       * @param options - Options object
+       * @param options.entry - When true, marks this asset as an entry point for client deps merging.
+       *                        This replaces the "index" entry convention when using customClientEntry.
+       * @returns Promise resolving to an object containing the asset URL
+       */
+      importAsset: (
+        specifier: string,
+        options?: { entry?: boolean },
+      ) => Promise<{ url: string }>
     }
   }
 


### PR DESCRIPTION
## Summary

- Add `import.meta.viteRsc.importAsset` API for importing client assets from server environments (SSR/RSC)
- Returns asset URL, providing a more flexible alternative to `loadBootstrapScriptContent`
- Supports `entry: true` option for HMR support in dev mode via virtual wrapper

**API Signature:**
```typescript
importAsset: (specifier: string, options?: { entry?: boolean }) => Promise<{ url: string }>
```

**Usage Example:**
```tsx
// In SSR entry
const asset = await import.meta.viteRsc.importAsset("./entry.browser.tsx", { entry: true });
const bootstrapScriptContent = `import(${JSON.stringify(asset.url)})`;
```

## Test plan

- [x] TypeScript check passes (`pnpm -C packages/plugin-rsc tsc --noEmit`)
- [x] Dev server starts successfully
- [x] Build completes and generates manifest in `dist/ssr/__vite_rsc_asset_imports_manifest.js`
- [ ] Manual testing of dev mode with `entry: true` (virtual wrapper with HMR)
- [ ] Manual testing of dev mode with `entry: false` (direct URL)
- [ ] Manual testing of production build

🤖 Generated with [Claude Code](https://claude.com/claude-code)