### PR TITLE
fix(plugin-rsc): move `onClientReference` to `wrapResourceProxy` and fix dev 

### DIFF
--- a/packages/plugin-rsc/src/core/ssr.ts
+++ b/packages/plugin-rsc/src/core/ssr.ts
@@ -6,11 +6,6 @@ let init = false
 
 export function setRequireModule(options: {
   load: (id: string) => unknown
-  /**
-   * Called EVERY time a module is requested
-   * @experimental
-   */
-  onLoad?: (id: string) => void
 }): void {
   if (init) return
   init = true
@@ -18,13 +13,7 @@ export function setRequireModule(options: {
   const requireModule = memoize((id: string) => {
     return options.load(removeReferenceCacheTag(id))
   })
-
-  const clientRequire = (id: string) => {
-    const cleanId = removeReferenceCacheTag(id)
-    options.onLoad?.(cleanId)
-    return requireModule(id)
-  }
-  ;(globalThis as any).__vite_rsc_client_require__ = clientRequire
+  ;(globalThis as any).__vite_rsc_client_require__ = requireModule
 
   setInternalRequire()
 }


### PR DESCRIPTION
## Summary
- Consolidate client reference notification by moving it into the resource proxy getter
- Remove the separate `onLoad` callback mechanism from `setRequireModule`
- Notify `onClientReference` early in `load` (production) alongside preload, and in proxy getter for per-request asset collection

Supersedes closes #1070

🤖 Generated with [Claude Code](https://claude.com/claude-code)