### PR TITLE
fix(rsc): support `rolldownOptions`

### DIFF
--- a/packages/plugin-rsc/src/plugins/import-environment.ts
+++ b/packages/plugin-rsc/src/plugins/import-environment.ts
@@ -7,6 +7,8 @@ import type { Plugin, ResolvedConfig } from 'vite'
 import type { RscPluginManager } from '../plugin'
 import {
   createVirtualPlugin,
+  getBuildOptionsInput,
+  createBuildInputConfig,
   normalizeRelativePath,
   normalizeRollupOpitonsInput,
 } from './utils'
@@ -24,21 +26,22 @@ export type EnvironmentImportMeta = {
   specifier: string
 }
 
-// ensure at least one entry since otherwise rollup build fails
+// ensure at least one entry since otherwise rollup/rolldown build fails
 export function ensureEnvironmentImportsEntryFallback({
   environments,
 }: ResolvedConfig): void {
   for (const [name, config] of Object.entries(environments)) {
     if (name === 'client') continue
     const input = normalizeRollupOpitonsInput(
-      config.build?.rollupOptions?.input,
+      getBuildOptionsInput(config.build),
     )
     if (Object.keys(input).length === 0) {
       config.build = config.build || {}
-      config.build.rollupOptions = config.build.rollupOptions || {}
-      config.build.rollupOptions.input = {
+      const fallbackInput = {
         __vite_rsc_env_imports_entry_fallback: ENV_IMPORTS_ENTRY_FALLBACK,
       }
+      const inputConfig = createBuildInputConfig(fallbackInput)
+      Object.assign(config.build, inputConfig)
     }
   }
 }


### PR DESCRIPTION
Add compatibility for Rolldown-based Vite by supporting both `build.rollupOptions.input` and `build.rolldownOptions.input`.

- Add `getBuildOptionsInput()` utility to read input from either option
- Add `createBuildInputConfig()` utility to generate config for both options
- Update `getEntrySource()` to use the new utility
- Update `ensureEnvironmentImportsEntryFallback()` to set both options
- Update environment config section to use `createBuildInputConfig()`
- Update `getFallbackRollupEntry()` usage to read from both options

This ensures the plugin works with both Rollup-based and Rolldown-based Vite versions as per the migration guide at main.vite.dev/guide/migration.

### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
