### PR TITLE
test(plugin-rsc): add rolldownOptions test coverage

### DIFF
--- a/packages/plugin-rsc/e2e/rolldown.test.ts
+++ b/packages/plugin-rsc/e2e/rolldown.test.ts
@@ -1,0 +1,31 @@
+import { test } from '@playwright/test'
+import * as vite from 'vite'
+import { setupInlineFixture, useFixture } from './fixture'
+import { defineStarterTest } from './starter'
+
+test.describe('rolldownOptions', () => {
+  test.skip(!('rolldownVersion' in vite), 'rolldown only')
+
+  const root = 'examples/e2e/temp/rolldown-options'
+  test.beforeAll(async () => {
+    await setupInlineFixture({
+      src: 'examples/starter',
+      dest: root,
+      files: {
+        'vite.config.ts': {
+          edit: (s) => s.replace(/rollupOptions/g, 'rolldownOptions'),
+        },
+      },
+    })
+  })
+
+  test.describe('dev', () => {
+    const f = useFixture({ root, mode: 'dev' })
+    defineStarterTest(f)
+  })
+
+  test.describe('build', () => {
+    const f = useFixture({ root, mode: 'build' })
+    defineStarterTest(f)
+  })
+})


### PR DESCRIPTION
## Summary
- Add e2e test to verify that `rolldownOptions` works correctly with plugin-rsc
- Confirms Vite 8's interop functionality for rolldown configuration
- Test skips when not running with rolldown and reuses the starter fixture tests

## Test plan
- [ ] CI runs this test automatically in the rolldown matrix (ubuntu + chromium + rolldown: true)
- [ ] Test should skip on non-rolldown runs
- [ ] Test should pass on rolldown runs with both dev and build modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)