### PR TITLE
test(plugin-rsc): add ReadableStream polyfill for WebKit/Safari support

### DIFF
--- a/packages/plugin-rsc/e2e/browser-mode.test.ts
+++ b/packages/plugin-rsc/e2e/browser-mode.test.ts
@@ -2,10 +2,6 @@ import { expect, test, type Page } from '@playwright/test'
 import { useFixture } from './fixture'
 import { defineStarterTest } from './starter'
 
-// Webkit fails by
-// > TypeError: ReadableByteStreamController is not implemented
-test.skip(({ browserName }) => browserName === 'webkit')
-
 test.describe('dev-browser-mode', () => {
   const f = useFixture({ root: 'examples/browser-mode', mode: 'dev' })
   defineStarterTest(f, 'browser-mode')

--- a/packages/plugin-rsc/e2e/browser.test.ts
+++ b/packages/plugin-rsc/e2e/browser.test.ts
@@ -2,10 +2,6 @@ import { test } from '@playwright/test'
 import { useFixture } from './fixture'
 import { defineStarterTest } from './starter'
 
-// Webkit fails by
-// > TypeError: ReadableByteStreamController is not implemented
-test.skip(({ browserName }) => browserName === 'webkit')
-
 test.describe('dev-browser', () => {
   const f = useFixture({ root: 'examples/browser', mode: 'dev' })
   defineStarterTest(f, 'no-ssr')

--- a/packages/plugin-rsc/e2e/helper.ts
+++ b/packages/plugin-rsc/e2e/helper.ts
@@ -48,6 +48,9 @@ export function expectNoPageError(page: Page) {
   page.on('pageerror', (error) => {
     errors.push(error)
   })
+  page.on('console', (msg) => {
+    console.log(`[browser:${msg.type()}]`, msg.text())
+  })
   return {
     [Symbol.dispose]: () => {
       expect(errors).toEqual([])

--- a/packages/plugin-rsc/examples/browser-mode/package.json
+++ b/packages/plugin-rsc/examples/browser-mode/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.2.3",
-    "react-dom": "^19.2.3"
+    "react-dom": "^19.2.3",
+    "web-streams-polyfill": "^4.2.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.8",

--- a/packages/plugin-rsc/examples/browser-mode/src/framework/main.tsx
+++ b/packages/plugin-rsc/examples/browser-mode/src/framework/main.tsx
@@ -1,7 +1,9 @@
 import loadClient from 'virtual:vite-rsc-browser-mode/load-client'
 import * as server from './entry.rsc'
+import { polyfillReady } from './polyfill'
 
 async function main() {
+  await polyfillReady
   const client = await loadClient()
   server.initialize()
   client.initialize({ fetchServer: server.fetchServer })

--- a/packages/plugin-rsc/examples/browser-mode/src/framework/polyfill.ts
+++ b/packages/plugin-rsc/examples/browser-mode/src/framework/polyfill.ts
@@ -3,12 +3,8 @@
 // https://github.com/gaearon/rscexplorer/blob/main/src/shared/polyfill.ts
 export const polyfillReady: Promise<void> =
   typeof globalThis.ReadableByteStreamController === 'undefined'
-    ? import('web-streams-polyfill').then(
-        ({ ReadableStream, ReadableByteStreamController }) => {
-          globalThis.ReadableStream =
-            ReadableStream as typeof globalThis.ReadableStream
-          globalThis.ReadableByteStreamController =
-            ReadableByteStreamController as typeof globalThis.ReadableByteStreamController
-        },
-      )
+    ? import('web-streams-polyfill').then(({ ReadableStream }) => {
+        globalThis.ReadableStream =
+          ReadableStream as typeof globalThis.ReadableStream
+      })
     : Promise.resolve()

--- a/packages/plugin-rsc/examples/browser-mode/src/framework/polyfill.ts
+++ b/packages/plugin-rsc/examples/browser-mode/src/framework/polyfill.ts
@@ -3,8 +3,12 @@
 // https://github.com/gaearon/rscexplorer/blob/main/src/shared/polyfill.ts
 export const polyfillReady: Promise<void> =
   typeof globalThis.ReadableByteStreamController === 'undefined'
-    ? import('web-streams-polyfill').then(({ ReadableStream }) => {
-        globalThis.ReadableStream =
-          ReadableStream as typeof globalThis.ReadableStream
-      })
+    ? import('web-streams-polyfill').then(
+        ({ ReadableStream, ReadableByteStreamController }) => {
+          globalThis.ReadableStream =
+            ReadableStream as typeof globalThis.ReadableStream
+          globalThis.ReadableByteStreamController =
+            ReadableByteStreamController as typeof globalThis.ReadableByteStreamController
+        },
+      )
     : Promise.resolve()

--- a/packages/plugin-rsc/examples/browser-mode/src/framework/polyfill.ts
+++ b/packages/plugin-rsc/examples/browser-mode/src/framework/polyfill.ts
@@ -1,0 +1,10 @@
+// Safari doesn't implement ReadableByteStreamController.
+// Only load the polyfill when needed.
+// https://github.com/gaearon/rscexplorer/blob/main/src/shared/polyfill.ts
+export const polyfillReady: Promise<void> =
+  typeof globalThis.ReadableByteStreamController === 'undefined'
+    ? import('web-streams-polyfill').then(({ ReadableStream }) => {
+        globalThis.ReadableStream =
+          ReadableStream as typeof globalThis.ReadableStream
+      })
+    : Promise.resolve()

--- a/packages/plugin-rsc/examples/browser/package.json
+++ b/packages/plugin-rsc/examples/browser/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.2.3",
-    "react-dom": "^19.2.3"
+    "react-dom": "^19.2.3",
+    "web-streams-polyfill": "^4.2.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.8",

--- a/packages/plugin-rsc/examples/browser/src/framework/entry.browser.tsx
+++ b/packages/plugin-rsc/examples/browser/src/framework/entry.browser.tsx
@@ -8,6 +8,7 @@ import React from 'react'
 import { createRoot } from 'react-dom/client'
 import { loadEntryRsc } from '../../lib/runtime'
 import type { RscPayload } from './entry.rsc'
+import { polyfillReady } from './polyfill'
 
 async function fetchRsc(request: Request): Promise<Response> {
   const module = await loadEntryRsc()
@@ -15,6 +16,8 @@ async function fetchRsc(request: Request): Promise<Response> {
 }
 
 async function main() {
+  await polyfillReady
+
   // stash `setPayload` function to trigger re-rendering
   // from outside of `BrowserRoot` component (e.g. server function call, navigation, hmr)
   let setPayload: (v: RscPayload) => void

--- a/packages/plugin-rsc/examples/browser/src/framework/polyfill.ts
+++ b/packages/plugin-rsc/examples/browser/src/framework/polyfill.ts
@@ -3,12 +3,8 @@
 // https://github.com/gaearon/rscexplorer/blob/main/src/shared/polyfill.ts
 export const polyfillReady: Promise<void> =
   typeof globalThis.ReadableByteStreamController === 'undefined'
-    ? import('web-streams-polyfill').then(
-        ({ ReadableStream, ReadableByteStreamController }) => {
-          globalThis.ReadableStream =
-            ReadableStream as typeof globalThis.ReadableStream
-          globalThis.ReadableByteStreamController =
-            ReadableByteStreamController as typeof globalThis.ReadableByteStreamController
-        },
-      )
+    ? import('web-streams-polyfill').then(({ ReadableStream }) => {
+        globalThis.ReadableStream =
+          ReadableStream as typeof globalThis.ReadableStream
+      })
     : Promise.resolve()

--- a/packages/plugin-rsc/examples/browser/src/framework/polyfill.ts
+++ b/packages/plugin-rsc/examples/browser/src/framework/polyfill.ts
@@ -3,8 +3,12 @@
 // https://github.com/gaearon/rscexplorer/blob/main/src/shared/polyfill.ts
 export const polyfillReady: Promise<void> =
   typeof globalThis.ReadableByteStreamController === 'undefined'
-    ? import('web-streams-polyfill').then(({ ReadableStream }) => {
-        globalThis.ReadableStream =
-          ReadableStream as typeof globalThis.ReadableStream
-      })
+    ? import('web-streams-polyfill').then(
+        ({ ReadableStream, ReadableByteStreamController }) => {
+          globalThis.ReadableStream =
+            ReadableStream as typeof globalThis.ReadableStream
+          globalThis.ReadableByteStreamController =
+            ReadableByteStreamController as typeof globalThis.ReadableByteStreamController
+        },
+      )
     : Promise.resolve()

--- a/packages/plugin-rsc/examples/browser/src/framework/polyfill.ts
+++ b/packages/plugin-rsc/examples/browser/src/framework/polyfill.ts
@@ -1,0 +1,10 @@
+// Safari doesn't implement ReadableByteStreamController.
+// Only load the polyfill when needed.
+// https://github.com/gaearon/rscexplorer/blob/main/src/shared/polyfill.ts
+export const polyfillReady: Promise<void> =
+  typeof globalThis.ReadableByteStreamController === 'undefined'
+    ? import('web-streams-polyfill').then(({ ReadableStream }) => {
+        globalThis.ReadableStream =
+          ReadableStream as typeof globalThis.ReadableStream
+      })
+    : Promise.resolve()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -573,6 +573,9 @@ importers:
       react-dom:
         specifier: ^19.2.3
         version: 19.2.3(react@19.2.3)
+      web-streams-polyfill:
+        specifier: ^4.2.0
+        version: 4.2.0
     devDependencies:
       '@types/react':
         specifier: ^19.2.8
@@ -601,6 +604,9 @@ importers:
       react-dom:
         specifier: ^19.2.3
         version: 19.2.3(react@19.2.3)
+      web-streams-polyfill:
+        specifier: ^4.2.0
+        version: 4.2.0
     devDependencies:
       '@types/react':
         specifier: ^19.2.8
@@ -4699,6 +4705,10 @@ packages:
     resolution: {integrity: sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==}
     engines: {node: '>= 8'}
 
+  web-streams-polyfill@4.2.0:
+    resolution: {integrity: sha512-0rYDzGOh9EZpig92umN5g5D/9A1Kff7k0/mzPSSCY8jEQeYkgRMoY7LhbXtUCWzLCMX0TUE9aoHkjFNB7D9pfA==}
+    engines: {node: '>= 8'}
+
   webpack-sources@3.3.3:
     resolution: {integrity: sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==}
     engines: {node: '>=10.13.0'}
@@ -8379,6 +8389,8 @@ snapshots:
   walk-up-path@3.0.1: {}
 
   web-streams-polyfill@3.2.1: {}
+
+  web-streams-polyfill@4.2.0: {}
 
   webpack-sources@3.3.3: {}
 


### PR DESCRIPTION
## Summary
- Add `web-streams-polyfill` to browser and browser-mode examples to polyfill `ReadableStream` for Safari/WebKit which doesn't implement `ReadableByteStreamController`
- Remove webkit skip from `browser.test.ts` and `browser-mode.test.ts` e2e tests
- Based on https://github.com/gaearon/rscexplorer/blob/main/src/shared/polyfill.ts

## Test plan
- [ ] Run e2e tests with webkit: `pnpm exec playwright test e2e/browser.test.ts e2e/browser-mode.test.ts --project=webkit`

🤖 Generated with [Claude Code](https://claude.ai/code)