### PR TITLE
chore(rsc): change starter server export to `export default { fetch }`

### DIFF
--- a/packages/plugin-rsc/examples/e2e/middleware-mode.ts
+++ b/packages/plugin-rsc/examples/e2e/middleware-mode.ts
@@ -28,7 +28,7 @@ async function main() {
     const entry = await import(
       pathToFileURL(path.resolve('dist/rsc/index.js')).href
     )
-    app.use(toNodeHandler(entry.default) as any)
+    app.use(toNodeHandler(entry.default.fetch) as any)
   } else {
     console.error(`Unknown command: ${command}`)
     process.exitCode = 1

--- a/packages/plugin-rsc/examples/starter/src/framework/entry.rsc.tsx
+++ b/packages/plugin-rsc/examples/starter/src/framework/entry.rsc.tsx
@@ -25,7 +25,9 @@ export type RscPayload = {
 
 // the plugin by default assumes `rsc` entry having default export of request handler.
 // however, how server entries are executed can be customized by registering own server handler.
-export default async function handler(request: Request): Promise<Response> {
+export default { fetch: handler }
+
+async function handler(request: Request): Promise<Response> {
   // differentiate RSC, SSR, action, etc.
   const renderRequest = parseRenderRequest(request)
   request = renderRequest.request


### PR DESCRIPTION
I just noticed we haven't done that when testing https://github.com/hi-ogawa/vite-rsc-runtime-integration-examples

## Summary
- Change the RSC entry export from a direct function export to an object with a `fetch` property
- Aligns with the Workers-style module export convention used by runtimes like Cloudflare Workers

## Test plan
- [ ] Verify the starter example still works with this export format
- [ ] Test with target runtime that expects Workers-style exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)