### PR TITLE
test(plugin-rsc): add non-form action server action tests

### DIFF
--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -355,6 +355,26 @@ function defineTest(f: Fixture) {
     )
   }
 
+  test('non form action error @js', async ({ page }) => {
+    await page.goto(f.url())
+    await waitForHydration(page)
+    await expect(page.getByTestId('non-form-action-error')).toContainText('?')
+    await page.getByTestId('non-form-action-error').click()
+    await expect(page.getByTestId('non-form-action-error')).toContainText(
+      'non-form-action-error',
+    )
+  })
+
+  test('non form action args @js', async ({ page }) => {
+    await page.goto(f.url())
+    await waitForHydration(page)
+    await expect(page.getByTestId('non-form-action-args')).toContainText('?')
+    await page.getByTestId('non-form-action-args').click()
+    await expect(page.getByTestId('non-form-action-args')).toContainText(
+      'received: test-42',
+    )
+  })
+
   test('useActionState with jsx @js', async ({ page }) => {
     await page.goto(f.url())
     await waitForHydration(page)

--- a/packages/plugin-rsc/examples/basic/src/routes/action-from-client/action.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/action-from-client/action.tsx
@@ -25,3 +25,14 @@ export async function testAction2() {
 export async function testActionState(prev: number) {
   return prev + 1
 }
+
+export async function testNonFormActionError() {
+  throw new Error('non-form-action-error')
+}
+
+export async function testNonFormActionArgs(data: {
+  name: string
+  count: number
+}) {
+  return `received: ${data.name}-${data.count}`
+}

--- a/packages/plugin-rsc/examples/basic/src/routes/action-from-client/client.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/action-from-client/client.tsx
@@ -1,7 +1,13 @@
 'use client'
 
 import React from 'react'
-import { testAction, testAction2, testActionState } from './action'
+import {
+  testAction,
+  testAction2,
+  testActionState,
+  testNonFormActionArgs,
+  testNonFormActionError,
+} from './action'
 
 export function TestActionFromClient() {
   return (
@@ -21,5 +27,39 @@ export function TestUseActionState() {
         test-useActionState: {state}
       </button>
     </form>
+  )
+}
+
+export function TestNonFormActionError() {
+  const [state, setState] = React.useState('?')
+  return (
+    <button
+      data-testid="non-form-action-error"
+      onClick={async () => {
+        try {
+          await testNonFormActionError()
+          setState('no-error')
+        } catch (e) {
+          setState(e instanceof Error ? e.message : 'unknown-error')
+        }
+      }}
+    >
+      non-form-action-error: {state}
+    </button>
+  )
+}
+
+export function TestNonFormActionArgs() {
+  const [state, setState] = React.useState('?')
+  return (
+    <button
+      data-testid="non-form-action-args"
+      onClick={async () => {
+        const result = await testNonFormActionArgs({ name: 'test', count: 42 })
+        setState(result)
+      }}
+    >
+      non-form-action-args: {state}
+    </button>
   )
 }

--- a/packages/plugin-rsc/examples/basic/src/routes/root.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/root.tsx
@@ -10,6 +10,8 @@ import {
 import { TestServerActionError } from './action-error/server'
 import {
   TestActionFromClient,
+  TestNonFormActionArgs,
+  TestNonFormActionError,
   TestUseActionState,
 } from './action-from-client/client'
 import { TestActionStateServer } from './action-state/server'
@@ -95,6 +97,8 @@ export function Root(props: { url: URL }) {
         <TestSuspense url={props.url} />
         <TestActionFromClient />
         <TestUseActionState />
+        <TestNonFormActionError />
+        <TestNonFormActionArgs />
         <TestPayloadServer url={props.url} />
         <TestServerActionBindReset />
         <TestServerActionBindSimple />


### PR DESCRIPTION
I realized we didn't have test cases for this. This type of action uses `encodeReply(args)` with `args` plain object (or arbitrary object) instead of `FormData`. This helps when poking around how serialization works (a bit related to `use cache` feature's inner working).

## Summary
- Add dedicated test cases for calling server actions from onClick handlers (non-form actions)
- Test error handling with try/catch when server action throws
- Test argument serialization when passing objects to server actions

## Test plan
- [x] Run `pnpm test-e2e -g "non form action"` - all 4 tests pass (dev + build modes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)