### PR TITLE
chore(plugin-rsc): remove unused debug component

### DIFF
--- a/packages/plugin-rsc/examples/basic/src/routes/use-cache/debug.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/use-cache/debug.tsx
@@ -1,3 +1,0 @@
-export function DebugUseCache() {
-  return null
-}


### PR DESCRIPTION
This got in when I released https://github.com/vitejs/vite-plugin-react/commit/8d9648ec6c5ecba00188259305cbb05f24fa9821. This was just hanging local diff, so this PR cleans it up.

## Summary
- Remove unused `DebugUseCache` component from use-cache example route

## Test plan
- [x] No functionality affected as the component was unused

🤖 Generated with [Claude Code](https://claude.com/claude-code)