### PR TITLE
refactor(plugin-rsc): convert hooks to nested handler form

### DIFF
--- a/packages/plugin-rsc/src/core/plugin.ts
+++ b/packages/plugin-rsc/src/core/plugin.ts
@@ -4,23 +4,28 @@ export default function vitePluginRscCore(): Plugin[] {
   return [
     {
       name: 'rsc:patch-react-server-dom-webpack',
-      transform(originalCode, _id, _options) {
-        let code = originalCode
-        if (code.includes('__webpack_require__.u')) {
-          // avoid accessing `__webpack_require__` on import side effect
-          // https://github.com/facebook/react/blob/a9bbe34622885ef5667d33236d580fe7321c0d8b/packages/react-server-dom-webpack/src/client/ReactFlightClientConfigBundlerWebpackBrowser.js#L16-L17
-          code = code.replaceAll('__webpack_require__.u', '({}).u')
-        }
+      transform: {
+        handler(originalCode, _id, _options) {
+          let code = originalCode
+          if (code.includes('__webpack_require__.u')) {
+            // avoid accessing `__webpack_require__` on import side effect
+            // https://github.com/facebook/react/blob/a9bbe34622885ef5667d33236d580fe7321c0d8b/packages/react-server-dom-webpack/src/client/ReactFlightClientConfigBundlerWebpackBrowser.js#L16-L17
+            code = code.replaceAll('__webpack_require__.u', '({}).u')
+          }
 
-        // the existance of `__webpack_require__` global can break some packages
-        // https://github.com/TooTallNate/node-bindings/blob/c8033dcfc04c34397384e23f7399a30e6c13830d/bindings.js#L90-L94
-        if (code.includes('__webpack_require__')) {
-          code = code.replaceAll('__webpack_require__', '__vite_rsc_require__')
-        }
+          // the existance of `__webpack_require__` global can break some packages
+          // https://github.com/TooTallNate/node-bindings/blob/c8033dcfc04c34397384e23f7399a30e6c13830d/bindings.js#L90-L94
+          if (code.includes('__webpack_require__')) {
+            code = code.replaceAll(
+              '__webpack_require__',
+              '__vite_rsc_require__',
+            )
+          }
 
-        if (code !== originalCode) {
-          return { code, map: null }
-        }
+          if (code !== originalCode) {
+            return { code, map: null }
+          }
+        },
       },
     },
     {

--- a/packages/plugin-rsc/src/plugins/import-environment.ts
+++ b/packages/plugin-rsc/src/plugins/import-environment.ts
@@ -49,11 +49,13 @@ export function vitePluginImportEnvironment(
   return [
     {
       name: 'rsc:import-environment',
-      resolveId(source) {
-        // Use placeholder as external, renderChunk will replace with correct relative path
-        if (source === ENV_IMPORTS_MANIFEST_PLACEHOLDER) {
-          return { id: ENV_IMPORTS_MANIFEST_PLACEHOLDER, external: true }
-        }
+      resolveId: {
+        handler(source) {
+          // Use placeholder as external, renderChunk will replace with correct relative path
+          if (source === ENV_IMPORTS_MANIFEST_PLACEHOLDER) {
+            return { id: ENV_IMPORTS_MANIFEST_PLACEHOLDER, external: true }
+          }
+        },
       },
       buildStart() {
         // Emit discovered entries during build

--- a/packages/plugin-rsc/src/plugins/scan.ts
+++ b/packages/plugin-rsc/src/plugins/scan.ts
@@ -14,10 +14,12 @@ export function scanBuildStripPlugin({
     name: 'rsc:scan-strip',
     apply: 'build',
     enforce: 'post',
-    async transform(code, _id, _options) {
-      if (!manager.isScanBuild) return
-      const output = await transformScanBuildStrip(code)
-      return { code: output, map: { mappings: '' } }
+    transform: {
+      async handler(code, _id, _options) {
+        if (!manager.isScanBuild) return
+        const output = await transformScanBuildStrip(code)
+        return { code: output, map: { mappings: '' } }
+      },
     },
   }
 }

--- a/packages/plugin-rsc/src/plugins/utils.ts
+++ b/packages/plugin-rsc/src/plugins/utils.ts
@@ -44,13 +44,17 @@ export function createVirtualPlugin(
   name = 'virtual:' + name
   return {
     name: `rsc:virtual-${name}`,
-    resolveId(source, _importer, _options) {
-      return source === name ? '\0' + name : undefined
+    resolveId: {
+      handler(source, _importer, _options) {
+        return source === name ? '\0' + name : undefined
+      },
     },
-    load(id, options) {
-      if (id === '\0' + name) {
-        return (load as Function).apply(this, [id, options])
-      }
+    load: {
+      handler(id, options) {
+        if (id === '\0' + name) {
+          return (load as Function).apply(this, [id, options])
+        }
+      },
     },
   }
 }

--- a/packages/plugin-rsc/src/plugins/validate-import.ts
+++ b/packages/plugin-rsc/src/plugins/validate-import.ts
@@ -35,15 +35,17 @@ export function validateImportPlugin(): Plugin {
         return
       },
     },
-    load(id) {
-      if (id.startsWith('\0virtual:vite-rsc/validate-imports/invalid/')) {
-        // it should surface as build error but we make a runtime error just in case.
-        const source = id.slice(id.lastIndexOf('/') + 1)
-        return `throw new Error("invalid import of '${source}'")`
-      }
-      if (id.startsWith('\0virtual:vite-rsc/validate-imports/')) {
-        return `export {}`
-      }
+    load: {
+      handler(id) {
+        if (id.startsWith('\0virtual:vite-rsc/validate-imports/invalid/')) {
+          // it should surface as build error but we make a runtime error just in case.
+          const source = id.slice(id.lastIndexOf('/') + 1)
+          return `throw new Error("invalid import of '${source}'")`
+        }
+        if (id.startsWith('\0virtual:vite-rsc/validate-imports/')) {
+          return `export {}`
+        }
+      },
     },
     // for dev, use DevEnvironment.moduleGraph during post transform
     transform: {


### PR DESCRIPTION
> [!TIP]
> Use "hide whitespaces" to review the change https://github.com/vitejs/vite-plugin-react/pull/1093/files?diff=split&w=1 


- (supersedes) Closes https://github.com/vitejs/vite-plugin-react/pull/1043
- (supersedes) Closes https://github.com/vitejs/vite-plugin-react/pull/957

## Summary

- Convert all direct function hooks (`resolveId`, `load`, `transform`) to nested handler object form
- This is a preparatory refactoring for adding Vite hook filter support (ref #861)

**Before:**
```typescript
resolveId(source) { ... }
load(id) { ... }
transform(code, id) { ... }
```

**After:**
```typescript
resolveId: { handler(source) { ... } }
load: { handler(id) { ... } }
transform: { handler(code, id) { ... } }
```

### Files Changed

- `src/plugin.ts` - Main plugin file (19 hooks converted)
- `src/core/plugin.ts` - Core plugin (1 hook)
- `src/plugins/cjs.ts` - CJS transform plugin (1 hook)
- `src/plugins/import-environment.ts` - Environment import plugin (1 hook)
- `src/plugins/scan.ts` - Scan build plugin (1 hook)
- `src/plugins/utils.ts` - Virtual plugin helper (2 hooks)
- `src/plugins/validate-import.ts` - Import validation plugin (1 hook)

## Test plan

- [x] TypeScript compilation passes (`pnpm -C packages/plugin-rsc tsc`)
- [x] Build succeeds (`pnpm -C packages/plugin-rsc build`)
- [x] All 57 unit tests pass (`pnpm -C packages/plugin-rsc test`)

🤖 Generated with [Claude Code](https://claude.ai/code)