### PR TITLE
fix(plugin-rsc): avoid stripping rolldown runtime during scan build

### DIFF
--- a/packages/plugin-rsc/src/plugins/scan.ts
+++ b/packages/plugin-rsc/src/plugins/scan.ts
@@ -1,3 +1,4 @@
+import { exactRegex } from '@rolldown/pluginutils'
 import * as esModuleLexer from 'es-module-lexer'
 import { walk } from 'estree-walker'
 import { parseAstAsync, type Plugin } from 'vite'
@@ -15,6 +16,9 @@ export function scanBuildStripPlugin({
     apply: 'build',
     enforce: 'post',
     transform: {
+      filter: {
+        id: { exclude: exactRegex('\0rolldown/runtime.js') },
+      },
       async handler(code, _id, _options) {
         if (!manager.isScanBuild) return
         const output = await transformScanBuildStrip(code)


### PR DESCRIPTION
### Description

fixes this ecosystem-ci failure: https://github.com/vitejs/vite-ecosystem-ci/actions/runs/21699933912/job/62578172448#step:7:952

refs https://github.com/rolldown/rolldown/issues/8202

