### PR TITLE
fix(rsc): copy only imported css and assets from rsc environemnt to client environment

### DIFF
--- a/packages/plugin-rsc/docs/notes/2026-02-16-issue-1109-server-asset-copy-plan.md
+++ b/packages/plugin-rsc/docs/notes/2026-02-16-issue-1109-server-asset-copy-plan.md
@@ -187,31 +187,7 @@ Phase 2 (future major):
 3. `copyServerAssetsToClient` emits deprecation warning (once).
 4. `emitClientAsset` rejects non-asset emission in v1.
 
-## Action item: follow up with Vite core
+## Note on Vite metadata scope
 
-- Verify the stability/contract of `viteMetadata` on both chunks and assets across supported Vite backends/versions.
-- Ask whether asset-level metadata (`OutputAsset.viteMetadata`) is intended as public plugin API, or implementation detail.
-- If needed, propose a typing/docs improvement in Vite core so plugin authors can rely on this behavior safely.
-- Defer proposing an opt-in per-`emitFile` public-tag API for now, unless concrete ecosystem demand appears.
-
-### Vite 7 vs Vite 8 inconsistency notes
-
-Current workspace uses Vite 7 (`node_modules/vite/package.json` shows `7.3.1`), while local Vite main checkout is Vite 8 beta.
-
-- Vite 7 type surface (installed package):
-  - `node_modules/vite/types/metadata.d.ts` only exposes `ChunkMetadata` and augments `rollup.RenderedChunk` with `viteMetadata`.
-  - No `AssetMetadata` type and no `rollup.OutputAsset.viteMetadata` augmentation in that file.
-- Vite 8 type surface (local Vite repo):
-  - `~/code/others/vite/packages/vite/types/metadata.d.ts` defines both `AssetMetadata` and `ChunkMetadata`.
-  - It augments `rolldown.OutputAsset` (plus chunk types) with `viteMetadata`.
-- Practical effect for plugin authors:
-  - On Vite 7, reading `output.viteMetadata` on assets is a type error unless narrowed/cast.
-  - On Vite 8+ (rolldown typing), asset metadata access is typed.
-- Runtime ambiguity:
-  - Vite 7 runtime code does optional reads like `asset.viteMetadata?.importedAssets` in manifest generation (`node_modules/vite/dist/node/chunks/config.js`), but type declarations do not guarantee this.
-  - This creates a "runtime might have it, types may not" gap for downstream plugins.
-
-Recommendation when following up in Vite core:
-
-- clarify intended contract per major/version and backend (`rollup` vs `rolldown` typing)
-- either document asset `viteMetadata` as supported API in Vite 8+ only, or provide cross-version guidance/fallback expectations
+Final implementation intentionally relies only on `chunk.viteMetadata.importedCss/importedAssets`.
+This avoids depending on asset-level metadata contracts across Vite versions and backends.

--- a/packages/plugin-rsc/docs/notes/2026-02-16-issue-1109-server-asset-copy-plan.md
+++ b/packages/plugin-rsc/docs/notes/2026-02-16-issue-1109-server-asset-copy-plan.md
@@ -1,0 +1,107 @@
+# Issue #1109 - Safer RSC server-asset copying
+
+## Problem statement
+
+`@vitejs/plugin-rsc` currently copies almost every emitted asset from the `rsc` build into the `client` build (`packages/plugin-rsc/src/plugin.ts`, around `generateBundle`).
+
+That behavior is convenient, but unsafe as a default:
+
+- it can expose server-only assets produced by framework/user plugins via `emitFile({ type: "asset" })`
+- it relies on a coarse heuristic (`copyServerAssetsToClient ?? (() => true)`)
+- it already needs special-case exclusions (`.vite/manifest.json`), which is a smell
+
+## Implementation status
+
+Implemented on 2026-02-16.
+
+- Added `collectPublicServerAssets(bundle)` in `packages/plugin-rsc/src/plugin.ts`.
+- Updated `generateBundle` copy logic to use that set as the default filter.
+- Kept `copyServerAssetsToClient` as an explicit override (same signature/behavior).
+- Updated `packages/plugin-rsc/examples/basic/vite.config.ts` to stop relying on option filtering for `__server_secret.txt`, so default behavior covers the security case.
+
+## What we should copy by default
+
+Copy only assets that are clearly public-by-construction from RSC code:
+
+1. side-effect CSS used by server components
+2. `?url` (and similar Vite asset URL) imports that flow into rendered markup
+3. transitive assets referenced by those assets (e.g. fonts/images from copied CSS)
+
+Do **not** copy arbitrary emitted assets that are not referenced from RSC chunk metadata.
+
+## Concrete implementation idea
+
+### 1) Add an explicit "public server assets" collector
+
+Introduce a helper in `packages/plugin-rsc/src/plugin.ts` (next to `collectAssetDeps*`) that traverses the `rsc` output bundle and returns a `Set<string>` of asset file names to copy.
+
+Suggested logic:
+
+- Walk all output chunks in the RSC bundle.
+- Collect roots from `chunk.viteMetadata`:
+  - `importedCss`
+  - `importedAssets`
+- Recursively walk collected assets:
+  - for each asset, read `bundle[fileName]`
+  - if `asset.viteMetadata?.importedAssets` exists, add and recurse
+  - (optional) also recurse into `asset.viteMetadata?.importedCss` for completeness
+
+This follows Vite's own metadata contract (verified in `~/code/others/vite`):
+
+- `packages/vite/types/metadata.d.ts` defines `importedCss` and `importedAssets` on chunks/assets
+- Vite plugins populate these sets in asset/css transforms
+
+### 2) Change default copy behavior in `generateBundle`
+
+Current:
+
+- iterate all RSC assets and copy when `filterAssets(fileName)` passes
+
+Proposed:
+
+- compute `defaultPublicAssets = collectPublicServerAssets(manager.bundles['rsc']!)`
+- default predicate is now `fileName => defaultPublicAssets.has(fileName)`
+- keep manifest exclusion guard (or make collector naturally exclude it)
+
+So the existing option remains backward-compatible as an escape hatch, but default becomes safe.
+
+### 3) Keep / slightly reshape `copyServerAssetsToClient`
+
+Minimal-change path:
+
+- keep current signature `(fileName: string) => boolean`
+- keep it as an override filter (if provided, it replaces default filter behavior)
+
+Cleaner composable path (future follow-up):
+
+- extend option context to include why an asset is selected
+  - e.g. `{ fileName, reason: 'chunk:importedCss' | 'chunk:importedAssets' | 'asset:transitive' }`
+- this lets frameworks opt-in extra categories intentionally without reimplementing internals
+
+## Why this addresses #1109
+
+- server-only `emitFile` assets are no longer copied unless they are referenced by public RSC asset metadata
+- intended public assets (CSS and `?url`) continue to work
+- behavior aligns with issue intent: secure default + explicit opt-in for non-standard cases
+
+## Expected compatibility impact
+
+- Potentially breaking for setups that relied on accidental copying of unreferenced server assets.
+- This is acceptable for security-hardening behavior, but should be called out in changelog.
+- For migration, users can temporarily use `copyServerAssetsToClient` to opt back in selectively.
+
+## Test plan
+
+Add/adjust e2e checks in `packages/plugin-rsc/examples/basic` tests:
+
+1. **Security baseline**: emitted `__server_secret.txt` from RSC is present in RSC output and absent in client output by default.
+2. **RSC CSS**: CSS imported in server component is available in client output and links resolve.
+3. **RSC `?url`**: `import x from './foo.css?url'` (or image/font) from server component resolves to an existing client asset.
+4. **Transitive CSS assets**: font/image referenced from copied CSS is also copied.
+5. **Override path**: `copyServerAssetsToClient` can explicitly allow an otherwise skipped asset.
+
+## Optional follow-up (if we want Astro-like ergonomics)
+
+Add a dedicated API for intentional server->client asset emission (conceptually similar to Astro's `emitClientAsset`).
+
+This is not required for the initial fix, but could improve composability for framework authors that legitimately need to publish custom artifacts.

--- a/packages/plugin-rsc/docs/notes/2026-02-16-issue-1109-server-asset-copy-plan.md
+++ b/packages/plugin-rsc/docs/notes/2026-02-16-issue-1109-server-asset-copy-plan.md
@@ -25,7 +25,7 @@ Copy only assets that are clearly public-by-construction from RSC code:
 
 1. side-effect CSS used by server components
 2. `?url` (and similar Vite asset URL) imports that flow into rendered markup
-3. transitive assets referenced by those assets (e.g. fonts/images from copied CSS)
+3. transitive assets referenced by those assets (via chunk metadata, e.g. fonts/images from copied CSS)
 
 Do **not** copy arbitrary emitted assets that are not referenced from RSC chunk metadata.
 
@@ -41,10 +41,8 @@ Suggested logic:
 - Collect roots from `chunk.viteMetadata`:
   - `importedCss`
   - `importedAssets`
-- Recursively walk collected assets:
-  - for each asset, read `bundle[fileName]`
-  - if `asset.viteMetadata?.importedAssets` exists, add and recurse
-  - (optional) also recurse into `asset.viteMetadata?.importedCss` for completeness
+- (original idea) recursively walk collected assets via `asset.viteMetadata`
+- (updated implementation) rely only on chunk metadata (`chunk.viteMetadata.importedCss/importedAssets`) for cross-version consistency
 
 This follows Vite's own metadata contract (verified in `~/code/others/vite`):
 
@@ -75,7 +73,7 @@ Minimal-change path:
 Cleaner composable path (future follow-up):
 
 - extend option context to include why an asset is selected
-  - e.g. `{ fileName, reason: 'chunk:importedCss' | 'chunk:importedAssets' | 'asset:transitive' }`
+  - e.g. `{ fileName, reason: 'chunk:importedCss' | 'chunk:importedAssets' }`
 - this lets frameworks opt-in extra categories intentionally without reimplementing internals
 
 ## Why this addresses #1109
@@ -193,3 +191,32 @@ Phase 2 (future major):
 2. plain `emitFile({ type: "asset" })` from `rsc` is not copied by default.
 3. `copyServerAssetsToClient` emits deprecation warning (once).
 4. `emitClientAsset` rejects non-asset emission in v1.
+
+## Action item: follow up with Vite core
+
+- Verify the stability/contract of `viteMetadata` on both chunks and assets across supported Vite backends/versions.
+- Ask whether asset-level metadata (`OutputAsset.viteMetadata`) is intended as public plugin API, or implementation detail.
+- If needed, propose a typing/docs improvement in Vite core so plugin authors can rely on this behavior safely.
+- Defer proposing an opt-in per-`emitFile` public-tag API for now, unless concrete ecosystem demand appears.
+
+### Vite 7 vs Vite 8 inconsistency notes
+
+Current workspace uses Vite 7 (`node_modules/vite/package.json` shows `7.3.1`), while local Vite main checkout is Vite 8 beta.
+
+- Vite 7 type surface (installed package):
+  - `node_modules/vite/types/metadata.d.ts` only exposes `ChunkMetadata` and augments `rollup.RenderedChunk` with `viteMetadata`.
+  - No `AssetMetadata` type and no `rollup.OutputAsset.viteMetadata` augmentation in that file.
+- Vite 8 type surface (local Vite repo):
+  - `~/code/others/vite/packages/vite/types/metadata.d.ts` defines both `AssetMetadata` and `ChunkMetadata`.
+  - It augments `rolldown.OutputAsset` (plus chunk types) with `viteMetadata`.
+- Practical effect for plugin authors:
+  - On Vite 7, reading `output.viteMetadata` on assets is a type error unless narrowed/cast.
+  - On Vite 8+ (rolldown typing), asset metadata access is typed.
+- Runtime ambiguity:
+  - Vite 7 runtime code does optional reads like `asset.viteMetadata?.importedAssets` in manifest generation (`node_modules/vite/dist/node/chunks/config.js`), but type declarations do not guarantee this.
+  - This creates a "runtime might have it, types may not" gap for downstream plugins.
+
+Recommendation when following up in Vite core:
+
+- clarify intended contract per major/version and backend (`rollup` vs `rolldown` typing)
+- either document asset `viteMetadata` as supported API in Vite 8+ only, or provide cross-version guidance/fallback expectations

--- a/packages/plugin-rsc/examples/basic/vite.config.ts
+++ b/packages/plugin-rsc/examples/basic/vite.config.ts
@@ -28,8 +28,6 @@ export default defineConfig({
         ssr: './src/framework/entry.ssr.tsx',
         rsc: './src/framework/entry.rsc.tsx',
       },
-      copyServerAssetsToClient: (fileName) =>
-        fileName !== '__server_secret.txt',
       clientChunks(meta) {
         if (process.env.TEST_CUSTOM_CLIENT_CHUNKS) {
           if (meta.id.includes('/src/routes/chunk/')) {

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -2161,19 +2161,11 @@ function collectAssetDepsInner(
 
 function collectPublicServerAssets(bundle: Rollup.OutputBundle) {
   const assets = new Set<string>()
-  const stack: string[] = []
-  type AssetWithMetadata = Rollup.OutputAsset & {
-    viteMetadata?: {
-      importedCss: Set<string>
-      importedAssets: Set<string>
-    }
-  }
 
   function add(fileName: string) {
     if (assets.has(fileName)) return
     if (bundle[fileName]?.type !== 'asset') return
     assets.add(fileName)
-    stack.push(fileName)
   }
 
   for (const output of Object.values(bundle)) {
@@ -2181,15 +2173,6 @@ function collectPublicServerAssets(bundle: Rollup.OutputBundle) {
       output.viteMetadata?.importedCss.forEach(add)
       output.viteMetadata?.importedAssets.forEach(add)
     }
-  }
-
-  while (stack.length > 0) {
-    const fileName = stack.pop()!
-    const output = bundle[fileName]
-    if (output?.type !== 'asset') continue
-    const asset = output as AssetWithMetadata
-    asset.viteMetadata?.importedCss.forEach(add)
-    asset.viteMetadata?.importedAssets.forEach(add)
   }
 
   return assets

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -188,9 +188,8 @@ export type RscPluginOptions = {
   rscCssTransform?: false | { filter?: (id: string) => boolean }
 
   /**
-   * This option allows customizing how client build copies assets from server build.
-   * By default, only server assets referenced by RSC chunks are copied
-   * (e.g. side-effect CSS and `?url` imports).
+   * @deprecated This option is a no-op and will be removed in a future major.
+   * Use explicit client-asset emission APIs instead.
    */
   copyServerAssetsToClient?: (fileName: string) => boolean
 
@@ -1070,17 +1069,11 @@ export function createRpcClient(params) {
         if (this.environment.name === 'client') {
           const rscBundle = manager.bundles['rsc']!
           const defaultPublicAssets = collectPublicServerAssets(rscBundle)
-          const filterAssets =
-            rscPluginOptions.copyServerAssetsToClient ??
-            ((fileName: string) => defaultPublicAssets.has(fileName))
-          const rscBuildOptions = manager.config.environments.rsc!.build
-          const rscViteManifest =
-            typeof rscBuildOptions.manifest === 'string'
-              ? rscBuildOptions.manifest
-              : rscBuildOptions.manifest && '.vite/manifest.json'
           for (const asset of Object.values(rscBundle)) {
-            if (asset.fileName === rscViteManifest) continue
-            if (asset.type === 'asset' && filterAssets(asset.fileName)) {
+            if (
+              asset.type === 'asset' &&
+              defaultPublicAssets.has(asset.fileName)
+            ) {
               this.emitFile({
                 type: 'asset',
                 fileName: asset.fileName,

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -189,7 +189,6 @@ export type RscPluginOptions = {
 
   /**
    * @deprecated This option is a no-op and will be removed in a future major.
-   * Use explicit client-asset emission APIs instead.
    */
   copyServerAssetsToClient?: (fileName: string) => boolean
 
@@ -1068,8 +1067,8 @@ export function createRpcClient(params) {
 
         if (this.environment.name === 'client') {
           const rscBundle = manager.bundles['rsc']!
-          const defaultPublicAssets = collectPublicServerAssets(rscBundle)
-          for (const fileName of defaultPublicAssets) {
+          const assets = collectPublicServerAssets(rscBundle)
+          for (const fileName of assets) {
             const asset = rscBundle[fileName]
             assert(asset?.type === 'asset')
             this.emitFile({

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1069,17 +1069,14 @@ export function createRpcClient(params) {
         if (this.environment.name === 'client') {
           const rscBundle = manager.bundles['rsc']!
           const defaultPublicAssets = collectPublicServerAssets(rscBundle)
-          for (const asset of Object.values(rscBundle)) {
-            if (
-              asset.type === 'asset' &&
-              defaultPublicAssets.has(asset.fileName)
-            ) {
-              this.emitFile({
-                type: 'asset',
-                fileName: asset.fileName,
-                source: asset.source,
-              })
-            }
+          for (const fileName of defaultPublicAssets) {
+            const asset = rscBundle[fileName]
+            assert(asset?.type === 'asset')
+            this.emitFile({
+              type: 'asset',
+              fileName: asset.fileName,
+              source: asset.source,
+            })
           }
 
           const serverResources: Record<string, AssetDeps> = {}


### PR DESCRIPTION
### Description

- Closes https://github.com/vitejs/vite-plugin-react/issues/1109

The detail documented in `packages/plugin-rsc/docs/notes/2026-02-16-issue-1109-server-asset-copy-plan.md`.

It turns out `chunk.viteMetadta.importedCss/importedAssets` is exactly what we need. We have a test case to cover cases like:
- css side effect import 
- `?url` css
- nested assets through `.css` and `url()`
- `rsc` environment `emitFile` is not included in public asset 

So, if tests are passing, this should be the right behavior. We might consider opt-in public `emitFile` in server environment, but that seems unnecessary for the time being.