### PR TITLE
fix(rsc): exclude react 3rd party libs from server optimizeDeps

### DIFF
--- a/packages/plugin-rsc/examples/react-router/cf/vite.config.ts
+++ b/packages/plugin-rsc/examples/react-router/cf/vite.config.ts
@@ -40,15 +40,5 @@ export default defineConfig({
         include: ['react-router', 'react-router/internal/react-server-client'],
       },
     },
-    ssr: {
-      optimizeDeps: {
-        exclude: ['react-router'],
-      },
-    },
-    rsc: {
-      optimizeDeps: {
-        exclude: ['react-router'],
-      },
-    },
   },
 })

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -542,7 +542,7 @@ export default function vitePluginRsc(
                   'react-dom/static.edge',
                   `${reactServerDomPackageName}/client.edge`,
                 ],
-                exclude: [PKG_NAME],
+                exclude: [PKG_NAME, ...noExternal],
               },
             },
             rsc: {
@@ -569,7 +569,7 @@ export default function vitePluginRsc(
                   `${reactServerDomPackageName}/server.edge`,
                   `${reactServerDomPackageName}/client.edge`,
                 ],
-                exclude: [PKG_NAME],
+                exclude: [PKG_NAME, ...noExternal],
               },
             },
           },

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -486,6 +486,10 @@ export default function vitePluginRsc(
           PKG_NAME,
           ...result.ssr.noExternal.sort(),
         ]
+        const optimizeDepsExclude = noExternal.filter(
+          (pkg) =>
+            !['react', 'react-dom', 'react-server-dom-webpack'].includes(pkg),
+        )
         hasReactServerDomWebpack = result.ssr.noExternal.includes(
           'react-server-dom-webpack',
         )
@@ -542,7 +546,7 @@ export default function vitePluginRsc(
                   'react-dom/static.edge',
                   `${reactServerDomPackageName}/client.edge`,
                 ],
-                exclude: [PKG_NAME, ...noExternal],
+                exclude: [PKG_NAME, ...optimizeDepsExclude],
               },
             },
             rsc: {
@@ -569,7 +573,7 @@ export default function vitePluginRsc(
                   `${reactServerDomPackageName}/server.edge`,
                   `${reactServerDomPackageName}/client.edge`,
                 ],
-                exclude: [PKG_NAME, ...noExternal],
+                exclude: [PKG_NAME, ...optimizeDepsExclude],
               },
             },
           },


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

We don't normally need this since server doesn't optimize, but this is more correct (like we already do exclude own `PKG_NAME`) since the idea is to apply vite transform to those dependencies.

This will likely help integrations with cloudflare plugin, which employs server optimize deps via `optimizeDeps.noDiscover: false`:
- https://github.com/cloudflare/vinext/pull/18

TODO
- [x] test
  - Indeed, we already had explicit `optimizeDeps.exclude: ["react-router"]` in the example. After this change, it's not necessary.