### PR TITLE
fix(plugin-react): resolve base-prefixed refresh runtime in bundledDev

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -481,6 +481,20 @@ export default function viteReact(opts: Options = {}): Plugin[] {
     },
   }
 
+  const viteReactRefreshBundledDevModeResolveRuntime: Plugin = {
+    name: 'vite:react-refresh-fbm-resolve-runtime',
+    enforce: 'pre',
+    resolveId(id) {
+      if (skipFastRefresh || !isBundledDev || base === '/') return
+
+      const basePrefixedRuntimePublicPath =
+        base.slice(0, -1) + runtimePublicPath
+      if (id === basePrefixedRuntimePublicPath) {
+        return runtimePublicPath
+      }
+    },
+  }
+
   const dependencies = [
     'react',
     'react-dom',
@@ -541,6 +555,7 @@ export default function viteReact(opts: Options = {}): Plugin[] {
     ...(isRolldownVite
       ? [viteRefreshWrapper, viteConfigPost, viteReactRefreshBundledDevMode]
       : []),
+    viteReactRefreshBundledDevModeResolveRuntime,
     viteReactRefresh,
     virtualPreamblePlugin({
       name: '@vitejs/plugin-react/preamble',


### PR DESCRIPTION
Fixes vitejs/vite#21679.

This follows maintainer guidance from vitejs/vite#21704 to handle the issue on the plugin-react side.

## What changes
- add a pre resolve hook in plugin-react that normalizes base-prefixed refresh runtime ids in bundledDev mode
- map base-prefixed /@react-refresh back to /@react-refresh when Fast Refresh is enabled
- add a regression unit test for /ui/@react-refresh -> /@react-refresh in bundledDev

## Validation
- pnpm --filter @vitejs/plugin-react run test-unit -- tests/rolldown.test.ts
- pnpm --filter @vitejs/plugin-react run test-unit
- pnpm --filter @vitejs/plugin-react exec tsc -p tsconfig.json --noEmit

Implementation is original and written fresh for this repo path.
