### PR TITLE
chore(rsc): switch Cloudflare examples from `nodejs_als` to `nodejs_compat`

### DIFF
--- a/packages/plugin-rsc/examples/basic/wrangler.jsonc
+++ b/packages/plugin-rsc/examples/basic/wrangler.jsonc
@@ -7,5 +7,5 @@
   },
   "workers_dev": true,
   "compatibility_date": "2025-10-01",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }

--- a/packages/plugin-rsc/examples/react-router/cf/wrangler.rsc.jsonc
+++ b/packages/plugin-rsc/examples/react-router/cf/wrangler.rsc.jsonc
@@ -4,5 +4,5 @@
   "main": "./entry.rsc.tsx",
   "workers_dev": true,
   "compatibility_date": "2025-10-01",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }

--- a/packages/plugin-rsc/examples/react-router/cf/wrangler.ssr.jsonc
+++ b/packages/plugin-rsc/examples/react-router/cf/wrangler.ssr.jsonc
@@ -5,5 +5,5 @@
   "workers_dev": true,
   "services": [{ "binding": "RSC", "service": "vite-rsc-react-router-rsc" }],
   "compatibility_date": "2025-10-01",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }

--- a/packages/plugin-rsc/examples/starter-cf-single/wrangler.jsonc
+++ b/packages/plugin-rsc/examples/starter-cf-single/wrangler.jsonc
@@ -4,5 +4,5 @@
   "main": "./src/framework/entry.rsc.tsx",
   "workers_dev": true,
   "compatibility_date": "2025-10-01",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

Just recently noticed that `nodejs_compat` is a part of their "best practices" https://developers.cloudflare.com/workers/best-practices/workers-best-practices/#enable-nodejs_compat. I don't think I'd bother testing `nodejs_als` which is their non best practices.