### PR TITLE
test(rsc): add e2e test for custom root via CLI argument

### DIFF
--- a/packages/plugin-rsc/e2e/root.test.ts
+++ b/packages/plugin-rsc/e2e/root.test.ts
@@ -45,3 +45,50 @@ test.describe(() => {
     defineStarterTest(f)
   })
 })
+
+// Test that the RSC plugin works when `root` is passed as a CLI argument
+// e.g. `vite dev ./app` where the app lives in a subdirectory.
+// This effectively tests `createServer/createBuilder({ root })`
+// and then loading config file from the specified root.
+test.describe('root-config', () => {
+  const root = 'examples/e2e/temp/root-config'
+
+  test.beforeAll(async () => {
+    await setupInlineFixture({
+      src: 'examples/starter',
+      dest: `${root}/app`,
+      files: {
+        'vite.config.base.ts': { cp: 'vite.config.ts' },
+        'vite.config.ts': /* js */ `
+          import baseConfig from './vite.config.base.ts'
+          import path from "node:path";
+          for (const e of Object.values(baseConfig.environments)) {
+            e.build.rollupOptions.input.index = path.resolve(
+              'app',
+              e.build.rollupOptions.input.index,
+            );
+          }
+          export default baseConfig;
+        `,
+      },
+    })
+  })
+
+  test.describe('dev', () => {
+    const f = useFixture({ root, mode: 'dev', command: 'vite dev ./app' })
+    const oldCreateEditor = f.createEditor
+    f.createEditor = (filePath: string) =>
+      oldCreateEditor(path.resolve(root, 'app', filePath))
+    defineStarterTest(f)
+  })
+
+  test.describe('build', () => {
+    const f = useFixture({
+      root,
+      mode: 'build',
+      buildCommand: 'vite build ./app',
+      command: 'vite preview ./app',
+    })
+    defineStarterTest(f)
+  })
+})


### PR DESCRIPTION

### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

Related
- https://github.com/vitejs/vite-plugin-react/issues/1126
- https://github.com/vitejs/vite-plugin-react/pull/1133

Test that the RSC plugin works when root is passed as a CLI argument (e.g. `vite dev ./app`) with config file loaded from the specified root.
