### PR TITLE
fix(rsc): handle shadowed local declarations in "use server" closure binding

### DIFF
--- a/packages/plugin-rsc/src/transforms/hoist.test.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.test.ts
@@ -489,6 +489,26 @@ function buildAction(config) {
         /* #__PURE__ */ Object.defineProperty($$hoist_0_submitAction, "name", { value: "submitAction" });
         "
       `)
+      expect(await testTransform(input, { encode: true }))
+        .toMatchInlineSnapshot(`
+        "
+        function buildAction(config) {
+          const cookies = getCookies();
+
+          const submitAction = /* #__PURE__ */ $$register($$hoist_0_submitAction, "<id>", "$$hoist_0_submitAction").bind(null, __enc([config]));
+
+          return submitAction;
+        }
+
+        ;export async function $$hoist_0_submitAction($$hoist_encoded, formData) {
+            const [config] = __dec($$hoist_encoded);
+        "use server";
+            const cookies = formData.get("value");
+            return doSomething(config, cookies);
+          };
+        /* #__PURE__ */ Object.defineProperty($$hoist_0_submitAction, "name", { value: "submitAction" });
+        "
+      `)
     })
 
     it('const shadows function parameter', async () => {
@@ -517,82 +537,6 @@ function buildAction(cookies) {
             "use server";
             const cookies = formData.get("value");
             return cookies;
-          };
-        /* #__PURE__ */ Object.defineProperty($$hoist_0_submitAction, "name", { value: "submitAction" });
-        "
-      `)
-    })
-
-    it('non-colliding closure variable is still bound', async () => {
-      // Regression guard: `config` is a genuine closure (not redeclared inside
-      // the action) and must still appear in bindVars after the fix.
-      // Covered more precisely by 'const shadows outer variable' above, but
-      // kept as an explicit intent marker.
-      const input = `
-function buildAction(config) {
-  const cookies = getCookies();
-
-  async function submitAction(formData) {
-    "use server";
-    const cookies = formData.get("value");
-    return doSomething(config, cookies);
-  }
-
-  return submitAction;
-}
-`
-      expect(await testTransform(input)).toMatchInlineSnapshot(`
-        "
-        function buildAction(config) {
-          const cookies = getCookies();
-
-          const submitAction = /* #__PURE__ */ $$register($$hoist_0_submitAction, "<id>", "$$hoist_0_submitAction").bind(null, config);
-
-          return submitAction;
-        }
-
-        ;export async function $$hoist_0_submitAction(config, formData) {
-            "use server";
-            const cookies = formData.get("value");
-            return doSomething(config, cookies);
-          };
-        /* #__PURE__ */ Object.defineProperty($$hoist_0_submitAction, "name", { value: "submitAction" });
-        "
-      `)
-    })
-
-    it('encode: local declaration not included in bound args', async () => {
-      // Same as above but with encode/decode — the encrypted bound-args payload
-      // must only include genuine closure vars, not locally-redeclared names.
-      const input = `
-function buildAction(config) {
-  const cookies = getCookies();
-
-  async function submitAction(formData) {
-    "use server";
-    const cookies = formData.get("value");
-    return doSomething(config, cookies);
-  }
-
-  return submitAction;
-}
-`
-      expect(await testTransform(input, { encode: true }))
-        .toMatchInlineSnapshot(`
-        "
-        function buildAction(config) {
-          const cookies = getCookies();
-
-          const submitAction = /* #__PURE__ */ $$register($$hoist_0_submitAction, "<id>", "$$hoist_0_submitAction").bind(null, __enc([config]));
-
-          return submitAction;
-        }
-
-        ;export async function $$hoist_0_submitAction($$hoist_encoded, formData) {
-            const [config] = __dec($$hoist_encoded);
-        "use server";
-            const cookies = formData.get("value");
-            return doSomething(config, cookies);
           };
         /* #__PURE__ */ Object.defineProperty($$hoist_0_submitAction, "name", { value: "submitAction" });
         "

--- a/packages/plugin-rsc/src/transforms/hoist.test.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.test.ts
@@ -580,6 +580,75 @@ function buildAction(config) {
         "
       `)
     })
+
+    it('inner accessing both outer and own names', async () => {
+      const input = `
+function buildAction() {
+  const cookies = getCookies();
+  async function action() {
+    "use server";
+    if (condition) {
+      const cookies = localValue;  // block-scoped to the if
+      process(cookies);
+    }
+    return cookies;  // refers to OUTER cookies — needs binding
+  }
+}
+`
+      expect(await testTransform(input)).toMatchInlineSnapshot(`
+        "
+        function buildAction() {
+          const cookies = getCookies();
+          const action = /* #__PURE__ */ $$register($$hoist_0_action, "<id>", "$$hoist_0_action").bind(null, cookies);
+        }
+
+        ;export async function $$hoist_0_action(cookies) {
+            "use server";
+            if (condition) {
+              const cookies = localValue;  // block-scoped to the if
+              process(cookies);
+            }
+            return cookies;  // refers to OUTER cookies — needs binding
+          };
+        /* #__PURE__ */ Object.defineProperty($$hoist_0_action, "name", { value: "action" });
+        "
+      `)
+    })
+  })
+
+  // TODO: is this supposed to work? probably yes
+  it('self-referencing function', async () => {
+    const input = `
+function Parent() {
+  const count = 0;
+
+  async function recurse(n) {
+    "use server";
+    if (n > 0) return recurse(n - 1);
+    return count;
+  }
+
+  return recurse;
+}
+`
+    expect(await testTransform(input)).toMatchInlineSnapshot(`
+      "
+      function Parent() {
+        const count = 0;
+
+        const recurse = /* #__PURE__ */ $$register($$hoist_0_recurse, "<id>", "$$hoist_0_recurse").bind(null, count, recurse);
+
+        return recurse;
+      }
+
+      ;export async function $$hoist_0_recurse(count, recurse, n) {
+          "use server";
+          if (n > 0) return recurse(n - 1);
+          return count;
+        };
+      /* #__PURE__ */ Object.defineProperty($$hoist_0_recurse, "name", { value: "recurse" });
+      "
+    `)
   })
 
   it('no ending new line', async () => {

--- a/packages/plugin-rsc/src/transforms/hoist.test.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.test.ts
@@ -600,9 +600,24 @@ function buildAction(config) {
   return submitAction;
 }
 `
-      const result = await testTransform(input)
-      expect(result).toContain('.bind(null, config)')
-      expect(result).not.toContain('bind(null, cookies')
+      expect(await testTransform(input)).toMatchInlineSnapshot(`
+        "
+        function buildAction(config) {
+          const cookies = getCookies();
+
+          const submitAction = /* #__PURE__ */ $$register($$hoist_0_submitAction, "<id>", "$$hoist_0_submitAction").bind(null, config);
+
+          return submitAction;
+        }
+
+        ;export async function $$hoist_0_submitAction(config, formData) {
+            "use server";
+            const { cookies } = parseForm(formData);
+            return doSomething(config, cookies);
+          };
+        /* #__PURE__ */ Object.defineProperty($$hoist_0_submitAction, "name", { value: "submitAction" });
+        "
+      `)
     })
   })
 

--- a/packages/plugin-rsc/src/transforms/hoist.test.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.test.ts
@@ -615,6 +615,7 @@ function outer() {
       `)
     })
 
+    // TODO: not working
     it('inner has own block then shadows', async () => {
       const input = `
 function outer() {

--- a/packages/plugin-rsc/src/transforms/hoist.test.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.test.ts
@@ -541,9 +541,24 @@ function buildAction(config) {
   return submitAction;
 }
 `
-      const result = await testTransform(input)
-      expect(result).toContain('.bind(null, config)')
-      expect(result).not.toContain('bind(null, cookies')
+      expect(await testTransform(input)).toMatchInlineSnapshot(`
+        "
+        function buildAction(config) {
+          const cookies = getCookies();
+
+          const submitAction = /* #__PURE__ */ $$register($$hoist_0_submitAction, "<id>", "$$hoist_0_submitAction").bind(null, config);
+
+          return submitAction;
+        }
+
+        ;export async function $$hoist_0_submitAction(config, formData) {
+            "use server";
+            const cookies = formData.get("value");
+            return doSomething(config, cookies);
+          };
+        /* #__PURE__ */ Object.defineProperty($$hoist_0_submitAction, "name", { value: "submitAction" });
+        "
+      `)
     })
 
     it('encode: local declaration not included in bound args', async () => {

--- a/packages/plugin-rsc/src/transforms/hoist.test.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.test.ts
@@ -583,12 +583,12 @@ function buildAction(config) {
 
     it('inner accessing both outer and own names', async () => {
       const input = `
-function buildAction() {
-  const cookies = getCookies();
+function outer() {
+  const cookies = 0;
   async function action() {
     "use server";
     if (condition) {
-      const cookies = localValue;  // block-scoped to the if
+      const cookies = 1;  // block-scoped to the if
       process(cookies);
     }
     return cookies;  // refers to OUTER cookies — needs binding
@@ -597,18 +597,50 @@ function buildAction() {
 `
       expect(await testTransform(input)).toMatchInlineSnapshot(`
         "
-        function buildAction() {
-          const cookies = getCookies();
+        function outer() {
+          const cookies = 0;
           const action = /* #__PURE__ */ $$register($$hoist_0_action, "<id>", "$$hoist_0_action").bind(null, cookies);
         }
 
         ;export async function $$hoist_0_action(cookies) {
             "use server";
             if (condition) {
-              const cookies = localValue;  // block-scoped to the if
+              const cookies = 1;  // block-scoped to the if
               process(cookies);
             }
             return cookies;  // refers to OUTER cookies — needs binding
+          };
+        /* #__PURE__ */ Object.defineProperty($$hoist_0_action, "name", { value: "action" });
+        "
+      `)
+    })
+
+    it('inner has own block then shadows', async () => {
+      const input = `
+function outer() {
+  const cookie = 0;
+  async function action() {
+    "use server";
+    if (cond) {
+      const cookie = 1;
+      return cookie;  // refers to if-block's cookie
+    }
+  }
+}
+`
+      expect(await testTransform(input)).toMatchInlineSnapshot(`
+        "
+        function outer() {
+          const cookie = 0;
+          const action = /* #__PURE__ */ $$register($$hoist_0_action, "<id>", "$$hoist_0_action").bind(null, cookie);
+        }
+
+        ;export async function $$hoist_0_action(cookie) {
+            "use server";
+            if (cond) {
+              const cookie = 1;
+              return cookie;  // refers to if-block's cookie
+            }
           };
         /* #__PURE__ */ Object.defineProperty($$hoist_0_action, "name", { value: "action" });
         "

--- a/packages/plugin-rsc/src/transforms/hoist.test.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.test.ts
@@ -448,6 +448,164 @@ export async function kv() {
     `)
   })
 
+  // periscopic misclassifies block-scoped declarations inside a "use server"
+  // function body as outer-scope closure variables when the same name exists in
+  // an enclosing scope.  The hoist transform then injects a duplicate `const`
+  // declaration (from decryptActionBoundArgs) which causes a SyntaxError at
+  // runtime.
+  describe('local declaration shadows outer binding', () => {
+    it('const shadows outer variable', async () => {
+      // `cookies` is declared in the outer scope AND re-declared with const
+      // inside the server action. periscopic sees it as a closure ref, but it
+      // is NOT — the server action owns its own `cookies`.
+      const input = `
+function buildAction(config) {
+  const cookies = getCookies();
+
+  async function submitAction(formData) {
+    "use server";
+    const cookies = formData.get("value");
+    return doSomething(config, cookies);
+  }
+
+  return submitAction;
+}
+`
+      expect(await testTransform(input)).toMatchInlineSnapshot(`
+        "
+        function buildAction(config) {
+          const cookies = getCookies();
+
+          const submitAction = /* #__PURE__ */ $$register($$hoist_0_submitAction, "<id>", "$$hoist_0_submitAction").bind(null, config);
+
+          return submitAction;
+        }
+
+        ;export async function $$hoist_0_submitAction(config, formData) {
+            "use server";
+            const cookies = formData.get("value");
+            return doSomething(config, cookies);
+          };
+        /* #__PURE__ */ Object.defineProperty($$hoist_0_submitAction, "name", { value: "submitAction" });
+        "
+      `)
+    })
+
+    it('const shadows function parameter', async () => {
+      // the outer `cookies` binding comes from a function parameter, not a
+      // variable declaration — collectOuterNames must handle params too.
+      const input = `
+function buildAction(cookies) {
+  async function submitAction(formData) {
+    "use server";
+    const cookies = formData.get("value");
+    return cookies;
+  }
+
+  return submitAction;
+}
+`
+      expect(await testTransform(input)).toMatchInlineSnapshot(`
+        "
+        function buildAction(cookies) {
+          const submitAction = /* #__PURE__ */ $$register($$hoist_0_submitAction, "<id>", "$$hoist_0_submitAction");
+
+          return submitAction;
+        }
+
+        ;export async function $$hoist_0_submitAction(formData) {
+            "use server";
+            const cookies = formData.get("value");
+            return cookies;
+          };
+        /* #__PURE__ */ Object.defineProperty($$hoist_0_submitAction, "name", { value: "submitAction" });
+        "
+      `)
+    })
+
+    it('non-colliding closure variable is still bound', async () => {
+      // Regression guard: `config` is a genuine closure (not redeclared inside
+      // the action) and must still appear in bindVars after the fix.
+      // Covered more precisely by 'const shadows outer variable' above, but
+      // kept as an explicit intent marker.
+      const input = `
+function buildAction(config) {
+  const cookies = getCookies();
+
+  async function submitAction(formData) {
+    "use server";
+    const cookies = formData.get("value");
+    return doSomething(config, cookies);
+  }
+
+  return submitAction;
+}
+`
+      const result = await testTransform(input)
+      expect(result).toContain('.bind(null, config)')
+      expect(result).not.toContain('bind(null, cookies')
+    })
+
+    it('encode: local declaration not included in bound args', async () => {
+      // Same as above but with encode/decode — the encrypted bound-args payload
+      // must only include genuine closure vars, not locally-redeclared names.
+      const input = `
+function buildAction(config) {
+  const cookies = getCookies();
+
+  async function submitAction(formData) {
+    "use server";
+    const cookies = formData.get("value");
+    return doSomething(config, cookies);
+  }
+
+  return submitAction;
+}
+`
+      expect(await testTransform(input, { encode: true }))
+        .toMatchInlineSnapshot(`
+        "
+        function buildAction(config) {
+          const cookies = getCookies();
+
+          const submitAction = /* #__PURE__ */ $$register($$hoist_0_submitAction, "<id>", "$$hoist_0_submitAction").bind(null, __enc([config]));
+
+          return submitAction;
+        }
+
+        ;export async function $$hoist_0_submitAction($$hoist_encoded, formData) {
+            const [config] = __dec($$hoist_encoded);
+        "use server";
+            const cookies = formData.get("value");
+            return doSomething(config, cookies);
+          };
+        /* #__PURE__ */ Object.defineProperty($$hoist_0_submitAction, "name", { value: "submitAction" });
+        "
+      `)
+    })
+
+    it('destructured local declaration not included in bound args', async () => {
+      // `const { cookies } = ...` — the name comes from a destructuring pattern,
+      // not a plain Identifier declarator.  Must still be excluded from bindVars.
+      const input = `
+function buildAction(config) {
+  const cookies = getCookies();
+
+  async function submitAction(formData) {
+    "use server";
+    const { cookies } = parseForm(formData);
+    return doSomething(config, cookies);
+  }
+
+  return submitAction;
+}
+`
+      const result = await testTransform(input)
+      expect(result).toContain('.bind(null, config)')
+      expect(result).not.toContain('bind(null, cookies')
+    })
+  })
+
   it('no ending new line', async () => {
     const input = `\
 export async function test() {

--- a/packages/plugin-rsc/src/transforms/hoist.test.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.test.ts
@@ -1,3 +1,5 @@
+import { walk } from 'estree-walker'
+import { analyze } from 'periscopic'
 import { parseAstAsync } from 'vite'
 import { describe, expect, it } from 'vitest'
 import { transformHoistInlineDirective } from './hoist'
@@ -597,9 +599,121 @@ export async function test() {
   })
 })
 
-// TODO: should report to upstream or looks for alternative
+// TODO: report upstream
 // https://github.com/Rich-Harris/periscopic/
-describe.skip('periscopic issues', () => {
-  // TODO: re-export
-  // TODO: shadowed variable in nested functions
+describe('periscopic behavior', () => {
+  it('re-export confuses scopes', async () => {
+    // periscopic bug: `export { x } from "y"` creates a block scope with `x`
+    // as a declaration, which shadows the real module-level import.
+    // `find_owner` then returns that intermediate scope instead of
+    // `analyzed.scope`, causing the hoist algorithm to misidentify `redirect`
+    // as a closure variable.  The workaround in hoist.ts strips re-exports
+    // before calling analyze.
+    const ast = await parseAstAsync(`
+export { redirect } from "react-router/rsc";
+import { redirect } from "react-router/rsc";
+
+export default () => {
+  const f = async () => {
+    "use server";
+    throw redirect();
+  };
+}
+`)
+    const { map, scope: root } = analyze(ast)
+    // find the arrow with "use server"
+    let serverScope: ReturnType<typeof analyze>['scope'] | undefined
+    walk(ast, {
+      enter(node) {
+        if (
+          node.type === 'ArrowFunctionExpression' &&
+          node.body.type === 'BlockStatement' &&
+          node.body.body.some(
+            (s: any) =>
+              s.type === 'ExpressionStatement' &&
+              s.expression.type === 'Literal' &&
+              s.expression.value === 'use server',
+          )
+        ) {
+          serverScope = map.get(node)
+        }
+      },
+    })
+    expect(serverScope).toBeDefined()
+    expect(serverScope!.references.has('redirect')).toBe(true)
+    // find_owner should return the root scope (where the import lives), but
+    // instead returns the synthetic block scope periscopic creates for the
+    // re-export — this is a periscopic bug.
+    const owner = serverScope!.find_owner('redirect')
+    expect(owner).not.toBe(root)
+    expect(owner).not.toBe(serverScope)
+  })
+
+  it('shadowed variable: find_owner misses child block scope', async () => {
+    // When a `const` inside a function body shadows an outer name, periscopic
+    // puts the declaration in the BlockStatement's scope (a child of the
+    // function scope).  `find_owner` walks *up* from the function scope, so it
+    // finds the outer declaration instead of the inner one.
+    //
+    // This is not a periscopic bug — it is correct scope modeling.  The hoist
+    // algorithm was using find_owner from the function scope, which cannot see
+    // declarations in child (block) scopes.
+    const ast = await parseAstAsync(`
+function outer() {
+  const cookies = getCookies();
+  async function inner(formData) {
+    "use server";
+    const cookies = formData.get("value");
+    return cookies;
+  }
+}
+`)
+    const { map, scope: root } = analyze(ast)
+    // find the inner function and its body block scope
+    let innerFnScope: ReturnType<typeof analyze>['scope'] | undefined
+    let innerBlockScope: ReturnType<typeof analyze>['scope'] | undefined
+    walk(ast, {
+      enter(node) {
+        if (
+          node.type === 'FunctionDeclaration' &&
+          (node as any).id?.name === 'inner'
+        ) {
+          innerFnScope = map.get(node)
+        }
+        if (
+          node.type === 'BlockStatement' &&
+          node.body.some(
+            (s: any) =>
+              s.type === 'ExpressionStatement' &&
+              s.expression.type === 'Literal' &&
+              s.expression.value === 'use server',
+          )
+        ) {
+          innerBlockScope = map.get(node)
+        }
+      },
+    })
+    expect(innerFnScope).toBeDefined()
+    expect(innerBlockScope).toBeDefined()
+
+    // periscopic correctly declares `cookies` in the block scope (child of function scope)
+    expect(innerBlockScope!.declarations.has('cookies')).toBe(true)
+    // the function scope does NOT have `cookies` — only `formData` (param)
+    expect(innerFnScope!.declarations.has('cookies')).toBe(false)
+    expect(innerFnScope!.declarations.has('formData')).toBe(true)
+
+    // `cookies` propagates up as a reference through all ancestor scopes
+    expect(innerFnScope!.references.has('cookies')).toBe(true)
+
+    // find_owner from function scope walks UP and finds the OUTER `cookies`,
+    // not the inner one (which is in a child block scope, unreachable by walking up)
+    const ownerFromFnScope = innerFnScope!.find_owner('cookies')
+    expect(ownerFromFnScope).not.toBe(innerFnScope)
+    expect(ownerFromFnScope).not.toBe(innerBlockScope)
+    expect(ownerFromFnScope).not.toBe(root)
+
+    // find_owner from block scope correctly finds the INNER `cookies`
+    const ownerFromBlockScope = innerBlockScope!.find_owner('cookies')
+    expect(ownerFromBlockScope).toBe(innerBlockScope)
+  })
 })

--- a/packages/plugin-rsc/src/transforms/hoist.test.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.test.ts
@@ -652,3 +652,10 @@ export async function test() {
     `)
   })
 })
+
+// TODO: should report to upstream or looks for alternative
+// https://github.com/Rich-Harris/periscopic/
+describe.skip('periscopic issues', () => {
+  // TODO: re-export
+  // TODO: shadowed variable in nested functions
+})

--- a/packages/plugin-rsc/src/transforms/hoist.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.ts
@@ -71,7 +71,7 @@ export function transformHoistInlineDirective(
           )
         }
 
-        const scope = analyzed.map.get(node)
+        const scope = analyzed.map.get(node.body)
         tinyassert(scope)
         const declName = node.type === 'FunctionDeclaration' && node.id.name
         const originalName =
@@ -82,18 +82,10 @@ export function transformHoistInlineDirective(
           'anonymous_server_function'
 
         // bind variables which are neither global nor in own scope
-        const localDecls = collectLocallyDeclaredNames(node.body)
+        const ownParams = new Set(node.params.flatMap((p) => extract_names(p)))
         const bindVars = [...scope.references].filter((ref) => {
-          // declared function itself is included as reference
-          if (ref === declName) {
-            return false
-          }
-
-          // periscopic misclassifies block-scoped declarations inside a
-          // "use server" function body as closure references when the same
-          // name exists in an enclosing scope. Exclude any name that is
-          // actually declared within this function body.
-          if (localDecls.has(ref)) {
+          // own parameters are available in a hoisted function
+          if (ownParams.has(ref)) {
             return false
           }
 
@@ -199,40 +191,4 @@ export function findDirectives(ast: Program, directive: string): Literal[] {
     },
   })
   return nodes
-}
-
-/**
- * Collect all names declared within a function body, without crossing into
- * nested function boundaries (which have their own scope).
- *
- * This guards against a periscopic limitation where block-scoped declarations
- * (`const`/`let`) inside a `BlockStatement` are misclassified as references
- * to outer-scope bindings.  Any name returned here must NOT be in `bindVars`.
- */
-function collectLocallyDeclaredNames(
-  body: Program['body'][number],
-): Set<string> {
-  const names = new Set<string>()
-
-  walk(body, {
-    enter(node) {
-      switch (node.type) {
-        case 'FunctionDeclaration':
-        case 'FunctionExpression':
-        case 'ClassDeclaration':
-          if (node.id) names.add(node.id.name)
-          return this.skip()
-        case 'ArrowFunctionExpression':
-          return this.skip()
-        case 'VariableDeclaration':
-          for (const decl of node.declarations) {
-            for (const name of extract_names(decl.id)) {
-              names.add(name)
-            }
-          }
-      }
-    },
-  })
-
-  return names
 }

--- a/packages/plugin-rsc/src/transforms/hoist.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.ts
@@ -1,5 +1,5 @@
 import { tinyassert } from '@hiogawa/utils'
-import type { Program, Literal } from 'estree'
+import type { Program, Literal, Pattern } from 'estree'
 import { walk } from 'estree-walker'
 import MagicString from 'magic-string'
 import { analyze } from 'periscopic'
@@ -82,11 +82,21 @@ export function transformHoistInlineDirective(
           'anonymous_server_function'
 
         // bind variables which are neither global nor in own scope
+        const localDecls = collectLocallyDeclaredNames(node.body)
         const bindVars = [...scope.references].filter((ref) => {
           // declared function itself is included as reference
           if (ref === declName) {
             return false
           }
+
+          // periscopic misclassifies block-scoped declarations inside a
+          // "use server" function body as closure references when the same
+          // name exists in an enclosing scope. Exclude any name that is
+          // actually declared within this function body.
+          if (localDecls.has(ref)) {
+            return false
+          }
+
           const owner = scope.find_owner(ref)
           return owner && owner !== scope && owner !== analyzed.scope
         })
@@ -189,4 +199,61 @@ export function findDirectives(ast: Program, directive: string): Literal[] {
     },
   })
   return nodes
+}
+
+/**
+ * Collect all names declared within a function body, without crossing into
+ * nested function boundaries (which have their own scope).
+ *
+ * This guards against a periscopic limitation where block-scoped declarations
+ * (`const`/`let`) inside a `BlockStatement` are misclassified as references
+ * to outer-scope bindings.  Any name returned here must NOT be in `bindVars`.
+ */
+function collectLocallyDeclaredNames(
+  body: Program['body'][number],
+): Set<string> {
+  const names = new Set<string>()
+
+  function collectPattern(node: Pattern | null): void {
+    switch (node?.type) {
+      case 'Identifier':
+        names.add(node.name)
+        break
+      case 'AssignmentPattern':
+        return collectPattern(node.left)
+      case 'RestElement':
+        return collectPattern(node.argument)
+      case 'ArrayPattern':
+        for (const el of node.elements) {
+          collectPattern(el)
+        }
+        break
+      case 'ObjectPattern':
+        for (const prop of node.properties) {
+          collectPattern(
+            prop.type === 'RestElement' ? prop.argument : prop.value,
+          )
+        }
+    }
+  }
+
+  walk(body, {
+    enter(node) {
+      switch (node.type) {
+        case 'FunctionDeclaration':
+        case 'FunctionExpression':
+        case 'ClassDeclaration':
+          if (node.id) names.add(node.id.name)
+          return this.skip()
+        case 'ArrowFunctionExpression':
+          return this.skip()
+        case 'VariableDeclaration':
+          for (const decl of node.declarations) {
+            collectPattern(decl.id)
+          }
+      }
+    },
+  })
+
+  return names
 }

--- a/packages/plugin-rsc/src/transforms/hoist.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.ts
@@ -1,8 +1,8 @@
 import { tinyassert } from '@hiogawa/utils'
-import type { Program, Literal, Pattern } from 'estree'
+import type { Program, Literal } from 'estree'
 import { walk } from 'estree-walker'
 import MagicString from 'magic-string'
-import { analyze } from 'periscopic'
+import { analyze, extract_names } from 'periscopic'
 
 export function transformHoistInlineDirective(
   input: string,
@@ -214,29 +214,6 @@ function collectLocallyDeclaredNames(
 ): Set<string> {
   const names = new Set<string>()
 
-  function collectPattern(node: Pattern | null): void {
-    switch (node?.type) {
-      case 'Identifier':
-        names.add(node.name)
-        break
-      case 'AssignmentPattern':
-        return collectPattern(node.left)
-      case 'RestElement':
-        return collectPattern(node.argument)
-      case 'ArrayPattern':
-        for (const el of node.elements) {
-          collectPattern(el)
-        }
-        break
-      case 'ObjectPattern':
-        for (const prop of node.properties) {
-          collectPattern(
-            prop.type === 'RestElement' ? prop.argument : prop.value,
-          )
-        }
-    }
-  }
-
   walk(body, {
     enter(node) {
       switch (node.type) {
@@ -249,7 +226,9 @@ function collectLocallyDeclaredNames(
           return this.skip()
         case 'VariableDeclaration':
           for (const decl of node.declarations) {
-            collectPattern(decl.id)
+            for (const name of extract_names(decl.id)) {
+              names.add(name)
+            }
           }
       }
     },


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

This PR fixes a bug where periscopic misclassifies block-scoped declarations inside a `"use server"` function body as closure variables when the same name exists in a scope, causing a syntax error in the hoisted output (ran into this when testing Payload CMS with Vinext).

It essentially collects the names of local declarations from the function's scope and then stop them from being bound.

There's also a few regression tests that were generated by AI.

This is an attempt to upstream a real fix for https://github.com/cloudflare/vinext/pull/527.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
