### PR TITLE
ci: update node 24 to fix publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set node version
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org/
           # disable cache, to avoid cache poisoning (https://docs.zizmor.sh/audits/#cache-poisoning)
           package-manager-cache: false


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

Released failed https://github.com/vitejs/vite-plugin-react/actions/runs/24022005781/job/70052639503 and this seems like only diff from Vite's release workflow.

```
Run npm i -g npm@^11.5.2 && pnpm run ci-publish plugin-rsc@0.5.22
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error Require stack:
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/index.js
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/index.js
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/libnpmfund/lib/index.js
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/lib/utils/reify-output.js
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/lib/utils/reify-finish.js
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/lib/commands/install.js
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/lib/npm.js
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/lib/cli/entry.js
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/lib/cli.js
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/bin/npm-cli.js
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-04-06T06_47_45_772Z-debug-0.log
Error: Process completed with exit code 1.
```