### PR TITLE
test(rsc): e2e for server action closure member binding

### DIFF
--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -1404,6 +1404,33 @@ function defineTest(f: Fixture) {
       .click()
   }
 
+  test('action bind member @js', async ({ page }) => {
+    await page.goto(f.url())
+    await waitForHydration(page)
+    await using _ = await expectNoReload(page)
+    await testActionBindMember(page)
+  })
+
+  testNoJs('action bind member @nojs', async ({ page }) => {
+    await page.goto(f.url())
+    await testActionBindMember(page)
+  })
+
+  async function testActionBindMember(page: Page) {
+    await expect(page.getByTestId('test-server-action-bind-member')).toHaveText(
+      '[?]',
+    )
+    await page
+      .getByRole('button', { name: 'test-server-action-bind-member' })
+      .click()
+    await expect(page.getByTestId('test-server-action-bind-member')).toHaveText(
+      'true',
+    )
+    await page
+      .getByRole('button', { name: 'test-server-action-bind-reset' })
+      .click()
+  }
+
   test('action bind client @js', async ({ page }) => {
     await page.goto(f.url())
     await waitForHydration(page)

--- a/packages/plugin-rsc/examples/basic/src/routes/action-bind/server.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/action-bind/server.tsx
@@ -10,6 +10,7 @@ export function TestServerActionBindReset() {
       action={async () => {
         'use server'
         testServerActionBindSimpleState = '[?]'
+        testServerActionBindMemberState = '[?]'
         testServerActionBindActionState = '[?]'
         testServerActionBindClientState++
       }}
@@ -90,6 +91,31 @@ export function TestServerActionBindAction() {
       <button type="submit">test-server-action-bind-action</button>
       <span data-testid="test-server-action-bind-action">
         {testServerActionBindActionState}
+      </span>
+    </form>
+  )
+}
+
+let testServerActionBindMemberState = '[?]'
+
+export function TestServerActionBindMember() {
+  const x = {
+    y: {
+      z: 1234,
+    },
+    invalid: () => {},
+  }
+
+  return (
+    <form
+      action={async () => {
+        'use server'
+        testServerActionBindMemberState = JSON.stringify(x.y.z === 1234)
+      }}
+    >
+      <button type="submit">test-server-action-bind-member</button>
+      <span data-testid="test-server-action-bind-member">
+        {testServerActionBindMemberState}
       </span>
     </form>
   )

--- a/packages/plugin-rsc/examples/basic/src/routes/root.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/root.tsx
@@ -6,6 +6,7 @@ import {
   TestServerActionBindClient,
   TestServerActionBindReset,
   TestServerActionBindSimple,
+  TestServerActionBindMember,
 } from './action-bind/server'
 import { TestServerActionError } from './action-error/server'
 import {
@@ -105,6 +106,7 @@ export function Root(props: { url: URL }) {
         <TestServerActionBindSimple />
         <TestServerActionBindClient />
         <TestServerActionBindAction />
+        <TestServerActionBindMember />
         <TestSerializationServer />
         <TestClientInServer />
         <TestServerInServer />


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

- Follow up to https://github.com/vitejs/vite-plugin-react/pull/1172

I realized we didn't have e2e to verify member binding behavior. This example fails in the previous version.
