### PR TITLE
fix(rsc): preserve `*` for generators

### DIFF
--- a/packages/plugin-rsc/src/transforms/fixtures/hoist/async-generator-loses-star.js
+++ b/packages/plugin-rsc/src/transforms/fixtures/hoist/async-generator-loses-star.js
@@ -1,0 +1,14 @@
+// The hoist transform must preserve `function*` / `async function*` syntax.
+// Previously the `*` was dropped, making `yield` a SyntaxError.
+function outer() {
+  const items = [1, 2, 3]
+
+  async function* stream() {
+    'use server'
+    for (const item of items) {
+      yield item
+    }
+  }
+
+  return stream
+}

--- a/packages/plugin-rsc/src/transforms/fixtures/hoist/async-generator-loses-star.js.snap.encode.js
+++ b/packages/plugin-rsc/src/transforms/fixtures/hoist/async-generator-loses-star.js.snap.encode.js
@@ -1,0 +1,18 @@
+// The hoist transform must preserve `function*` / `async function*` syntax.
+// Previously the `*` was dropped, making `yield` a SyntaxError.
+function outer() {
+  const items = [1, 2, 3]
+
+  const stream = /* #__PURE__ */ $$register($$hoist_0_stream, "<id>", "$$hoist_0_stream").bind(null, __enc([items]));
+
+  return stream
+}
+
+;export async function* $$hoist_0_stream($$hoist_encoded) {
+    const [items] = __dec($$hoist_encoded);
+'use server'
+    for (const item of items) {
+      yield item
+    }
+  };
+/* #__PURE__ */ Object.defineProperty($$hoist_0_stream, "name", { value: "stream" });

--- a/packages/plugin-rsc/src/transforms/fixtures/hoist/async-generator-loses-star.js.snap.js
+++ b/packages/plugin-rsc/src/transforms/fixtures/hoist/async-generator-loses-star.js.snap.js
@@ -1,0 +1,17 @@
+// The hoist transform must preserve `function*` / `async function*` syntax.
+// Previously the `*` was dropped, making `yield` a SyntaxError.
+function outer() {
+  const items = [1, 2, 3]
+
+  const stream = /* #__PURE__ */ $$register($$hoist_0_stream, "<id>", "$$hoist_0_stream").bind(null, items);
+
+  return stream
+}
+
+;export async function* $$hoist_0_stream(items) {
+    'use server'
+    for (const item of items) {
+      yield item
+    }
+  };
+/* #__PURE__ */ Object.defineProperty($$hoist_0_stream, "name", { value: "stream" });

--- a/packages/plugin-rsc/src/transforms/hoist.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.ts
@@ -100,7 +100,7 @@ export function transformHoistInlineDirective(
           node.body.start,
           `\n;${options.noExport ? '' : 'export '}${
             node.async ? 'async ' : ''
-          }function ${newName}(${newParams}) `,
+          }function${node.generator ? '*' : ''} ${newName}(${newParams}) `,
         )
         output.appendLeft(
           node.end,


### PR DESCRIPTION
The `*` syntax for generator functions was being dropped, resulting in syntax errors. This preserves it.