### PR TITLE
feat(react): whitelist debugging-options

### DIFF
--- a/packages/plugin-react/README.md
+++ b/packages/plugin-react/README.md
@@ -107,6 +107,8 @@ The `reactCompilerPreset` accepts an optional options object with the following 
 - `compilationMode` — Set to `'annotation'` to only compile components annotated with `"use memo"`.
 - `target` — Set to `'17'` or `'18'` to target older React versions (uses `react-compiler-runtime` instead of `react/compiler-runtime`).
 
+Additional options can be found in the [documentation](https://react.dev/reference/react-compiler/configuration).
+
 ```js
 babel({
   presets: [reactCompilerPreset({ compilationMode: 'annotation' })],

--- a/packages/plugin-react/src/reactCompilerPreset.ts
+++ b/packages/plugin-react/src/reactCompilerPreset.ts
@@ -4,10 +4,7 @@ import type {
 } from '#optionalTypes'
 
 export const reactCompilerPreset = (
-  options: Pick<
-    ReactCompilerBabelPluginOptions,
-    'compilationMode' | 'target'
-  > = {},
+  options: ReactCompilerBabelPluginOptions = {},
 ): RolldownBabelPreset => ({
   preset: () => ({
     plugins: [['babel-plugin-react-compiler', options]],


### PR DESCRIPTION
### Description

tldr: Options should allow debug-settings. 

Changes in code can easily cause a component to be skipped over.
You might not notice, but infinite loops or self-ddos can also happen. 

Options added from [debugging-docs](https://react.dev/reference/react-compiler/configuration#debugging).