### PR TITLE
chore: (experiment) invalidate virtual css on css change

### DIFF
--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -2229,6 +2229,9 @@ function vitePluginRscCss(
     const visitedFiles = new Set<string>()
 
     function recurse(id: string) {
+      if (id.startsWith('\0virtual:vite-rsc/css?')) {
+        return
+      }
       if (visited.has(id)) {
         return
       }
@@ -2243,6 +2246,15 @@ function vitePluginRscCss(
             if (hasSpecialCssQuery(next.id)) {
               continue
             }
+            // TODO:
+            // - without visitedFiles.add, commenting out `styles-server/server.tsx`'s `server.css` works
+            // - but with this, server.css still gets visited after commented out why
+            if (next.file) {
+              visitedFiles.add(next.file)
+            }
+            // if (next.id.includes("/style-server/server.css")) {
+            //   console.log({ entryId, importer: mod?.id, css: next.id })
+            // }
             cssIds.add(next.id)
           } else {
             recurse(next.id)
@@ -2486,6 +2498,10 @@ function vitePluginRscCss(
             const importer = parsed.id
             if (this.environment.mode === 'dev') {
               const result = collectCss(server.environments.rsc!, importer)
+              //  console.log({ id: importer, result })
+              // if (importer.includes("style-server")) {
+              //   console.log({ importer, result })
+              // }
               for (const file of [importer, ...result.visitedFiles]) {
                 this.addWatchFile(file)
               }


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

- Related to https://github.com/vitejs/vite-plugin-react/pull/1188#discussion_r3136149284

Experimenting on `collectCss + addWatchFile` technique. I hope Vite can make `addWatchFile` work, but if stretching this direction is too clumsy, we should just go back manual traverse and css invalidation approach like we had before https://github.com/vitejs/vite-plugin-react/pull/847