### PR TITLE
fix(rsc): pre-include React peers in client env optimizeDeps (fix #1213)

### DIFF
--- a/packages/plugin-rsc/e2e/use-client-hook-in-provider.test.ts
+++ b/packages/plugin-rsc/e2e/use-client-hook-in-provider.test.ts
@@ -1,0 +1,121 @@
+import { expect, test } from '@playwright/test'
+import { setupInlineFixture, type Fixture, useFixture } from './fixture'
+import { waitForHydration } from './helper'
+
+// Regression test for the cold-start optimizer-cache version drift that
+// caused `Invalid hook call` when a `'use client'` third-party package
+// synchronously called a React hook in a Provider on first paint.
+// https://github.com/vitejs/vite-plugin-react/issues/1213
+test.describe(() => {
+  const root = 'examples/e2e/temp/use-client-hook-in-provider'
+
+  test.beforeAll(async () => {
+    await setupInlineFixture({
+      src: 'examples/starter-extra',
+      dest: root,
+      files: {
+        'package.json': /* json */ `
+          {
+            "name": "@vitejs/plugin-rsc-examples-use-client-hook-in-provider",
+            "version": "0.0.0",
+            "private": true,
+            "license": "MIT",
+            "type": "module",
+            "scripts": {
+              "dev": "vite",
+              "build": "vite build",
+              "preview": "vite preview"
+            },
+            "dependencies": {
+              "react": "^19.2.6",
+              "react-dom": "^19.2.6",
+              "@vitejs/test-dep-use-client-hook-in-provider": "*"
+            },
+            "devDependencies": {
+              "@types/react": "^19.2.14",
+              "@types/react-dom": "^19.2.3",
+              "@vitejs/plugin-react": "latest",
+              "@vitejs/plugin-rsc": "latest",
+              "rsc-html-stream": "^0.0.7",
+              "vite": "^8.0.10"
+            }
+          }
+        `,
+        'node_modules/@vitejs/test-dep-use-client-hook-in-provider/package.json': /* json */ `
+          {
+            "name": "@vitejs/test-dep-use-client-hook-in-provider",
+            "private": true,
+            "type": "module",
+            "exports": "./index.js",
+            "peerDependencies": { "react": "*" }
+          }
+        `,
+        'node_modules/@vitejs/test-dep-use-client-hook-in-provider/index.js': /* js */ `
+          'use client'
+          import * as React from 'react'
+
+          // Synchronously call a hook in a top-level Provider. With the
+          // pre-fix optimizer behaviour, lazy discovery emits this module
+          // at a different ?v= than the renderer's React, so React.H is
+          // null when useMemo runs.
+          export function TestProvider(props) {
+            const value = React.useMemo(() => 'ready', [])
+            return React.createElement(
+              'span',
+              { 'data-testid': 'use-client-hook-in-provider' },
+              value,
+            )
+          }
+        `,
+        'src/client.tsx': /* tsx */ `
+          'use client'
+          export { TestProvider } from '@vitejs/test-dep-use-client-hook-in-provider'
+        `,
+        'src/root.tsx': /* tsx */ `
+          import { TestProvider } from './client.tsx'
+
+          export function Root() {
+            return (
+              <html lang="en">
+                <head>
+                  <meta charSet="UTF-8" />
+                </head>
+                <body>
+                  <TestProvider />
+                </body>
+              </html>
+            )
+          }
+        `,
+      },
+    })
+  })
+
+  function defineUseClientHookTest(f: Fixture) {
+    test('renders without Invalid hook call on cold start', async ({
+      page,
+    }) => {
+      const errors: string[] = []
+      page.on('pageerror', (e) => errors.push(e.message))
+      page.on('console', (msg) => {
+        if (msg.type() === 'error') errors.push(msg.text())
+      })
+      await page.goto(f.url())
+      await waitForHydration(page)
+      await expect(page.getByTestId('use-client-hook-in-provider')).toHaveText(
+        'ready',
+      )
+      expect(errors.join('\n')).not.toMatch(/Invalid hook call/)
+    })
+  }
+
+  test.describe('dev', () => {
+    const f = useFixture({ root, mode: 'dev' })
+    defineUseClientHookTest(f)
+  })
+
+  test.describe('build', () => {
+    const f = useFixture({ root, mode: 'build' })
+    defineUseClientHookTest(f)
+  })
+})

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -111,6 +111,18 @@ function resolvePackage(name: string) {
   return pathToFileURL(require.resolve(name)).href
 }
 
+function filterBareResolvable(packages: string[], root: string): string[] {
+  const userRequire = createRequire(path.join(root, 'package.json'))
+  return packages.filter((name) => {
+    try {
+      userRequire.resolve(name)
+      return true
+    } catch {
+      return false
+    }
+  })
+}
+
 export type { RscPluginManager }
 
 /**
@@ -517,8 +529,15 @@ export default function vitePluginRsc(
               },
               optimizeDeps: {
                 include: [
+                  'react',
+                  'react-dom',
+                  'react/jsx-runtime',
+                  'react/jsx-dev-runtime',
                   'react-dom/client',
                   `${reactServerDomPackageName}/client.browser`,
+                  // Without these, the client optimizer re-scans on first
+                  // request, drifting `?v=` hashes and duplicating React.
+                  ...filterBareResolvable(result.ssr.noExternal, process.cwd()),
                 ],
                 exclude: [PKG_NAME],
               },


### PR DESCRIPTION
fix #1213

## Summary

The `client` environment's `optimizeDeps.include` only listed
`react-dom/client` and one React Server DOM entry — not `react`,
`react/jsx-runtime`, or any of the React-peer packages crawled by
`crawlFrameworkPkgs`. Those got discovered lazily as the browser
requested modules, the optimizer re-ran mid-load, and the `?v=` hash
changed on chunks that had already been served. The browser ended up
with two distinct React module records, and `'use client'` libraries
that synchronously call hooks in providers hit the wrong dispatcher
(`React.H` is null), throwing `Invalid hook call`.

The `ssr` and `rsc` envs don't hit this because their
`optimizeDeps.include` already lists `react`, `react-dom`,
`react/jsx-runtime`, and `react/jsx-dev-runtime`.

## Change

Mirror the SSR/RSC env behaviour for the `client` env: pre-include
those four React subpaths plus the React-peer packages that
`crawlFrameworkPkgs` already discovers for `noExternal`. Filter that
spread to packages whose bare specifier resolves from the user's
project root — server-only React peers (e.g. the
`@vitejs/test-dep-client-in-server` test fixture, which only exports
`./server`) would otherwise break dep optimization.

## Reproduction

Repro repo: https://github.com/jgeurts/vite-rsc-cjs-subpath-named-exports

```sh
git clone https://github.com/jgeurts/vite-rsc-cjs-subpath-named-exports
cd vite-rsc-cjs-subpath-named-exports
npm install
rm -rf node_modules/.vite
npm run dev
# open http://localhost:5173/
```

The page mounts, then the browser console shows two `Invalid hook call`
errors and a `TypeError: Cannot read properties of null (reading 'useMemo')`
where the React, `@liveblocks_react`, and `react-dom_client` chunks each
carry a different `?v=` hash. With this PR applied (drop the patched
`@vitejs/plugin-rsc` into the repro's `node_modules`), the page renders
cleanly.

## Verification

- All 424 plugin-rsc unit tests pass (`pnpm test`).
- `examples/basic` runs cleanly in `pnpm dev` and `pnpm build` after
  the change. The fixture exercises a wide range of `'use client'` /
  `'use server'` paths, including the `@vitejs/test-dep-client-in-server`
  fixture that lacks a `.` export — confirms the resolution-based filter
  works.
- New regression test `e2e/use-client-hook-in-provider.test.ts` stands
  up an isolated dev fixture with a `'use client'` package that calls
  `useMemo` synchronously in a Provider. With the fix it passes; with
  the fix reverted it fails the dev case (the build case still passes —
  this bug is dev-only).
- Repro repo (linked above) loads cleanly with the patched plugin.
