### PR TITLE
feat: use carets for rolldown versions

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -8,7 +8,7 @@
     "./refresh-runtime": "./refresh-runtime.js"
   },
   "dependencies": {
-    "@rolldown/pluginutils": "1.0.0"
+    "@rolldown/pluginutils": "^1.0.0"
   },
   "peerDependencies": {
     "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/packages/plugin-react-swc/package.json
+++ b/packages/plugin-react-swc/package.json
@@ -29,7 +29,7 @@
     "test": "playwright test"
   },
   "dependencies": {
-    "@rolldown/pluginutils": "1.0.0",
+    "@rolldown/pluginutils": "^1.0.0",
     "@swc/core": "^1.15.11"
   },
   "devDependencies": {

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -43,7 +43,7 @@
     "test-unit": "vitest run"
   },
   "dependencies": {
-    "@rolldown/pluginutils": "1.0.0"
+    "@rolldown/pluginutils": "^1.0.0"
   },
   "devDependencies": {
     "@babel/core": "8.0.0-rc.4",
@@ -52,7 +52,7 @@
     "babel-plugin-react-compiler": "^1.0.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "rolldown": "1.0.0",
+    "rolldown": "^1.0.0",
     "tsdown": "^0.22.0",
     "vite": "^8.0.11"
   },
@@ -76,7 +76,7 @@
     "schemaVersion": 1,
     "rolldown": {
       "type": "compatible",
-      "versions": "^1.0.0-beta.44",
+      "versions": "^1.0.0",
       "note": "You can use Rolldown's built-in feature directly."
     },
     "rollup": {

--- a/packages/plugin-rsc/package.json
+++ b/packages/plugin-rsc/package.json
@@ -39,7 +39,7 @@
     "prepack": "tsdown"
   },
   "dependencies": {
-    "@rolldown/pluginutils": "1.0.0",
+    "@rolldown/pluginutils": "^1.0.0",
     "es-module-lexer": "^2.1.0",
     "estree-walker": "^3.0.3",
     "magic-string": "^0.30.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,13 +75,13 @@ importers:
   packages/common:
     dependencies:
       '@rolldown/pluginutils':
-        specifier: 1.0.0
+        specifier: ^1.0.0
         version: 1.0.0
 
   packages/plugin-react:
     dependencies:
       '@rolldown/pluginutils':
-        specifier: 1.0.0
+        specifier: ^1.0.0
         version: 1.0.0
     devDependencies:
       '@babel/core':
@@ -103,7 +103,7 @@ importers:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
       rolldown:
-        specifier: 1.0.0
+        specifier: ^1.0.0
         version: 1.0.0
       tsdown:
         specifier: ^0.22.0
@@ -115,7 +115,7 @@ importers:
   packages/plugin-react-swc:
     dependencies:
       '@rolldown/pluginutils':
-        specifier: 1.0.0
+        specifier: ^1.0.0
         version: 1.0.0
       '@swc/core':
         specifier: ^1.15.11
@@ -409,7 +409,7 @@ importers:
   packages/plugin-rsc:
     dependencies:
       '@rolldown/pluginutils':
-        specifier: 1.0.0
+        specifier: ^1.0.0
         version: 1.0.0
       es-module-lexer:
         specifier: ^2.1.0


### PR DESCRIPTION
### Description

- changed all pluginutils requests to carets now that rolldown is at stable 1.0.0 (and to match other deps)