### PR TITLE
ci: remove node 20 and add node 26

### DIFF
--- a/.github/workflows/ci-rsc.yml
+++ b/.github/workflows/ci-rsc.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
       - run: pnpm i
       - run: pnpm build
       - run: pnpm -C packages/plugin-rsc tsc
@@ -63,7 +63,7 @@ jobs:
       - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
       - run: pnpm i
       - name: install react
         if: ${{ matrix.react_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node_version: [20, 22, 24]
+        node_version: [22, 24, 26]
         include:
           # Active LTS + other OS
           - os: macos-latest
@@ -96,7 +96,7 @@ jobs:
     if: github.repository == 'vitejs/vite-plugin-react'
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    name: 'Lint: node-20, ubuntu-latest'
+    name: 'Lint: node-24, ubuntu-latest'
     steps:
       - uses: actions/checkout@v6
         with:
@@ -105,10 +105,10 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
 
-      - name: Set node version to 20
+      - name: Set node version to 24
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install deps
         run: pnpm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,9 @@ jobs:
         include:
           # Active LTS + other OS
           - os: macos-latest
-            node_version: 22
+            node_version: 24
           - os: windows-latest
-            node_version: 22
+            node_version: 24
       fail-fast: false
 
     name: 'Build&Test: node-${{ matrix.node_version }}, ${{ matrix.os }}'

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -23,6 +23,6 @@ jobs:
       - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
       - run: pnpm i
       - run: pnpm exec playwright install chromium


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

- related https://github.com/vitejs/vite-plugin-react/pull/1218#issuecomment-4416808125

This PR replaces Node 20 build/test job with Node 26 and uses Node 24 for lint, fixed setup jobs, and cross-OS coverage, without changing package support metadata.

Tsdown dropped node 20 support and that's blocking renovate PR https://github.com/vitejs/vite-plugin-react/pull/1218