### PR TITLE
chore: pin official actions as well

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,7 +29,6 @@
     {
       matchDepTypes: ['action'],
       pinDigests: true,
-      matchPackageNames: ['!actions/{/,}**', '!github/{/,}**'],
     },
     {
       groupName: 'react-related dependencies',


### PR DESCRIPTION
so that we can enable ["enforce SHA pinning"](https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/#enforce-sha-pinning) setting across the org