### PR TITLE
ci: replace issues-helper action with inline script

### DIFF
--- a/.github/actions/issues-helper/action.yml
+++ b/.github/actions/issues-helper/action.yml
@@ -80,6 +80,7 @@ runs:
 
           let closed = 0
           for (const issue of issues) {
+            if (issue.pull_request) continue
             if (new Date(issue.updated_at) > cutoff) continue
 
             const events = await github.paginate(github.rest.issues.listEvents, {

--- a/.github/actions/issues-helper/action.yml
+++ b/.github/actions/issues-helper/action.yml
@@ -1,18 +1,18 @@
 name: Issues Helper
-description: Add labels, create comments, or close stale issues by label.
+description: Create comments or close stale issues by label.
 inputs:
   actions:
     required: true
-    description: One of `add-labels`, `create-comment`, `close-issues`.
+    description: One of `create-comment`, `close-issues`.
   token:
     required: true
     description: GitHub token.
   issue-number:
     required: false
-    description: Issue or PR number. Required for `add-labels` and `create-comment`.
+    description: Issue number. Required for `create-comment`.
   labels:
     required: false
-    description: Comma-separated label names. Required for `add-labels` and `close-issues`.
+    description: Comma-separated label names. Required for `close-issues`.
   body:
     required: false
     description: Comment body. Required for `create-comment`.
@@ -23,23 +23,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Add labels
-      if: inputs.actions == 'add-labels'
-      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-      env:
-        INPUT_ISSUE_NUMBER: ${{ inputs.issue-number }}
-        INPUT_LABELS: ${{ inputs.labels }}
-      with:
-        github-token: ${{ inputs.token }}
-        script: |
-          const labels = process.env.INPUT_LABELS.split(',').map(label => label.trim()).filter(Boolean)
-          await github.rest.issues.addLabels({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: Number(process.env.INPUT_ISSUE_NUMBER),
-            labels,
-          })
-
     - name: Create comment
       if: inputs.actions == 'create-comment'
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0

--- a/.github/actions/issues-helper/action.yml
+++ b/.github/actions/issues-helper/action.yml
@@ -1,0 +1,132 @@
+name: Issues Helper
+description: Add labels, remove labels, create comments, or close stale issues by label.
+inputs:
+  actions:
+    required: true
+    description: 'Comma-separated list of actions: `add-labels`, `remove-labels`, `create-comment`, `close-issues`.'
+  token:
+    required: true
+    description: GitHub token.
+  issue-number:
+    required: false
+    description: Issue or PR number. Required for `add-labels`, `remove-labels`, and `create-comment`.
+  labels:
+    required: false
+    description: Comma-separated label names. Required for `add-labels`, `remove-labels`, and `close-issues`.
+  body:
+    required: false
+    description: Comment body. Required for `create-comment`.
+  inactive-day:
+    required: false
+    description: Close issues whose matching label was added at least this many days ago and have had no activity since then. Required for `close-issues`.
+
+runs:
+  using: composite
+  steps:
+    - name: Add labels
+      if: contains(inputs.actions, 'add-labels')
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+      env:
+        INPUT_ISSUE_NUMBER: ${{ inputs.issue-number }}
+        INPUT_LABELS: ${{ inputs.labels }}
+      with:
+        github-token: ${{ inputs.token }}
+        script: |
+          const labels = process.env.INPUT_LABELS.split(',').map(label => label.trim()).filter(Boolean)
+          await github.rest.issues.addLabels({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: Number(process.env.INPUT_ISSUE_NUMBER),
+            labels,
+          })
+
+    - name: Create comment
+      if: contains(inputs.actions, 'create-comment')
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+      env:
+        INPUT_ISSUE_NUMBER: ${{ inputs.issue-number }}
+        INPUT_BODY: ${{ inputs.body }}
+      with:
+        github-token: ${{ inputs.token }}
+        script: |
+          await github.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: Number(process.env.INPUT_ISSUE_NUMBER),
+            body: process.env.INPUT_BODY,
+          })
+
+    - name: Remove labels
+      if: contains(inputs.actions, 'remove-labels')
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+      env:
+        INPUT_ISSUE_NUMBER: ${{ inputs.issue-number }}
+        INPUT_LABELS: ${{ inputs.labels }}
+      with:
+        github-token: ${{ inputs.token }}
+        script: |
+          const labels = process.env.INPUT_LABELS.split(',').map(label => label.trim()).filter(Boolean)
+          for (const name of labels) {
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: Number(process.env.INPUT_ISSUE_NUMBER),
+                name,
+              })
+            } catch (error) {
+              if (error.status !== 404) throw error
+            }
+          }
+
+    - name: Close stale issues
+      if: contains(inputs.actions, 'close-issues')
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+      env:
+        INPUT_LABELS: ${{ inputs.labels }}
+        INPUT_INACTIVE_DAY: ${{ inputs.inactive-day }}
+      with:
+        github-token: ${{ inputs.token }}
+        script: |
+          const labels = process.env.INPUT_LABELS
+          const inactiveDay = Number(process.env.INPUT_INACTIVE_DAY)
+          const cutoff = new Date(Date.now() - inactiveDay * 24 * 60 * 60 * 1000)
+          const labelSet = new Set(labels.split(',').map(label => label.trim()).filter(Boolean))
+
+          const issues = await github.paginate(github.rest.issues.listForRepo, {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            state: 'open',
+            labels,
+            per_page: 100,
+          })
+
+          let closed = 0
+          for (const issue of issues) {
+            if (new Date(issue.updated_at) > cutoff) continue
+
+            const events = await github.paginate(github.rest.issues.listEvents, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              per_page: 100,
+            })
+            const labeledAt = events
+              .filter(event => event.event === 'labeled' && labelSet.has(event.label?.name))
+              .at(-1)?.created_at
+
+            if (!labeledAt || new Date(labeledAt) > cutoff) continue
+
+            console.log(`Closing #${issue.number}, labeled at ${labeledAt}, updated at ${issue.updated_at}`)
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              state: 'closed',
+            })
+            closed++
+          }
+
+          if (closed === 0) {
+            console.log(`No stale items with label "${labels}" found`)
+          }

--- a/.github/actions/issues-helper/action.yml
+++ b/.github/actions/issues-helper/action.yml
@@ -3,7 +3,7 @@ description: Add labels, create comments, or close stale issues by label.
 inputs:
   actions:
     required: true
-    description: 'Comma-separated list of actions: `add-labels`, `create-comment`, `close-issues`.'
+    description: One of `add-labels`, `create-comment`, `close-issues`.
   token:
     required: true
     description: GitHub token.
@@ -24,7 +24,7 @@ runs:
   using: composite
   steps:
     - name: Add labels
-      if: contains(inputs.actions, 'add-labels')
+      if: inputs.actions == 'add-labels'
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       env:
         INPUT_ISSUE_NUMBER: ${{ inputs.issue-number }}
@@ -41,7 +41,7 @@ runs:
           })
 
     - name: Create comment
-      if: contains(inputs.actions, 'create-comment')
+      if: inputs.actions == 'create-comment'
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       env:
         INPUT_ISSUE_NUMBER: ${{ inputs.issue-number }}
@@ -57,7 +57,7 @@ runs:
           })
 
     - name: Close stale issues
-      if: contains(inputs.actions, 'close-issues')
+      if: inputs.actions == 'close-issues'
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       env:
         INPUT_LABELS: ${{ inputs.labels }}

--- a/.github/actions/issues-helper/action.yml
+++ b/.github/actions/issues-helper/action.yml
@@ -1,18 +1,18 @@
 name: Issues Helper
-description: Add labels, remove labels, create comments, or close stale issues by label.
+description: Add labels, create comments, or close stale issues by label.
 inputs:
   actions:
     required: true
-    description: 'Comma-separated list of actions: `add-labels`, `remove-labels`, `create-comment`, `close-issues`.'
+    description: 'Comma-separated list of actions: `add-labels`, `create-comment`, `close-issues`.'
   token:
     required: true
     description: GitHub token.
   issue-number:
     required: false
-    description: Issue or PR number. Required for `add-labels`, `remove-labels`, and `create-comment`.
+    description: Issue or PR number. Required for `add-labels` and `create-comment`.
   labels:
     required: false
-    description: Comma-separated label names. Required for `add-labels`, `remove-labels`, and `close-issues`.
+    description: Comma-separated label names. Required for `add-labels` and `close-issues`.
   body:
     required: false
     description: Comment body. Required for `create-comment`.
@@ -55,29 +55,6 @@ runs:
             issue_number: Number(process.env.INPUT_ISSUE_NUMBER),
             body: process.env.INPUT_BODY,
           })
-
-    - name: Remove labels
-      if: contains(inputs.actions, 'remove-labels')
-      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-      env:
-        INPUT_ISSUE_NUMBER: ${{ inputs.issue-number }}
-        INPUT_LABELS: ${{ inputs.labels }}
-      with:
-        github-token: ${{ inputs.token }}
-        script: |
-          const labels = process.env.INPUT_LABELS.split(',').map(label => label.trim()).filter(Boolean)
-          for (const name of labels) {
-            try {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: Number(process.env.INPUT_ISSUE_NUMBER),
-                name,
-              })
-            } catch (error) {
-              if (error.status !== 404) throw error
-            }
-          }
 
     - name: Close stale issues
       if: contains(inputs.actions, 'close-issues')

--- a/.github/workflows/issue-close-require.yml
+++ b/.github/workflows/issue-close-require.yml
@@ -9,56 +9,18 @@ jobs:
     if: github.repository == 'vitejs/vite-plugin-react'
     runs-on: ubuntu-latest
     permissions:
+      contents: read # to check out the repo for local actions
       issues: write # to close stale issues
       pull-requests: write # to close stale PRs
     steps:
-      - name: need reproduction
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        env:
-          LABELS: need reproduction
-          INACTIVE_DAY: 3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const labels = process.env.LABELS
-            const inactiveDay = Number(process.env.INACTIVE_DAY)
-            const cutoff = new Date(Date.now() - inactiveDay * 24 * 60 * 60 * 1000)
-            const labelSet = new Set(labels.split(',').map(label => label.trim()))
+          persist-credentials: false
 
-            const issues = await github.paginate(github.rest.issues.listForRepo, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels,
-              per_page: 100,
-            })
-
-            let closed = 0
-            for (const issue of issues) {
-              if (new Date(issue.updated_at) > cutoff) continue
-
-              const events = await github.paginate(github.rest.issues.listEvents, {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                per_page: 100,
-              })
-              const labeledAt = events
-                .filter(event => event.event === 'labeled' && labelSet.has(event.label?.name))
-                .at(-1)?.created_at
-
-              if (!labeledAt || new Date(labeledAt) > cutoff) continue
-
-              console.log(`Closing #${issue.number}, labeled at ${labeledAt}, updated at ${issue.updated_at}`)
-              await github.rest.issues.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                state: 'closed',
-              })
-              closed++
-            }
-
-            if (closed === 0) {
-              console.log(`No stale items with label "${labels}" found`)
-            }
+      - name: need reproduction
+        uses: ./.github/actions/issues-helper
+        with:
+          actions: close-issues
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: need reproduction
+          inactive-day: 3

--- a/.github/workflows/issue-close-require.yml
+++ b/.github/workflows/issue-close-require.yml
@@ -9,13 +9,56 @@ jobs:
     if: github.repository == 'vitejs/vite-plugin-react'
     runs-on: ubuntu-latest
     permissions:
-      issues: write # for actions-cool/issues-helper to update issues
-      pull-requests: write # for actions-cool/issues-helper to update PRs
+      issues: write # to close stale issues
+      pull-requests: write # to close stale PRs
     steps:
       - name: need reproduction
-        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          LABELS: need reproduction
+          INACTIVE_DAY: 3
         with:
-          actions: 'close-issues'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          labels: 'need reproduction'
-          inactive-day: 3
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const labels = process.env.LABELS
+            const inactiveDay = Number(process.env.INACTIVE_DAY)
+            const cutoff = new Date(Date.now() - inactiveDay * 24 * 60 * 60 * 1000)
+            const labelSet = new Set(labels.split(',').map(label => label.trim()))
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels,
+              per_page: 100,
+            })
+
+            let closed = 0
+            for (const issue of issues) {
+              if (new Date(issue.updated_at) > cutoff) continue
+
+              const events = await github.paginate(github.rest.issues.listEvents, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                per_page: 100,
+              })
+              const labeledAt = events
+                .filter(event => event.event === 'labeled' && labelSet.has(event.label?.name))
+                .at(-1)?.created_at
+
+              if (!labeledAt || new Date(labeledAt) > cutoff) continue
+
+              console.log(`Closing #${issue.number}, labeled at ${labeledAt}, updated at ${issue.updated_at}`)
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+              })
+              closed++
+            }
+
+            if (closed === 0) {
+              console.log(`No stale items with label "${labels}" found`)
+            }

--- a/.github/workflows/issue-close-require.yml
+++ b/.github/workflows/issue-close-require.yml
@@ -11,7 +11,6 @@ jobs:
     permissions:
       contents: read # to check out the repo for local actions
       issues: write # to close stale issues
-      pull-requests: write # to close stale PRs
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/issue-close-require.yml
+++ b/.github/workflows/issue-close-require.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+          ref: main
 
       - name: need reproduction
         uses: ./.github/actions/issues-helper

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -10,8 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # to check out the repo for local actions
-      issues: write # to comment on and update issues
-      pull-requests: write # to update PR labels
+      issues: write # to comment on issues
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -22,29 +21,18 @@ jobs:
         if: github.event.label.name == 'contribution welcome' || github.event.label.name == 'help wanted'
         uses: ./.github/actions/issues-helper
         with:
-          actions: create-comment, remove-labels
+          actions: create-comment
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.issue.number }}
           body: |
             Hello @${{ github.event.issue.user.login }}. We like your proposal/feedback and would appreciate a contribution via a Pull Request by you or another community member. We thank you in advance for your contribution and are looking forward to reviewing it!
-          labels: pending triage, need reproduction
-
-      - name: remove pending
-        if: (github.event.label.name == 'enhancement' || contains(github.event.label.description, '(priority)')) && contains(github.event.issue.labels.*.name, 'pending triage')
-        uses: ./.github/actions/issues-helper
-        with:
-          actions: remove-labels
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          labels: pending triage
 
       - name: need reproduction
         if: github.event.label.name == 'need reproduction'
         uses: ./.github/actions/issues-helper
         with:
-          actions: create-comment, remove-labels
+          actions: create-comment
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.issue.number }}
           body: |
             Hello @${{ github.event.issue.user.login }}. Please provide a [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) using a GitHub repository or [StackBlitz](https://vite.new). Issues marked with `need reproduction` will be closed if they have no activity within 3 days.
-          labels: pending triage

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -9,92 +9,42 @@ jobs:
     if: github.repository == 'vitejs/vite-plugin-react'
     runs-on: ubuntu-latest
     permissions:
+      contents: read # to check out the repo for local actions
       issues: write # to comment on and update issues
       pull-requests: write # to update PR labels
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          ref: main
+
       - name: contribution welcome
         if: github.event.label.name == 'contribution welcome' || github.event.label.name == 'help wanted'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        env:
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          BODY: |
-            Hello @${{ github.event.issue.user.login }}. We like your proposal/feedback and would appreciate a contribution via a Pull Request by you or another community member. We thank you in advance for your contribution and are looking forward to reviewing it!
-          LABELS: pending triage, need reproduction
+        uses: ./.github/actions/issues-helper
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const issue_number = Number(process.env.ISSUE_NUMBER)
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number,
-              body: process.env.BODY,
-            })
-
-            for (const name of process.env.LABELS.split(',').map(label => label.trim())) {
-              try {
-                await github.rest.issues.removeLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number,
-                  name,
-                })
-              } catch (error) {
-                if (error.status !== 404) throw error
-              }
-            }
+          actions: create-comment, remove-labels
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            Hello @${{ github.event.issue.user.login }}. We like your proposal/feedback and would appreciate a contribution via a Pull Request by you or another community member. We thank you in advance for your contribution and are looking forward to reviewing it!
+          labels: pending triage, need reproduction
 
       - name: remove pending
         if: (github.event.label.name == 'enhancement' || contains(github.event.label.description, '(priority)')) && contains(github.event.issue.labels.*.name, 'pending triage')
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        env:
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          LABELS: pending triage
+        uses: ./.github/actions/issues-helper
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const issue_number = Number(process.env.ISSUE_NUMBER)
-            for (const name of process.env.LABELS.split(',').map(label => label.trim())) {
-              try {
-                await github.rest.issues.removeLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number,
-                  name,
-                })
-              } catch (error) {
-                if (error.status !== 404) throw error
-              }
-            }
+          actions: remove-labels
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          labels: pending triage
 
       - name: need reproduction
         if: github.event.label.name == 'need reproduction'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        env:
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          BODY: |
-            Hello @${{ github.event.issue.user.login }}. Please provide a [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) using a GitHub repository or [StackBlitz](https://vite.new). Issues marked with `need reproduction` will be closed if they have no activity within 3 days.
-          LABELS: pending triage
+        uses: ./.github/actions/issues-helper
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const issue_number = Number(process.env.ISSUE_NUMBER)
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number,
-              body: process.env.BODY,
-            })
-
-            for (const name of process.env.LABELS.split(',').map(label => label.trim())) {
-              try {
-                await github.rest.issues.removeLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number,
-                  name,
-                })
-              } catch (error) {
-                if (error.status !== 404) throw error
-              }
-            }
+          actions: create-comment, remove-labels
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            Hello @${{ github.event.issue.user.login }}. Please provide a [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) using a GitHub repository or [StackBlitz](https://vite.new). Issues marked with `need reproduction` will be closed if they have no activity within 3 days.
+          labels: pending triage

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -9,36 +9,92 @@ jobs:
     if: github.repository == 'vitejs/vite-plugin-react'
     runs-on: ubuntu-latest
     permissions:
-      issues: write # for actions-cool/issues-helper to update issues
-      pull-requests: write # for actions-cool/issues-helper to update PRs
+      issues: write # to comment on and update issues
+      pull-requests: write # to update PR labels
     steps:
       - name: contribution welcome
         if: github.event.label.name == 'contribution welcome' || github.event.label.name == 'help wanted'
-        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
-        with:
-          actions: 'create-comment, remove-labels'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          body: |
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          BODY: |
             Hello @${{ github.event.issue.user.login }}. We like your proposal/feedback and would appreciate a contribution via a Pull Request by you or another community member. We thank you in advance for your contribution and are looking forward to reviewing it!
-          labels: 'pending triage, need reproduction'
+          LABELS: pending triage, need reproduction
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issue_number = Number(process.env.ISSUE_NUMBER)
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              body: process.env.BODY,
+            })
+
+            for (const name of process.env.LABELS.split(',').map(label => label.trim())) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number,
+                  name,
+                })
+              } catch (error) {
+                if (error.status !== 404) throw error
+              }
+            }
 
       - name: remove pending
         if: (github.event.label.name == 'enhancement' || contains(github.event.label.description, '(priority)')) && contains(github.event.issue.labels.*.name, 'pending triage')
-        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          LABELS: pending triage
         with:
-          actions: 'remove-labels'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          labels: 'pending triage'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issue_number = Number(process.env.ISSUE_NUMBER)
+            for (const name of process.env.LABELS.split(',').map(label => label.trim())) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number,
+                  name,
+                })
+              } catch (error) {
+                if (error.status !== 404) throw error
+              }
+            }
 
       - name: need reproduction
         if: github.event.label.name == 'need reproduction'
-        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
-        with:
-          actions: 'create-comment, remove-labels'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          body: |
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          BODY: |
             Hello @${{ github.event.issue.user.login }}. Please provide a [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) using a GitHub repository or [StackBlitz](https://vite.new). Issues marked with `need reproduction` will be closed if they have no activity within 3 days.
-          labels: 'pending triage'
+          LABELS: pending triage
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issue_number = Number(process.env.ISSUE_NUMBER)
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              body: process.env.BODY,
+            })
+
+            for (const name of process.env.LABELS.split(',').map(label => label.trim())) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number,
+                  name,
+                })
+              } catch (error) {
+                if (error.status !== 404) throw error
+              }
+            }


### PR DESCRIPTION
### Description

This removes our dependency on `actions-cool/issues-helper` because the action was taken down after a reported vulnerability and zizmor fails. The script is mostly copied from Vitest https://github.com/vitest-dev/vitest/pull/10416 

As side cleanup, I removed auto "pending triage" label removal since that automation doesn't seem to add much when you already manually adding labels.