### PR TITLE
docs: mention the Biome rule in the "Consistent components exports" section

### DIFF
--- a/packages/plugin-react/README.md
+++ b/packages/plugin-react/README.md
@@ -166,4 +166,4 @@ For React refresh to work correctly, your file should only export React componen
 
 If an incompatible change in exports is found, the module will be invalidated and HMR will propagate. To make it easier to export simple constants alongside your component, the module is only invalidated when their value changes.
 
-You can catch mistakes and get more detailed warnings with this [ESLint rule](https://github.com/ArnaudBarre/eslint-plugin-react-refresh), or the equivalent [Oxlint rule](https://oxc.rs/docs/guide/usage/linter/rules/react/only-export-components.html).
+You can catch mistakes and get more detailed warnings with this [ESLint rule](https://github.com/ArnaudBarre/eslint-plugin-react-refresh), this [Oxlint rule](https://oxc.rs/docs/guide/usage/linter/rules/react/only-export-components.html), or this [Biome rule](https://biomejs.dev/linter/rules/use-component-export-only-modules).


### PR DESCRIPTION
### Description

Mention the [Biome rule](https://biomejs.dev/linter/rules/use-component-export-only-modules/) in the [Consistent components exports](https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-react#consistent-components-exports) section, in addition to ESLint and Oxlint.