### PR TITLE
feat(rsc): support inline server action methods

### DIFF
--- a/packages/plugin-rsc/src/transforms/hoist.test.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.test.ts
@@ -521,12 +521,30 @@ class Actions {
 }
 `
     const transformed = await testTransform(input)
-    expect(transformed).toContain('cached: /* #__PURE__ */')
-    expect(transformed).toContain('"computed": /* #__PURE__ */')
-    expect(transformed).toContain('static cached = /* #__PURE__ */')
-    expect(transformed).toContain('static ["computed"] = /* #__PURE__ */')
-    expect(transformed).toContain('value: "cached"')
-    expect(transformed).toContain('value: "computed"')
+    expect(transformed).toMatchInlineSnapshot(`
+      "
+      const object = {
+        cached: /* #__PURE__ */ $$register($$hoist_0_cached, "<id>", "$$hoist_0_cached"),
+        "computed": /* #__PURE__ */ $$register($$hoist_1_computed, "<id>", "$$hoist_1_computed"),
+      };
+      class Actions {
+        static cached = /* #__PURE__ */ $$register($$hoist_2_cached, "<id>", "$$hoist_2_cached");
+        static ["computed"] = /* #__PURE__ */ $$register($$hoist_3_computed, "<id>", "$$hoist_3_computed");
+      }
+
+      ;export async function $$hoist_0_cached() { "use server"; return 1 };
+      /* #__PURE__ */ Object.defineProperty($$hoist_0_cached, "name", { value: "cached" });
+
+      ;export async function $$hoist_1_computed() { "use server"; return 2 };
+      /* #__PURE__ */ Object.defineProperty($$hoist_1_computed, "name", { value: "computed" });
+
+      ;export async function $$hoist_2_cached() { "use server"; return 3 };
+      /* #__PURE__ */ Object.defineProperty($$hoist_2_cached, "name", { value: "cached" });
+
+      ;export async function $$hoist_3_computed() { "use server"; return 4 };
+      /* #__PURE__ */ Object.defineProperty($$hoist_3_computed, "name", { value: "computed" });
+      "
+    `)
     await parseAstAsync(transformed!)
   })
 

--- a/packages/plugin-rsc/src/transforms/hoist.test.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.test.ts
@@ -508,4 +508,36 @@ export async function test() {
       "
     `)
   })
+
+  it('supports object and static class methods', async () => {
+    const input = `
+const object = {
+  async cached() { "use server"; return 1 },
+  async ["computed"]() { "use server"; return 2 },
+};
+class Actions {
+  static async cached() { "use server"; return 3 }
+  static async ["computed"]() { "use server"; return 4 }
+}
+`
+    const transformed = await testTransform(input)
+    expect(transformed).toContain('cached: /* #__PURE__ */')
+    expect(transformed).toContain('"computed": /* #__PURE__ */')
+    expect(transformed).toContain('static cached = /* #__PURE__ */')
+    expect(transformed).toContain('static ["computed"] = /* #__PURE__ */')
+    expect(transformed).toContain('value: "cached"')
+    expect(transformed).toContain('value: "computed"')
+    await parseAstAsync(transformed!)
+  })
+
+  it('rejects unsupported method forms', async () => {
+    for (const input of [
+      `class Actions { async action() { "use server" } }`,
+      `class Actions { static async #action() { "use server" } }`,
+      `const actions = { get action() { "use server"; return 1 } }`,
+      `class Actions { static set action(value) { "use server" } }`,
+    ]) {
+      await expect(testTransform(input)).rejects.toThrow(/not allowed/)
+    }
+  })
 })

--- a/packages/plugin-rsc/src/transforms/hoist.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.ts
@@ -65,12 +65,60 @@ export function transformHoistInlineDirective(
           )
         }
 
+        const isObjectMethod =
+          node.type === 'FunctionExpression' &&
+          parent?.type === 'Property' &&
+          (parent.method || parent.kind !== 'init')
+        const isClassMethod =
+          node.type === 'FunctionExpression' &&
+          parent?.type === 'MethodDefinition'
+        if (isClassMethod && !parent.static) {
+          throw Object.assign(
+            new Error(
+              `It is not allowed to define inline ${JSON.stringify(match[0])} annotated class instance methods. Use a function, object method property, or static class method instead.`,
+            ),
+            { pos: parent.start },
+          )
+        }
+        if (isClassMethod && parent.key.type === 'PrivateIdentifier') {
+          throw Object.assign(
+            new Error(
+              `It is not allowed to define inline ${JSON.stringify(match[0])} annotated private class methods.`,
+            ),
+            { pos: parent.start },
+          )
+        }
+        if (
+          (isObjectMethod && parent.kind !== 'init') ||
+          (isClassMethod && parent.kind !== 'method')
+        ) {
+          throw Object.assign(
+            new Error(
+              `It is not allowed to define inline ${JSON.stringify(match[0])} annotated getters or setters.`,
+            ),
+            { pos: parent.start },
+          )
+        }
+
         const declName = node.type === 'FunctionDeclaration' && node.id.name
+        const expressionName =
+          node.type === 'FunctionExpression' ? node.id?.name : undefined
+        const methodName =
+          (isObjectMethod || isClassMethod) &&
+          (parent.key.type === 'Identifier' || parent.key.type === 'Literal')
+            ? String(
+                parent.key.type === 'Identifier'
+                  ? parent.key.name
+                  : parent.key.value,
+              )
+            : undefined
         const originalName =
           declName ||
+          methodName ||
           (parent?.type === 'VariableDeclarator' &&
             parent.id.type === 'Identifier' &&
             parent.id.name) ||
+          expressionName ||
           'anonymous_server_function'
 
         const bindVars = getBindVars(node, scopeTree)
@@ -120,7 +168,19 @@ export function transformHoistInlineDirective(
             : bindVars.map((b) => b.expr).join(', ')
           newCode = `${newCode}.bind(null, ${bindArgs})`
         }
-        if (declName) {
+        if (isObjectMethod) {
+          output.update(
+            parent.start,
+            node.start,
+            `${input.slice(parent.key.start, parent.key.end)}: `,
+          )
+        } else if (isClassMethod) {
+          const key = parent.computed
+            ? `[${input.slice(parent.key.start, parent.key.end)}]`
+            : input.slice(parent.key.start, parent.key.end)
+          output.update(parent.start, node.start, `static ${key} = `)
+          newCode += ';'
+        } else if (declName) {
           newCode = `const ${declName} = ${newCode};`
           if (parent?.type === 'ExportDefaultDeclaration') {
             output.remove(parent.start, node.start)

--- a/packages/plugin-rsc/src/transforms/hoist.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.ts
@@ -65,29 +65,32 @@ export function transformHoistInlineDirective(
           )
         }
 
+        const isClassMethod =
+          node.type === 'FunctionExpression' &&
+          parent?.type === 'MethodDefinition'
+        if (isClassMethod) {
+          if (!parent.static) {
+            throw Object.assign(
+              new Error(
+                `It is not allowed to define inline ${JSON.stringify(match[0])} annotated class instance methods. Use a function, object method property, or static class method instead.`,
+              ),
+              { pos: parent.start },
+            )
+          }
+          if (parent.key.type === 'PrivateIdentifier') {
+            throw Object.assign(
+              new Error(
+                `It is not allowed to define inline ${JSON.stringify(match[0])} annotated private class methods.`,
+              ),
+              { pos: parent.start },
+            )
+          }
+        }
+
         const isObjectMethod =
           node.type === 'FunctionExpression' &&
           parent?.type === 'Property' &&
           (parent.method || parent.kind !== 'init')
-        const isClassMethod =
-          node.type === 'FunctionExpression' &&
-          parent?.type === 'MethodDefinition'
-        if (isClassMethod && !parent.static) {
-          throw Object.assign(
-            new Error(
-              `It is not allowed to define inline ${JSON.stringify(match[0])} annotated class instance methods. Use a function, object method property, or static class method instead.`,
-            ),
-            { pos: parent.start },
-          )
-        }
-        if (isClassMethod && parent.key.type === 'PrivateIdentifier') {
-          throw Object.assign(
-            new Error(
-              `It is not allowed to define inline ${JSON.stringify(match[0])} annotated private class methods.`,
-            ),
-            { pos: parent.start },
-          )
-        }
         if (
           (isObjectMethod && parent.kind !== 'init') ||
           (isClassMethod && parent.kind !== 'method')


### PR DESCRIPTION
Extracted from #1246.

Inline `"use server"` transforms currently produce invalid output for object methods and static class methods because method syntax cannot be replaced like a standalone function expression.

This rewrites supported methods to property/field assignments and gives their hoists method-derived names. Tests cover identifier and computed object/static methods, plus explicit errors for instance, private, getter, and setter methods.