### PR TITLE
fix(rsc): reset stateful directive regexes

### DIFF
--- a/packages/plugin-rsc/src/transforms/hoist.test.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.test.ts
@@ -508,4 +508,20 @@ export async function test() {
       "
     `)
   })
+
+  it.each([/^use server$/g, /^use server$/y])(
+    'resets stateful directive regexes: %s',
+    async (directive) => {
+      const input = `
+export async function one() { "use server" }
+export async function two() { "use server" }
+`
+      const first = await testTransform(input, { directive })
+      const second = await testTransform(input, { directive })
+      expect(first).toContain('$$hoist_0_one')
+      expect(first).toContain('$$hoist_1_two')
+      expect(second).toBe(first)
+      expect(directive.lastIndex).toBe(0)
+    },
+  )
 })

--- a/packages/plugin-rsc/src/transforms/hoist.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.ts
@@ -151,7 +151,9 @@ function matchDirective(
       stmt.expression.type === 'Literal' &&
       typeof stmt.expression.value === 'string'
     ) {
+      directive.lastIndex = 0
       const match = stmt.expression.value.match(directive)
+      directive.lastIndex = 0
       if (match) {
         return { match, node: stmt.expression }
       }


### PR DESCRIPTION
Extracted from #1246.

Global and sticky directive regexes retain `lastIndex`, so later functions or repeated transforms can miss matching directives.

This resets regex state around each match. Tests cover both `g` and `y` regexes, multiple functions, repeated transforms, and the final `lastIndex`.