### PR TITLE
feat(rsc): support stable inline action names

### DIFF
--- a/packages/plugin-rsc/src/transforms/hoist.test.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.test.ts
@@ -90,6 +90,16 @@ describe(transformHoistInlineDirective, () => {
     return result.names
   }
 
+  async function testStableTransformNames(input: string) {
+    const ast = await parseAstAsync(input)
+    return transformHoistInlineDirective(input, ast, {
+      runtime: (value, name) =>
+        `$$register(${value}, "<id>", ${JSON.stringify(name)})`,
+      directive: 'use server',
+      stableName: true,
+    }).names
+  }
+
   it('none', async () => {
     const input = `
 const x = "x";
@@ -507,5 +517,47 @@ export async function test() {
       /* #__PURE__ */ Object.defineProperty($$hoist_0_test, "name", { value: "test" });
       "
     `)
+  })
+
+  it('keeps hoist names stable across unrelated insertions', async () => {
+    const original = `
+async function action() { "use server"; return 1 }
+`
+    const withUnrelatedAction = `
+async function unrelated() { "use server"; return 0 }
+${original}
+`
+    const [originalName] = await testStableTransformNames(original)
+    const [, shiftedName] = await testStableTransformNames(withUnrelatedAction)
+    expect(shiftedName).toBe(originalName)
+    expect(originalName).toMatch(/^\$\$hoist_[a-f0-9]{12}_0_action$/)
+  })
+
+  it('changes stable hoist names when the function changes', async () => {
+    const [firstName] = await testStableTransformNames(
+      `async function action() { "use server"; return 1 }`,
+    )
+    const [secondName] = await testStableTransformNames(
+      `async function action() { "use server"; return 2 }`,
+    )
+    expect(secondName).not.toBe(firstName)
+  })
+
+  it('disambiguates duplicate stable hoist signatures', async () => {
+    const names = await testStableTransformNames(`
+const actions = [
+  async function() { "use server" },
+  async function() { "use server" },
+]
+`)
+    expect(names).toHaveLength(2)
+    expect(names[0]).toMatch(/_0_anonymous_server_function$/)
+    expect(names[1]).toMatch(/_1_anonymous_server_function$/)
+    expect(
+      names[1]!.replace(
+        '_1_anonymous_server_function',
+        '_0_anonymous_server_function',
+      ),
+    ).toBe(names[0])
   })
 })

--- a/packages/plugin-rsc/src/transforms/hoist.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.ts
@@ -8,6 +8,7 @@ import type {
 } from 'estree'
 import { walk } from 'estree-walker'
 import MagicString from 'magic-string'
+import { hashString } from '../plugins/utils'
 import { buildScopeTree, type ScopeTree } from './scope'
 
 export function transformHoistInlineDirective(
@@ -28,6 +29,7 @@ export function transformHoistInlineDirective(
     encode?: (value: string) => string
     decode?: (value: string) => string
     noExport?: boolean
+    stableName?: boolean
   },
 ): {
   output: MagicString
@@ -45,6 +47,7 @@ export function transformHoistInlineDirective(
 
   const scopeTree = buildScopeTree(ast)
   const names: string[] = []
+  const signatureCounts = new Map<string, number>()
 
   walk(ast, {
     enter(node, parent) {
@@ -92,8 +95,15 @@ export function transformHoistInlineDirective(
         }
 
         // append a new `FunctionDeclaration` at the end
+        let nameKey = String(names.length)
+        if (options.stableName) {
+          const signature = `${originalName}:${input.slice(node.start, node.end)}`
+          const signatureCount = signatureCounts.get(signature) ?? 0
+          signatureCounts.set(signature, signatureCount + 1)
+          nameKey = `${hashString(signature)}_${signatureCount}`
+        }
         const newName =
-          `$$hoist_${names.length}` + (originalName ? `_${originalName}` : '')
+          `$$hoist_${nameKey}` + (originalName ? `_${originalName}` : '')
         names.push(newName)
         output.update(
           node.start,

--- a/packages/plugin-rsc/src/transforms/server-action.ts
+++ b/packages/plugin-rsc/src/transforms/server-action.ts
@@ -15,6 +15,7 @@ export function transformServerActionServer(
     rejectNonAsyncFunction?: boolean
     encode?: (value: string) => string
     decode?: (value: string) => string
+    stableName?: boolean
   },
 ):
   | {


### PR DESCRIPTION
Extracted from #1246.

Inline action hoist names are currently based on traversal order, so inserting an unrelated action renumbers existing server-reference IDs.

This adds an opt-in `stableName` transform option using a content-derived hash with duplicate disambiguation. Tests verify stability across unrelated insertions, changes when the function changes, and deterministic duplicate handling.