### PR TITLE
feat(rsc): expose server function metadata

### DIFF
--- a/packages/plugin-rsc/src/transforms/hoist.test.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.test.ts
@@ -466,11 +466,11 @@ export async function kv() {
       }),
     ).toMatchInlineSnapshot(`
       "
-      export const none = /* #__PURE__ */ $$register($$hoist_0_none, "<id>", "$$hoist_0_none", {"directiveMatch":["use cache",null]});
+      export const none = /* #__PURE__ */ $$register($$hoist_0_none, "<id>", "$$hoist_0_none", {"directiveMatch":["use cache",null],"hasBoundArgs":false,"parameters":{"count":0,"hasRest":false}});
 
-      export const fs = /* #__PURE__ */ $$register($$hoist_1_fs, "<id>", "$$hoist_1_fs", {"directiveMatch":["use cache: fs",": fs"]});
+      export const fs = /* #__PURE__ */ $$register($$hoist_1_fs, "<id>", "$$hoist_1_fs", {"directiveMatch":["use cache: fs",": fs"],"hasBoundArgs":false,"parameters":{"count":0,"hasRest":false}});
 
-      export const kv = /* #__PURE__ */ $$register($$hoist_2_kv, "<id>", "$$hoist_2_kv", {"directiveMatch":["use cache: kv",": kv"]});
+      export const kv = /* #__PURE__ */ $$register($$hoist_2_kv, "<id>", "$$hoist_2_kv", {"directiveMatch":["use cache: kv",": kv"],"hasBoundArgs":false,"parameters":{"count":0,"hasRest":false}});
 
       ;async function $$hoist_0_none() {
         "use cache";
@@ -507,5 +507,32 @@ export async function test() {
       /* #__PURE__ */ Object.defineProperty($$hoist_0_test, "name", { value: "test" });
       "
     `)
+  })
+
+  it('reports parameter and bound argument metadata', async () => {
+    const input = `
+function outer(captured) {
+  return async function action(first, ...rest) {
+    "use server";
+    return [captured, first, rest];
+  }
+}
+`
+    const ast = await parseAstAsync(input)
+    const metadata: unknown[] = []
+    transformHoistInlineDirective(input, ast, {
+      runtime: (value, _name, meta) => {
+        metadata.push(meta)
+        return value
+      },
+      directive: 'use server',
+    })
+    expect(metadata).toEqual([
+      {
+        directiveMatch: expect.any(Array),
+        hasBoundArgs: true,
+        parameters: { count: 2, hasRest: true },
+      },
+    ])
   })
 })

--- a/packages/plugin-rsc/src/transforms/hoist.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.ts
@@ -9,6 +9,7 @@ import type {
 import { walk } from 'estree-walker'
 import MagicString from 'magic-string'
 import { buildScopeTree, type ScopeTree } from './scope'
+import type { FunctionParameters } from './wrap-export'
 
 export function transformHoistInlineDirective(
   input: string,
@@ -21,7 +22,11 @@ export function transformHoistInlineDirective(
     runtime: (
       value: string,
       name: string,
-      meta: { directiveMatch: RegExpMatchArray },
+      meta: {
+        directiveMatch: RegExpMatchArray
+        hasBoundArgs: boolean
+        parameters: FunctionParameters
+      },
     ) => string
     directive: string | RegExp
     rejectNonAsyncFunction?: boolean
@@ -113,6 +118,13 @@ export function transformHoistInlineDirective(
         // replace original declartion with action register + bind
         let newCode = `/* #__PURE__ */ ${runtime(newName, newName, {
           directiveMatch: match,
+          hasBoundArgs: bindVars.length > 0,
+          parameters: {
+            count: node.params.length,
+            hasRest: node.params.some(
+              (parameter) => parameter.type === 'RestElement',
+            ),
+          },
         })}`
         if (bindVars.length > 0) {
           const bindArgs = options.encode

--- a/packages/plugin-rsc/src/transforms/wrap-export.test.ts
+++ b/packages/plugin-rsc/src/transforms/wrap-export.test.ts
@@ -314,4 +314,54 @@ export default Page;
       "
     `)
   })
+
+  test('reports function parameter metadata for export forms', async () => {
+    const input = `
+export async function named(first, ...rest) {}
+export const arrow = async (first, second) => {}
+async function local(...args) {}
+export { local as renamed }
+export default local
+`
+    const ast = await parseAstAsync(input)
+    const metadata = new Map<string, unknown>()
+    transformWrapExport(input, ast, {
+      runtime: (value, name, meta) => {
+        metadata.set(name, meta)
+        return value
+      },
+    })
+    expect(metadata).toEqual(
+      new Map([
+        [
+          'named',
+          expect.objectContaining({
+            isFunction: true,
+            parameters: { count: 2, hasRest: true },
+          }),
+        ],
+        [
+          'arrow',
+          expect.objectContaining({
+            isFunction: true,
+            parameters: { count: 2, hasRest: false },
+          }),
+        ],
+        [
+          'renamed',
+          expect.objectContaining({
+            isFunction: true,
+            parameters: { count: 1, hasRest: true },
+          }),
+        ],
+        [
+          'default',
+          expect.objectContaining({
+            isFunction: false,
+            parameters: { count: 1, hasRest: true },
+          }),
+        ],
+      ]),
+    )
+  })
 })

--- a/packages/plugin-rsc/src/transforms/wrap-export.ts
+++ b/packages/plugin-rsc/src/transforms/wrap-export.ts
@@ -3,10 +3,16 @@ import type { Program } from 'estree'
 import MagicString from 'magic-string'
 import { extractNames, validateNonAsyncFunction } from './utils'
 
-type ExportMeta = {
+export type FunctionParameters = {
+  count: number
+  hasRest: boolean
+}
+
+export type ExportMeta = {
   declName?: string
   isFunction?: boolean
   defaultExportIdentifierName?: string
+  parameters?: FunctionParameters
 }
 
 export type TransformWrapExportFilter = (
@@ -33,6 +39,26 @@ export function transformWrapExport(
   const exportNames: string[] = []
   const toAppend: string[] = []
   const filter = options.filter ?? (() => true)
+  const localFunctionParameters = new Map<string, FunctionParameters>()
+
+  for (const node of ast.body) {
+    if (node.type === 'FunctionDeclaration' && node.id) {
+      localFunctionParameters.set(node.id.name, getFunctionParameters(node))
+    } else if (node.type === 'VariableDeclaration') {
+      for (const declaration of node.declarations) {
+        if (
+          declaration.id.type === 'Identifier' &&
+          (declaration.init?.type === 'ArrowFunctionExpression' ||
+            declaration.init?.type === 'FunctionExpression')
+        ) {
+          localFunctionParameters.set(
+            declaration.id.name,
+            getFunctionParameters(declaration.init),
+          )
+        }
+      }
+    }
+  }
 
   function wrapSimple(
     start: number,
@@ -97,7 +123,17 @@ export function transformWrapExport(
           validateNonAsyncFunction(options, node.declaration)
           const name = node.declaration.id.name
           wrapSimple(node.start, node.declaration.start, [
-            { name, meta: { isFunction: true, declName: name } },
+            {
+              name,
+              meta: {
+                isFunction: node.declaration.type === 'FunctionDeclaration',
+                declName: name,
+                parameters:
+                  node.declaration.type === 'FunctionDeclaration'
+                    ? getFunctionParameters(node.declaration)
+                    : undefined,
+              },
+            },
           ])
         } else if (node.declaration.type === 'VariableDeclaration') {
           /**
@@ -120,19 +156,27 @@ export function transformWrapExport(
           )
           // treat only simple single decl as function
           let isFunction = false
+          let parameters: FunctionParameters | undefined
           if (node.declaration.declarations.length === 1) {
             const decl = node.declaration.declarations[0]!
             isFunction =
               decl.id.type === 'Identifier' &&
               (decl.init?.type === 'ArrowFunctionExpression' ||
                 decl.init?.type === 'FunctionExpression')
+            if (isFunction) {
+              parameters = getFunctionParameters(
+                decl.init as
+                  | import('estree').ArrowFunctionExpression
+                  | import('estree').FunctionExpression,
+              )
+            }
           }
           wrapSimple(
             node.start,
             node.declaration.start,
             names.map((name) => ({
               name,
-              meta: { isFunction, declName: name },
+              meta: { isFunction, declName: name, parameters },
             })),
           )
         } else {
@@ -171,7 +215,12 @@ export function transformWrapExport(
                 { pos: spec.exported.start },
               )
             }
-            wrapExport(spec.local.name, spec.exported.name)
+            wrapExport(spec.local.name, spec.exported.name, {
+              isFunction: localFunctionParameters.has(spec.local.name)
+                ? true
+                : undefined,
+              parameters: localFunctionParameters.get(spec.local.name),
+            })
           }
         }
       }
@@ -199,6 +248,14 @@ export function transformWrapExport(
      */
     if (node.type === 'ExportDefaultDeclaration') {
       validateNonAsyncFunction(options, node.declaration)
+      const parameters =
+        node.declaration.type === 'FunctionDeclaration' ||
+        node.declaration.type === 'FunctionExpression' ||
+        node.declaration.type === 'ArrowFunctionExpression'
+          ? getFunctionParameters(node.declaration)
+          : node.declaration.type === 'Identifier'
+            ? localFunctionParameters.get(node.declaration.name)
+            : undefined
       let localName: string
       let isFunction = false
       let declName: string | undefined
@@ -225,6 +282,7 @@ export function transformWrapExport(
         isFunction,
         declName,
         defaultExportIdentifierName,
+        parameters,
       })
     }
   }
@@ -234,4 +292,13 @@ export function transformWrapExport(
   }
 
   return { exportNames, output }
+}
+
+function getFunctionParameters(node: {
+  params: import('estree').Pattern[]
+}): FunctionParameters {
+  return {
+    count: node.params.length,
+    hasRest: node.params.some((parameter) => parameter.type === 'RestElement'),
+  }
 }


### PR DESCRIPTION
Extracted from #1246.

Transform runtimes currently receive directive/export metadata but cannot tell whether an inline function captures bound values or inspect the declared parameter shape without reparsing source.

This adds `hasBoundArgs` and `{ count, hasRest }` metadata for inline functions, plus parameter metadata for named, variable, local re-export, and default module exports. Focused tests cover closure captures and all supported export forms.