### PR TITLE
feat(rsc): generalize server action transforms

### DIFF
--- a/packages/plugin-rsc/src/transforms/server-action.test.ts
+++ b/packages/plugin-rsc/src/transforms/server-action.test.ts
@@ -1,0 +1,71 @@
+import { parseAstAsync } from 'vite'
+import { describe, expect, it } from 'vitest'
+import { transformServerActionServer } from './server-action'
+
+const runtime = (value: string, name: string) =>
+  `wrap(${value}, ${JSON.stringify(name)})`
+
+describe(transformServerActionServer, () => {
+  it('supports custom inline directives and runtimes', async () => {
+    const input = `async function cached() { "use cache" }`
+    const ast = await parseAstAsync(input)
+    const result = transformServerActionServer(input, ast, {
+      runtime,
+      directive: 'use cache',
+      inlineRuntime: (value, name) =>
+        `cache(${value}, ${JSON.stringify(name)})`,
+    })
+    expect(result.output.toString()).toContain('cache($$hoist_0_cached')
+  })
+
+  it('supports explicit module directives, filtering, and validation', async () => {
+    const input = `"use cache"; export const metadata = 1; export async function cached() {}`
+    const ast = await parseAstAsync(input)
+    const directive = ast.body[0]!
+    expect(directive.type).toBe('ExpressionStatement')
+    if (
+      directive.type !== 'ExpressionStatement' ||
+      directive.expression.type !== 'Literal'
+    )
+      throw new Error('expected directive')
+    const result = transformServerActionServer(input, ast, {
+      runtime,
+      moduleDirective: directive.expression,
+      moduleRuntime: (value, name) =>
+        `cache(${value}, ${JSON.stringify(name)})`,
+      filter: (name) => name !== 'metadata',
+      rejectNonAsyncModule: true,
+    })
+    expect(result.output.toString()).toContain('/* "use cache" */')
+    expect(result.output.toString()).toContain('cache(cached, "cached")')
+    expect(result.output.toString()).not.toContain('cache(metadata')
+  })
+
+  it('can preserve explicit module directives', async () => {
+    const input = `"use cache"; export async function cached() {}`
+    const ast = await parseAstAsync(input)
+    const statement = ast.body[0]!
+    if (
+      statement.type !== 'ExpressionStatement' ||
+      statement.expression.type !== 'Literal'
+    )
+      throw new Error('expected directive')
+    const result = transformServerActionServer(input, ast, {
+      runtime,
+      moduleDirective: statement.expression,
+      preserveModuleDirective: true,
+    })
+    expect(result.output.toString()).toContain('"use cache"')
+  })
+
+  it('can disable built-in use server module detection', async () => {
+    const input = `"use server"; export async function action() {}`
+    const ast = await parseAstAsync(input)
+    const result = transformServerActionServer(input, ast, {
+      runtime,
+      detectUseServerModule: false,
+    })
+    expect('names' in result ? result.names : result.exportNames).toEqual([])
+    expect(result.output.hasChanged()).toBe(false)
+  })
+})

--- a/packages/plugin-rsc/src/transforms/server-action.ts
+++ b/packages/plugin-rsc/src/transforms/server-action.ts
@@ -1,8 +1,10 @@
-import type { Program } from 'estree'
+import type { Literal, Program } from 'estree'
 import type MagicString from 'magic-string'
 import { transformHoistInlineDirective } from './hoist'
-import { hasDirective } from './utils'
-import { transformWrapExport } from './wrap-export'
+import {
+  transformWrapExport,
+  type TransformWrapExportOptions,
+} from './wrap-export'
 
 // TODO
 // source map for `options.runtime` (registerServerReference) call
@@ -12,9 +14,19 @@ export function transformServerActionServer(
   ast: Program,
   options: {
     runtime: (value: string, name: string) => string
+    directive?: string | RegExp
+    moduleDirective?: Literal
+    moduleRuntime?: TransformWrapExportOptions['runtime']
+    inlineRuntime?: Parameters<
+      typeof transformHoistInlineDirective
+    >[2]['runtime']
+    filter?: TransformWrapExportOptions['filter']
     rejectNonAsyncFunction?: boolean
+    rejectNonAsyncModule?: boolean
     encode?: (value: string) => string
     decode?: (value: string) => string
+    preserveModuleDirective?: boolean
+    detectUseServerModule?: boolean
   },
 ):
   | {
@@ -25,12 +37,44 @@ export function transformServerActionServer(
       output: MagicString
       names: string[]
     } {
+  const useServerStatement =
+    options.detectUseServerModule === false
+      ? undefined
+      : ast.body.find(
+          (statement) =>
+            statement.type === 'ExpressionStatement' &&
+            statement.expression.type === 'Literal' &&
+            statement.expression.value === 'use server',
+        )
+  const moduleDirective =
+    options.moduleDirective ??
+    (useServerStatement?.type === 'ExpressionStatement' &&
+    useServerStatement.expression.type === 'Literal'
+      ? useServerStatement.expression
+      : undefined)
+
   // TODO: unify (generalize transformHoistInlineDirective to support top-level directive cases)
-  if (hasDirective(ast.body, 'use server')) {
-    return transformWrapExport(input, ast, options)
+  if (moduleDirective?.type === 'Literal') {
+    const result = transformWrapExport(input, ast, {
+      runtime: options.moduleRuntime ?? options.runtime,
+      filter: options.filter,
+      rejectNonAsyncFunction:
+        options.rejectNonAsyncModule ?? options.rejectNonAsyncFunction,
+    })
+    if (!options.preserveModuleDirective && options.moduleDirective) {
+      result.output.overwrite(
+        moduleDirective.start,
+        moduleDirective.end,
+        `/* ${JSON.stringify(moduleDirective.value)} */`,
+      )
+    }
+    return result
   }
   return transformHoistInlineDirective(input, ast, {
-    ...options,
-    directive: 'use server',
+    runtime: options.inlineRuntime ?? options.runtime,
+    directive: options.directive ?? 'use server',
+    rejectNonAsyncFunction: options.rejectNonAsyncFunction,
+    encode: options.encode,
+    decode: options.decode,
   })
 }


### PR DESCRIPTION
Extracted from #1246.

`transformServerActionServer` is currently hard-coded to the `"use server"` directive and a single runtime/validation policy. Framework directives otherwise need to duplicate the module-vs-inline dispatch logic.

This adds configurable inline/module directives, runtimes, filtering, validation, directive preservation, and built-in module detection. Direct tests cover each dispatch option.