### PR TITLE
feat(rsc): validate inline action lexical expressions

### DIFF
--- a/packages/plugin-rsc/src/transforms/hoist.test.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.test.ts
@@ -53,6 +53,7 @@ describe(transformHoistInlineDirective, () => {
       encode?: boolean
       noExport?: boolean
       directive?: string | RegExp
+      rejectForbiddenExpressions?: boolean
     },
   ) {
     const ast = await parseAstAsync(input)
@@ -68,6 +69,7 @@ describe(transformHoistInlineDirective, () => {
       encode: options?.encode ? (v) => `__enc(${v})` : undefined,
       decode: options?.encode ? (v) => `__dec(${v})` : undefined,
       noExport: options?.noExport,
+      rejectForbiddenExpressions: options?.rejectForbiddenExpressions,
     })
     if (!output.hasChanged()) {
       return
@@ -507,5 +509,42 @@ export async function test() {
       /* #__PURE__ */ Object.defineProperty($$hoist_0_test, "name", { value: "test" });
       "
     `)
+  })
+
+  it.each([
+    ['this', `async function action() { "use server"; return this }`],
+    ['arguments', `async function action() { "use server"; return arguments }`],
+    [
+      'super',
+      `class Base { method() {} } class Actions extends Base { static async action() { "use server"; return super.method() } }`,
+    ],
+  ])('rejects lexical %s expressions when requested', async (_name, input) => {
+    await expect(
+      testTransform(input, { rejectForbiddenExpressions: true }),
+    ).rejects.toThrow(/cannot use/)
+  })
+
+  it('does not inspect nested function scopes', async () => {
+    const input = `
+async function action() {
+  "use server";
+  return function nested() { return this }
+}
+`
+    await expect(
+      testTransform(input, { rejectForbiddenExpressions: true }),
+    ).resolves.toContain('function nested() { return this }')
+  })
+
+  it('allows JSX dev source metadata this arguments', async () => {
+    const input = `
+async function action() {
+  "use server";
+  return _jsxDEV("div", {}, undefined, false, undefined, this)
+}
+`
+    await expect(
+      testTransform(input, { rejectForbiddenExpressions: true }),
+    ).resolves.toContain('_jsxDEV')
   })
 })

--- a/packages/plugin-rsc/src/transforms/hoist.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.ts
@@ -1,6 +1,7 @@
 import { tinyassert } from '@hiogawa/utils'
 import type {
   Program,
+  BlockStatement,
   Literal,
   Node,
   MemberExpression,
@@ -28,6 +29,7 @@ export function transformHoistInlineDirective(
     encode?: (value: string) => string
     decode?: (value: string) => string
     noExport?: boolean
+    rejectForbiddenExpressions?: boolean
   },
 ): {
   output: MagicString
@@ -63,6 +65,9 @@ export function transformHoistInlineDirective(
               pos: node.start,
             },
           )
+        }
+        if (options.rejectForbiddenExpressions) {
+          validateForbiddenExpressions(node.body, match[0])
         }
 
         const declName = node.type === 'FunctionDeclaration' && node.id.name
@@ -136,6 +141,43 @@ export function transformHoistInlineDirective(
     output,
     names,
   }
+}
+
+function validateForbiddenExpressions(body: BlockStatement, directive: string) {
+  walk(body, {
+    enter(node, parent) {
+      if (
+        node !== body &&
+        (node.type === 'FunctionDeclaration' ||
+          node.type === 'FunctionExpression')
+      ) {
+        this.skip()
+        return
+      }
+      const isJsxDevSourceThis =
+        node.type === 'ThisExpression' &&
+        parent?.type === 'CallExpression' &&
+        parent.arguments.at(-1) === node &&
+        parent.callee.type === 'Identifier' &&
+        /(?:^|_)jsxDEV$/.test(parent.callee.name)
+      const expression =
+        node.type === 'ThisExpression' && !isJsxDevSourceThis
+          ? 'this'
+          : node.type === 'Super'
+            ? 'super'
+            : node.type === 'Identifier' && node.name === 'arguments'
+              ? 'arguments'
+              : undefined
+      if (expression) {
+        throw Object.assign(
+          new Error(
+            `${JSON.stringify(directive)} functions cannot use ${JSON.stringify(expression)}.`,
+          ),
+          { pos: node.start },
+        )
+      }
+    },
+  })
 }
 
 const exactRegex = (s: string): RegExp =>

--- a/packages/plugin-rsc/src/transforms/server-action.ts
+++ b/packages/plugin-rsc/src/transforms/server-action.ts
@@ -15,6 +15,7 @@ export function transformServerActionServer(
     rejectNonAsyncFunction?: boolean
     encode?: (value: string) => string
     decode?: (value: string) => string
+    rejectForbiddenExpressions?: boolean
   },
 ):
   | {


### PR DESCRIPTION
Extracted from #1246.

Hoisting a directive function changes the meaning of lexical `this`, `super`, and `arguments`. Custom directives that require semantic preservation need a transform-level way to reject these expressions.

This adds opt-in validation scoped to the transformed function, skips nested function scopes, and allows the JSX dev helper source-metadata `this` argument. Tests cover every rejected expression and both exceptions.