### PR TITLE
feat(rsc): export wrapped inline action hoists

### DIFF
--- a/packages/plugin-rsc/src/transforms/hoist.test.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.test.ts
@@ -53,6 +53,7 @@ describe(transformHoistInlineDirective, () => {
       encode?: boolean
       noExport?: boolean
       directive?: string | RegExp
+      exportWrappedHoist?: boolean
     },
   ) {
     const ast = await parseAstAsync(input)
@@ -68,6 +69,7 @@ describe(transformHoistInlineDirective, () => {
       encode: options?.encode ? (v) => `__enc(${v})` : undefined,
       decode: options?.encode ? (v) => `__dec(${v})` : undefined,
       noExport: options?.noExport,
+      exportWrappedHoist: options?.exportWrappedHoist,
     })
     if (!output.hasChanged()) {
       return
@@ -507,5 +509,29 @@ export async function test() {
       /* #__PURE__ */ Object.defineProperty($$hoist_0_test, "name", { value: "test" });
       "
     `)
+  })
+
+  it('exports wrapped hoists instead of implementations', async () => {
+    const transformed = await testTransform(
+      `async function action() { "use server"; return 1 }`,
+      { exportWrappedHoist: true },
+    )
+    expect(transformed).toContain(
+      'export const $$hoist_0_action = /* #__PURE__ */ $$register($$hoist_0_action$$impl',
+    )
+    expect(transformed).toContain('const action = $$hoist_0_action;')
+    expect(transformed).toContain('async function $$hoist_0_action$$impl()')
+    expect(transformed).not.toContain(
+      'export async function $$hoist_0_action$$impl',
+    )
+  })
+
+  it('binds captured values from the exported wrapped hoist', async () => {
+    const transformed = await testTransform(
+      `function outer(value) { const action = async function() { "use server"; return value }; return action }`,
+      { exportWrappedHoist: true },
+    )
+    expect(transformed).toContain('$$hoist_0_action.bind(null, value)')
+    expect(transformed).toContain('function $$hoist_0_action$$impl(value)')
   })
 })

--- a/packages/plugin-rsc/src/transforms/hoist.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.ts
@@ -28,6 +28,7 @@ export function transformHoistInlineDirective(
     encode?: (value: string) => string
     decode?: (value: string) => string
     noExport?: boolean
+    exportWrappedHoist?: boolean
   },
 ): {
   output: MagicString
@@ -95,25 +96,37 @@ export function transformHoistInlineDirective(
         const newName =
           `$$hoist_${names.length}` + (originalName ? `_${originalName}` : '')
         names.push(newName)
+        const implementationName = options.exportWrappedHoist
+          ? `${newName}$$impl`
+          : newName
         output.update(
           node.start,
           node.body.start,
-          `\n;${options.noExport ? '' : 'export '}${
+          `\n;${options.noExport || options.exportWrappedHoist ? '' : 'export '}${
             node.async ? 'async ' : ''
-          }function${node.generator ? '*' : ''} ${newName}(${newParams}) `,
+          }function${node.generator ? '*' : ''} ${implementationName}(${newParams}) `,
         )
         output.appendLeft(
           node.end,
-          `;\n/* #__PURE__ */ Object.defineProperty(${newName}, "name", { value: ${JSON.stringify(
+          `;\n/* #__PURE__ */ Object.defineProperty(${implementationName}, "name", { value: ${JSON.stringify(
             originalName,
           )} });\n`,
         )
         output.move(node.start, node.end, input.length)
 
         // replace original declartion with action register + bind
-        let newCode = `/* #__PURE__ */ ${runtime(newName, newName, {
-          directiveMatch: match,
-        })}`
+        const wrappedCode = `/* #__PURE__ */ ${runtime(
+          implementationName,
+          newName,
+          {
+            directiveMatch: match,
+          },
+        )}`
+        let newCode = wrappedCode
+        if (options.exportWrappedHoist) {
+          output.prepend(`export const ${newName} = ${wrappedCode};\n`)
+          newCode = newName
+        }
         if (bindVars.length > 0) {
           const bindArgs = options.encode
             ? options.encode('[' + bindVars.map((b) => b.expr).join(', ') + ']')

--- a/packages/plugin-rsc/src/transforms/server-action.ts
+++ b/packages/plugin-rsc/src/transforms/server-action.ts
@@ -15,6 +15,7 @@ export function transformServerActionServer(
     rejectNonAsyncFunction?: boolean
     encode?: (value: string) => string
     decode?: (value: string) => string
+    exportWrappedHoist?: boolean
   },
 ):
   | {


### PR DESCRIPTION
Extracted from #1246.

Inline transforms currently export the raw hoisted implementation. Consumers that need to import the transformed reference can therefore bypass the runtime wrapper.

This adds an opt-in mode that keeps the implementation private and exports the wrapped reference under the hoist name. Tests cover plain actions and closure-bound actions.