### PR TITLE
perf(rsc): skip scans without server references

### DIFF
--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -234,6 +234,15 @@ export type RscPluginOptions = {
   customBuildApp?: boolean
 
   /**
+   * Enable build-time server reference discovery for "use server" actions.
+   * Downstream frameworks that can prove an app contains no server actions may
+   * set this to false to skip the SSR scan build.
+   * @experimental
+   * @default true
+   */
+  serverReferences?: boolean
+
+  /**
    * Custom environment configuration
    * @experimental
    * @default { browser: 'client', ssr: 'ssr', rsc: 'rsc' }
@@ -412,13 +421,17 @@ export default function vitePluginRsc(
 
     // rsc -> ssr -> rsc -> client -> ssr
     ensureEnvironmentImportsEntryFallback(builder.config)
-    manager.isScanBuild = true
-    builder.environments.rsc!.config.build.write = false
-    builder.environments.ssr!.config.build.write = false
-    logStep('[1/5] analyze client references...')
-    await builder.build(builder.environments.rsc!)
-    logStep('[2/5] analyze server references...')
-    await builder.build(builder.environments.ssr!)
+    if (rscPluginOptions.serverReferences !== false) {
+      manager.isScanBuild = true
+      builder.environments.rsc!.config.build.write = false
+      builder.environments.ssr!.config.build.write = false
+      logStep('[1/5] analyze client references...')
+      await builder.build(builder.environments.rsc!)
+      logStep('[2/5] analyze server references...')
+      await builder.build(builder.environments.ssr!)
+    } else {
+      logStep('[1/5] skip reference analysis...')
+    }
     manager.isScanBuild = false
     builder.environments.rsc!.config.build.write = true
     builder.environments.ssr!.config.build.write = true


### PR DESCRIPTION
This PR adds a `serverReferences?: boolean` option to `@vitejs/plugin-rsc`, letting frameworks that can prove an app has no React `"use server"` actions skip the expensive reference-analysis builds.

RSC frameworks often already know their app roots, route files, and source conventions, so they can conservatively scan and set either `rsc({ serverReferences: false })` or top-level `rsc: { serverReferences: false }`.

This makes the optimization broadly useful across plugin-rsc-based frameworks.

### Framework Wiring Points

| Framework | Where to change | Wiring |
| --- | --- | --- |
| vinext | [`packages/vinext/src/index.ts`](https://github.com/cloudflare/vinext/blob/main/packages/vinext/src/index.ts) |  Can scan project source, then pass `serverReferences: earlyMayContainServerActions`. |
| Waku | [`packages/waku/src/lib/vite-plugins/combined-plugins.ts`](https://github.com/wakujs/waku/blob/main/packages/waku/src/lib/vite-plugins/combined-plugins.ts) | Add `serverReferences: mayContainServerActions` inside its existing `rsc({ ... })` call. |
| TanStack Start | [`packages/react-start-rsc/src/plugin/vite.ts`](https://github.com/TanStack/router/blob/main/packages/react-start-rsc/src/plugin/vite.ts) | Add `serverReferences` to the existing top-level returned `rsc: { ... }` config. |
| React Router | [`packages/react-router-dev/vite/rsc/plugin.ts`](https://github.com/remix-run/react-router/blob/main/packages/react-router-dev/vite/rsc/plugin.ts) | Add top-level `rsc: { serverReferences: mayContainServerActions }` beside its environment config. |

### Safety

Frameworks should only set `serverReferences: false` when they can conservatively determine that no React `"use server"` references exist.

If scanning fails, source roots are ambiguous, or server actions may come from transformed dependencies, the safe default is to leave `serverReferences` enabled.

### Benchmark

In my vinext benchmark I got a difference from **191.3 ms** (13.73% improvement). 

### Alternatives

* Make the existing scan builds cheaper
  * Possible but still runs extra RSC/SSR environment builds, so less efficient
  * Many small changes => higher maintenance risk.
* Automatic detection inside plugin-rsc
  * No: plugin-rsc does not reliably know every framework’s source roots, route conventions, virtual modules, MDX handling, or transformed dependency rules.
* Framework-provided reference manifests
  * Much larger API surface than a boolean + tight coupling to plugin-rsc internals
