### PR TITLE
fix(react): babel-plugin-react-compiler cannot be imported when used in a framework

### DIFF
--- a/packages/plugin-react/src/reactCompilerPreset.ts
+++ b/packages/plugin-react/src/reactCompilerPreset.ts
@@ -2,7 +2,7 @@ import type {
   ReactCompilerBabelPluginOptions,
   RolldownBabelPreset,
 } from '#optionalTypes'
-import { createRequire } from "module";
+import { createRequire } from 'node:module';
 
 export const defaultCodeFilter =
   /forwardRef|memo|(?:const|let|var|function)\s+(?:[A-Z]|use[A-Z0-9])|(?:[A-Z]|use[A-Z0-9])[^\s:=(){}[\],;]*\s*(?:\(|[:=]\s*(?:function|\())/

--- a/packages/plugin-react/src/reactCompilerPreset.ts
+++ b/packages/plugin-react/src/reactCompilerPreset.ts
@@ -2,15 +2,18 @@ import type {
   ReactCompilerBabelPluginOptions,
   RolldownBabelPreset,
 } from '#optionalTypes'
+import { createRequire } from "module";
 
 export const defaultCodeFilter =
   /forwardRef|memo|(?:const|let|var|function)\s+(?:[A-Z]|use[A-Z0-9])|(?:[A-Z]|use[A-Z0-9])[^\s:=(){}[\],;]*\s*(?:\(|[:=]\s*(?:function|\())/
+
+const require = createRequire(import.meta.url);
 
 export const reactCompilerPreset = (
   options: ReactCompilerBabelPluginOptions = {},
 ): RolldownBabelPreset => ({
   preset: () => ({
-    plugins: [['babel-plugin-react-compiler', options]],
+    plugins: [[require.resolve('babel-plugin-react-compiler'), options]],
   }),
   rolldown: {
     filter: {

--- a/packages/plugin-react/src/reactCompilerPreset.ts
+++ b/packages/plugin-react/src/reactCompilerPreset.ts
@@ -1,19 +1,22 @@
+import { fileURLToPath } from 'node:url'
 import type {
   ReactCompilerBabelPluginOptions,
   RolldownBabelPreset,
 } from '#optionalTypes'
-import { createRequire } from 'node:module';
 
 export const defaultCodeFilter =
   /forwardRef|memo|(?:const|let|var|function)\s+(?:[A-Z]|use[A-Z0-9])|(?:[A-Z]|use[A-Z0-9])[^\s:=(){}[\],;]*\s*(?:\(|[:=]\s*(?:function|\())/
-
-const require = createRequire(import.meta.url);
 
 export const reactCompilerPreset = (
   options: ReactCompilerBabelPluginOptions = {},
 ): RolldownBabelPreset => ({
   preset: () => ({
-    plugins: [[require.resolve('babel-plugin-react-compiler'), options]],
+    plugins: [
+      [
+        fileURLToPath(import.meta.resolve('babel-plugin-react-compiler')),
+        options,
+      ],
+    ],
   }),
   rolldown: {
     filter: {


### PR DESCRIPTION


### Description

I am a meta-framework developer that my library incorporates vite's javascript api.
My library is a cli based tool, calls vite's build() function internally, and processes user files.
It is supposed to be able to run regardless of whether there is a local node_module folder in the user's cwd.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

I encountered the following issue issue 

@rolldown/plugin-babel calls babel.loadOptionsAsync with { babelrc: false, configFile: false }. When there is no config file, Babel uses process.cwd() as the dirname for resolving plugins in programmatic presets — not the directory of the file being transformed.

reactCompilerPreset at @vitejs/plugin-react/dist/index.js:46 returns:
preset: () => ({ plugins: [["babel-plugin-react-compiler", options]] })
//                           ^ bare string, not a pre-resolved absolute path

Babel must then locate babel-plugin-react-compiler via:
import.meta.resolve("babel-plugin-react-compiler",
  pathToFileURL(path.join(process.cwd(), "babel-virtual-resolve-base.js")).href)

When process.cwd() is a directory that doesn't have babel-plugin-react-compiler in its node_modules ancestry — e.g., / (the Docker container default) — the resolution fails.

It needs to ensure Babel receive an absolute path, so it never needs to do CWD-relative resolution
<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
