### PR TITLE
fix(rsc): fix transitive dep as client boundary by bailing out client package virtual

### DIFF
--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -1616,6 +1616,14 @@ function defineTest(f: Fixture) {
     )
   })
 
+  test('transitive client package', async ({ page }) => {
+    await page.goto(f.url())
+    await waitForHydration(page)
+    await expect(page.getByTestId('transitive-client')).toHaveText(
+      '[test-transitive-client-dep: true]',
+    )
+  })
+
   test('server-in-server package', async ({ page }) => {
     await page.goto(f.url())
     await waitForHydration(page)

--- a/packages/plugin-rsc/examples/basic/package.json
+++ b/packages/plugin-rsc/examples/basic/package.json
@@ -27,6 +27,7 @@
     "@vitejs/test-dep-css-in-server": "file:./test-dep/css-in-server",
     "@vitejs/test-dep-server-in-client": "file:./test-dep/server-in-client",
     "@vitejs/test-dep-server-in-server": "file:./test-dep/server-in-server",
+    "@vitejs/test-dep-server-with-transitive-client": "file:./test-dep/server-with-transitive-client",
     "@vitejs/test-dep-transitive-cjs": "file:./test-dep/transitive-cjs",
     "@vitejs/test-dep-transitive-use-sync-external-store": "file:./test-dep/transitive-use-sync-external-store",
     "rsc-html-stream": "^0.0.7",

--- a/packages/plugin-rsc/examples/basic/src/routes/deps/transitive-client/server.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/deps/transitive-client/server.tsx
@@ -1,0 +1,10 @@
+// @ts-ignore
+import { TestServerWithTransitiveClientDep } from '@vitejs/test-dep-server-with-transitive-client/server'
+
+export function TestTransitiveClient() {
+  return (
+    <div data-testid="transitive-client">
+      [test-transitive-client-dep: <TestServerWithTransitiveClientDep />]
+    </div>
+  )
+}

--- a/packages/plugin-rsc/examples/basic/src/routes/root.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/root.tsx
@@ -30,6 +30,7 @@ import { TestClientInServer } from './deps/client-in-server/server'
 import { TestServerInClient } from './deps/server-in-client/client'
 import { TestServerInServer } from './deps/server-in-server/server'
 import { TestTransitiveCjsClient } from './deps/transitive-cjs/client'
+import { TestTransitiveClient } from './deps/transitive-client/server'
 import { TestExportAll } from './export-all/server'
 import { TestHmrClientDep } from './hmr-client-dep/client'
 import { TestHmrClientDep2 } from './hmr-client-dep2/client'
@@ -116,6 +117,7 @@ export function Root(props: { url: URL }) {
         <TestClientInServer />
         <TestServerInServer />
         <TestServerInClient />
+        <TestTransitiveClient />
         <TestTransitiveCjsClient />
         <TestActionStateServer />
         <TestModuleInvalidationServer />

--- a/packages/plugin-rsc/examples/basic/test-dep/server-with-transitive-client/package.json
+++ b/packages/plugin-rsc/examples/basic/test-dep/server-with-transitive-client/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@vitejs/test-dep-server-with-transitive-client",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./server": "./server.js"
+  },
+  "dependencies": {
+    "@vitejs/test-dep-transitive-client": "file:../transitive-client"
+  },
+  "peerDependencies": {
+    "react": "*"
+  }
+}

--- a/packages/plugin-rsc/examples/basic/test-dep/server-with-transitive-client/server.js
+++ b/packages/plugin-rsc/examples/basic/test-dep/server-with-transitive-client/server.js
@@ -1,0 +1,6 @@
+import { TestClient } from '@vitejs/test-dep-transitive-client/client'
+import React from 'react'
+
+export async function TestServerWithTransitiveClientDep() {
+  return React.createElement(TestClient)
+}

--- a/packages/plugin-rsc/examples/basic/test-dep/transitive-client/client.js
+++ b/packages/plugin-rsc/examples/basic/test-dep/transitive-client/client.js
@@ -1,0 +1,8 @@
+'use client'
+
+import React from 'react'
+
+export function TestClient() {
+  const [ok] = React.useState(() => true)
+  return React.createElement('span', null, String(ok))
+}

--- a/packages/plugin-rsc/examples/basic/test-dep/transitive-client/package.json
+++ b/packages/plugin-rsc/examples/basic/test-dep/transitive-client/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@vitejs/test-dep-transitive-client",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./client": "./client.js"
+  },
+  "peerDependencies": {
+    "react": "*"
+  }
+}

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1685,6 +1685,21 @@ function vitePluginUseClient(
           ) {
             const resolved = await this.resolve(source, importer, options)
             if (resolved && resolved.id.includes('/node_modules/')) {
+              // Virtualizing a client package keeps the bare `source` as the
+              // client reference id (e.g. `import "pkg-b"` in
+              // `virtual:vite-rsc/client-references`), which is later re-resolved
+              // from the project root. That breaks when `source` is only a
+              // transitive dependency reachable from `importer` but not installed
+              // at the root (see #1247). In that case, skip virtualization and
+              // let it fall back to referencing the fully resolved module id.
+              const resolvedAtRoot = await this.resolve(
+                source,
+                undefined,
+                options,
+              )
+              if (!resolvedAtRoot || resolvedAtRoot.id !== resolved.id) {
+                return
+              }
               packageSources.set(resolved.id, source)
               return resolved
             }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -524,6 +524,9 @@ importers:
       '@vitejs/test-dep-server-in-server':
         specifier: file:./test-dep/server-in-server
         version: file:packages/plugin-rsc/examples/basic/test-dep/server-in-server(react@19.2.7)
+      '@vitejs/test-dep-server-with-transitive-client':
+        specifier: file:./test-dep/server-with-transitive-client
+        version: file:packages/plugin-rsc/examples/basic/test-dep/server-with-transitive-client(react@19.2.7)
       '@vitejs/test-dep-transitive-cjs':
         specifier: file:./test-dep/transitive-cjs
         version: file:packages/plugin-rsc/examples/basic/test-dep/transitive-cjs(react@19.2.7)
@@ -2738,8 +2741,18 @@ packages:
     peerDependencies:
       react: '*'
 
+  '@vitejs/test-dep-server-with-transitive-client@file:packages/plugin-rsc/examples/basic/test-dep/server-with-transitive-client':
+    resolution: {directory: packages/plugin-rsc/examples/basic/test-dep/server-with-transitive-client, type: directory}
+    peerDependencies:
+      react: '*'
+
   '@vitejs/test-dep-transitive-cjs@file:packages/plugin-rsc/examples/basic/test-dep/transitive-cjs':
     resolution: {directory: packages/plugin-rsc/examples/basic/test-dep/transitive-cjs, type: directory}
+    peerDependencies:
+      react: '*'
+
+  '@vitejs/test-dep-transitive-client@file:packages/plugin-rsc/examples/basic/test-dep/transitive-client':
+    resolution: {directory: packages/plugin-rsc/examples/basic/test-dep/transitive-client, type: directory}
     peerDependencies:
       react: '*'
 
@@ -6144,9 +6157,18 @@ snapshots:
     dependencies:
       react: 19.2.7
 
+  '@vitejs/test-dep-server-with-transitive-client@file:packages/plugin-rsc/examples/basic/test-dep/server-with-transitive-client(react@19.2.7)':
+    dependencies:
+      '@vitejs/test-dep-transitive-client': file:packages/plugin-rsc/examples/basic/test-dep/transitive-client(react@19.2.7)
+      react: 19.2.7
+
   '@vitejs/test-dep-transitive-cjs@file:packages/plugin-rsc/examples/basic/test-dep/transitive-cjs(react@19.2.7)':
     dependencies:
       '@vitejs/test-dep-cjs': file:packages/plugin-rsc/examples/basic/test-dep/cjs(react@19.2.7)
+      react: 19.2.7
+
+  '@vitejs/test-dep-transitive-client@file:packages/plugin-rsc/examples/basic/test-dep/transitive-client(react@19.2.7)':
+    dependencies:
       react: 19.2.7
 
   '@vitejs/test-dep-transitive-use-sync-external-store@file:packages/plugin-rsc/examples/basic/test-dep/transitive-use-sync-external-store(react@19.2.7)':


### PR DESCRIPTION
### Description

- Closes https://github.com/vitejs/vite-plugin-react/issues/1247

When a server package imports a bare "use client" package that is only a transitive dependency (not installed at the project root), virtualizing it as a client package emitted a bare `import "pkg"` into `virtual:vite-rsc/client-references`, which fails to re-resolve from the root. Skip virtualization in that case and fall back to the fully resolved module id.
