### PR TITLE
fix(plugin-rsc): skip build-only generateBundle in bundledDev

### DIFF
--- a/packages/plugin-rsc/e2e/bundled-dev.test.ts
+++ b/packages/plugin-rsc/e2e/bundled-dev.test.ts
@@ -1,0 +1,14 @@
+import { test } from '@playwright/test'
+import { useFixture } from './fixture'
+import { defineStarterTest } from './starter'
+
+// `experimental.bundledDev` runs a client Rollup build in dev, which used to
+// crash the assets-manifest `generateBundle` hook (no RSC bundle in dev).
+test.describe('bundled-dev', () => {
+  const f = useFixture({
+    root: 'examples/starter',
+    mode: 'dev',
+    command: 'pnpm dev --experimental-bundle',
+  })
+  defineStarterTest(f)
+})

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -1121,6 +1121,14 @@ export function createRpcClient(params) {
       },
       // client build
       generateBundle(_options, bundle) {
+        // In bundledDev the client environment runs a Rollup build while
+        // `mode === 'dev'`, so this hook fires even though there is no RSC
+        // build output. The build-only asset copying and `buildAssetsManifest`
+        // construction below assume a production build (`manager.bundles['rsc']`
+        // is populated); in dev the manifest is served by the `load` hook above
+        // instead. Skip the build-only work in dev to avoid crashing on the
+        // absent RSC bundle.
+        if (this.environment.mode === 'dev') return
         // copy assets from rsc build to client build
         if (this.environment.name === 'client') {
           const rscBundle = manager.bundles['rsc']!


### PR DESCRIPTION
## Context

`experimental.bundledDev: true` crashes the dev server on startup:

```
TypeError: Cannot convert undefined or null to object
    at generateBundle (virtual:vite-rsc/assets-manifest)
```

The `assets-manifest` manifest is served two ways: the `load` hook builds it in dev, and `generateBundle` builds it in production from `manager.bundles['rsc']`. In normal dev, `generateBundle` never runs. In bundledDev the client environment runs a Rollup build while `mode === 'dev'`, so `generateBundle` fires, but there's no RSC build, so `manager.bundles['rsc']` is `undefined` and `Object.values(rscBundle)` throws.

The fix is to return early from `generateBundle` in dev, since the `load` hook already provides the manifest there. 

(Production builds and are unaffected)

## Testing

- `plugin-rsc` unit suite passes (448/448).
- Ran a real RSC app (SSR + `use client`/`use server` + hydration) with `bundledDev: true`: crashed before, works after, dev server starts and serves a correct RSC response.
- Production build of the same app still succeeds.
- Added `e2e/bundled-dev.test.ts` (runs `examples/starter` with `--experimental-bundle`). I couldn't run the Playwright suite locally, so CI should confirm it
