### PR TITLE
ci: cleanup renovate rules

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,19 +14,6 @@
       ignoreDeps: ['react', 'react-dom', '@types/react', '@types/react-dom'],
     },
     {
-      extends: ['monorepo:swc'],
-      groupName: 'swc monorepo',
-      separateMajorMinor: false,
-    },
-    // renovate doesn't properly handle x.x.x-beta-hash-yyyymm version schema
-    {
-      matchPackageNames: [
-        'react-compiler-runtime',
-        'babel-plugin-react-compiler',
-      ],
-      followTag: 'latest',
-    },
-    {
       matchDepTypes: ['action'],
       pinDigests: true,
     },


### PR DESCRIPTION
### Description

SWC now has backward compat for wasm plugins so it doesn't have to be grouped (refs https://github.com/vitejs/vite-plugin-react/pull/506, https://github.com/vitejs/vite-plugin-react/pull/509).

react compiler does not use x.x.x-beta-hash-yyyymm version schema any more.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
