### PR TITLE
docs: replace `tsc-dev` with `tsc` in agents instruction so they won't get stuck

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,5 +22,3 @@ pnpm install && pnpm build   # Initial setup (see CONTRIBUTING.md for details)
 pnpm dev                     # Watch mode development
 pnpm test                    # Run all tests
 ```
-
-For automated verification, use one-shot commands. Do not run `pnpm dev`, `tsc-dev`, or other watch commands unless the user explicitly asks for a persistent development process.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,3 +22,5 @@ pnpm install && pnpm build   # Initial setup (see CONTRIBUTING.md for details)
 pnpm dev                     # Watch mode development
 pnpm test                    # Run all tests
 ```
+
+For automated verification, use one-shot commands. Do not run `pnpm dev`, `tsc-dev`, or other watch commands unless the user explicitly asks for a persistent development process.

--- a/packages/plugin-rsc/CONTRIBUTING.md
+++ b/packages/plugin-rsc/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Use colocated unit tests for self-contained transforms and utilities.
 # Build packages
 pnpm dev # pnpm -C packages/plugin-rsc dev
 
-# Type check once
+# Type check
 pnpm -C packages/plugin-rsc tsc
 
 # Run unit tests

--- a/packages/plugin-rsc/CONTRIBUTING.md
+++ b/packages/plugin-rsc/CONTRIBUTING.md
@@ -38,8 +38,8 @@ Use colocated unit tests for self-contained transforms and utilities.
 # Build packages
 pnpm dev # pnpm -C packages/plugin-rsc dev
 
-# Type check
-pnpm -C packages/plugin-rsc tsc-dev
+# Type check once
+pnpm -C packages/plugin-rsc tsc
 
 # Run unit tests
 pnpm -C packages/plugin-rsc test --run


### PR DESCRIPTION
I had a few occasion Opencode GPT Sol running `tsc-dev` and getting stuck. This PR adjusts that specific mention.