### PR TITLE
fix(rsc): correct `keepUseClientProxy` option typo

### DIFF
--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -209,6 +209,11 @@ export type RscPluginOptions = {
   defineEncryptionKey?: string
 
   /** Escape hatch for Waku's `allowServer` */
+  keepUseClientProxy?: boolean
+
+  /**
+   * @deprecated Use `keepUseClientProxy` instead.
+   */
   keepUseCientProxy?: boolean
 
   /**
@@ -1435,7 +1440,7 @@ function createTransformExpandExportAllContext(
 function vitePluginUseClient(
   useClientPluginOptions: Pick<
     RscPluginOptions,
-    'keepUseCientProxy' | 'environment' | 'clientChunks'
+    'keepUseClientProxy' | 'keepUseCientProxy' | 'environment' | 'clientChunks'
   >,
   manager: RscPluginManager,
 ): Plugin[] {
@@ -1558,7 +1563,10 @@ function vitePluginUseClient(
           const result = transformDirectiveProxyExport_(ast, {
             directive: 'use client',
             code,
-            keep: !!useClientPluginOptions.keepUseCientProxy,
+            keep: !!(
+              useClientPluginOptions.keepUseClientProxy ??
+              useClientPluginOptions.keepUseCientProxy
+            ),
             runtime: (name, meta) => {
               let proxyValue =
                 `() => { throw new Error("Unexpectedly client reference export '" + ` +

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -212,7 +212,8 @@ export type RscPluginOptions = {
   keepUseClientProxy?: boolean
 
   /**
-   * @deprecated Use `keepUseClientProxy` instead.
+   * @deprecated This option contains a typo. Use `keepUseClientProxy` instead.
+   * It will be removed in the next breaking release.
    */
   keepUseCientProxy?: boolean
 

--- a/packages/plugin-rsc/src/transforms/proxy-export.test.ts
+++ b/packages/plugin-rsc/src/transforms/proxy-export.test.ts
@@ -239,6 +239,24 @@ export { x as "my thing" }
   })
 
   test('keep', async () => {
+    // Waku must run its DCE before this transform. For example:
+    //
+    //   // user source
+    //   export const countAtom = allowServer(atom(local1));
+    //   export const MyClientComp = () => <div />;
+    //
+    //   // after Waku's DCE
+    //   export const countAtom = atom(local1);
+    //   export const MyClientComp = () => { throw new Error('...') };
+    //
+    //   // after this transform with `keep: true`
+    //   export const countAtom = $$proxy(atom(local1), "<id>", "countAtom");
+    //   export const MyClientComp = $$proxy(
+    //     () => { throw new Error('...') }, "<id>", "MyClientComp"
+    //   );
+    //
+    // The input below represents Waku's output. `keep` disables our normal DCE
+    // so its retained imports, dependencies, and export initializers survive.
     const input = `\
 "use client"
 import { atom } from 'jotai/vanilla';


### PR DESCRIPTION
- closes https://github.com/vitejs/vite-plugin-react/issues/1317