### PR TITLE
fix(rsc): preserve server reference metadata compatibility

### DIFF
--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -127,6 +127,12 @@ class RscPluginManager {
   clientReferenceGroups: Record</* group name*/ string, ClientReferenceMeta[]> =
     {}
   serverReferences: ServerReferencesManager = new ServerReferencesManager(this)
+
+  /** @deprecated Use `serverReferences.metaMap` instead. */
+  get serverReferenceMetaMap(): Record<string, ServerReferenceMeta> {
+    return Object.fromEntries(this.serverReferences.metaMap)
+  }
+
   serverResourcesMetaMap: Record<string, { key: string }> = {}
   environmentImportMetaMap: Record<
     string, // sourceEnv


### PR DESCRIPTION
- closes https://github.com/vitejs/vite-plugin-react/issues/1339
- follow up to https://github.com/vitejs/vite-plugin-react/pull/1310

This PR restore the deprecated `serverReferenceMetaMap` read API removed in plugin-RSC 0.5.31 by deriving the compatibility record from `serverReferences.metaMap`.