### PR TITLE
chore(rsc): align example framework baseline

### DIFF
--- a/packages/plugin-rsc/AGENTS.md
+++ b/packages/plugin-rsc/AGENTS.md
@@ -7,6 +7,8 @@ This document provides AI-agent-specific guidance for the React Server Component
 
 Before adding integration coverage, follow the test fixture guidance in [CONTRIBUTING.md](CONTRIBUTING.md#choosing-a-test-fixture).
 
+Before creating or changing a conventional RSC example, use [`examples/starter-extra/src/framework`](examples/starter-extra/src/framework) as the comment-light framework baseline. Keep framework code aligned unless the example requires a behavioral difference. The specialized architectures described in [CONTRIBUTING.md](CONTRIBUTING.md#framework-baseline) may diverge.
+
 ## Quick Reference for AI Agents
 
 ### Essential Commands

--- a/packages/plugin-rsc/CONTRIBUTING.md
+++ b/packages/plugin-rsc/CONTRIBUTING.md
@@ -10,6 +10,12 @@ Tests use Playwright and are located in `e2e/` and use `examples` as test apps.
 
 Avoid reducing plugin or runtime behavior to mocked unit tests. Craft E2E coverage that clearly demonstrates the relevant RSC bundler semantics.
 
+#### Framework Baseline
+
+[`examples/starter/src/framework`](examples/starter/src/framework) is the annotated, instructional implementation. For conventional RSC examples, use the comment-light [`examples/starter-extra/src/framework`](examples/starter-extra/src/framework) as the maintenance baseline. Keep copied framework code aligned and limit differences to behavior required by the example so that each example remains independently runnable.
+
+Examples with specialized architectures, such as PPR, SSG, no-SSR, client-first, and browser-only examples, may diverge from this baseline. Keep those differences focused on the architecture being demonstrated.
+
 #### Choosing a Test Fixture
 
 **Adding a dedicated example**

--- a/packages/plugin-rsc/examples/basic/src/framework/entry.browser.tsx
+++ b/packages/plugin-rsc/examples/basic/src/framework/entry.browser.tsx
@@ -13,17 +13,10 @@ import { GlobalErrorBoundary } from './error-boundary'
 import { createRscRenderRequest } from './request'
 
 async function main() {
-  // stash `setPayload` function to trigger re-rendering
-  // from outside of `BrowserRoot` component (e.g. server function call, navigation, hmr)
   let setPayload: (v: RscPayload) => void
 
-  // deserialize RSC stream back to React VDOM for CSR
-  const initialPayload = await createFromReadableStream<RscPayload>(
-    // initial RSC stream is injected in SSR stream as <script>...FLIGHT_DATA...</script>
-    rscStream,
-  )
+  const initialPayload = await createFromReadableStream<RscPayload>(rscStream)
 
-  // browser root component to (re-)render RSC payload as state
   function BrowserRoot() {
     const [payload, setPayload_] = React.useState(initialPayload)
 
@@ -31,7 +24,6 @@ async function main() {
       setPayload = (v) => React.startTransition(() => setPayload_(v))
     }, [setPayload_])
 
-    // re-fetch/render on client side navigation
     React.useEffect(() => {
       return listenNavigation(() => fetchRscPayload())
     }, [])
@@ -39,15 +31,12 @@ async function main() {
     return payload.root
   }
 
-  // re-fetch RSC and trigger re-rendering
   async function fetchRscPayload() {
     const renderRequest = createRscRenderRequest(window.location.href)
     const payload = await createFromFetch<RscPayload>(fetch(renderRequest))
     setPayload(payload)
   }
 
-  // register a handler which will be internally called by React
-  // on server function request after hydration.
   setServerCallback(async (id, args) => {
     const temporaryReferences = createTemporaryReferenceSet()
     const renderRequest = createRscRenderRequest(window.location.href, {
@@ -63,7 +52,6 @@ async function main() {
     return data
   })
 
-  // hydration
   const browserRoot = (
     <React.StrictMode>
       <GlobalErrorBoundary>
@@ -79,7 +67,6 @@ async function main() {
     })
   }
 
-  // implement server HMR by triggering re-fetch/render of RSC upon server code change
   if (import.meta.hot) {
     import.meta.hot.on('rsc:update', (e) => {
       console.log('[vite-rsc:update]', e.file)
@@ -92,7 +79,6 @@ async function main() {
   }
 }
 
-// a little helper to setup events interception for client side navigation
 function listenNavigation(onNavigation: () => void) {
   window.addEventListener('popstate', onNavigation)
 
@@ -119,10 +105,10 @@ function listenNavigation(onNavigation: () => void) {
       (!link.target || link.target === '_self') &&
       link.origin === location.origin &&
       !link.hasAttribute('download') &&
-      e.button === 0 && // left clicks only
-      !e.metaKey && // open in new tab (mac)
-      !e.ctrlKey && // open in new tab (windows)
-      !e.altKey && // download
+      e.button === 0 &&
+      !e.metaKey &&
+      !e.ctrlKey &&
+      !e.altKey &&
       !e.shiftKey &&
       !e.defaultPrevented
     ) {

--- a/packages/plugin-rsc/examples/basic/src/framework/entry.rsc.tsx
+++ b/packages/plugin-rsc/examples/basic/src/framework/entry.rsc.tsx
@@ -10,16 +10,9 @@ import type React from 'react'
 import type { ReactFormState } from 'react-dom/client'
 import { parseRenderRequest } from './request.tsx'
 
-// The schema of payload which is serialized into RSC stream on rsc environment
-// and deserialized on ssr/client environments.
 export type RscPayload = {
-  // this demo renders/serializes/deserializes the entire root HTML element
-  // but this mechanism can be changed to render/fetch different parts of components
-  // based on your own route conventions.
   root: React.ReactNode
-  // server action return value of non-progressive enhancement case
   returnValue?: { ok: boolean; data: unknown }
-  // server action form state (e.g. useActionState) of progressive enhancement case
   formState?: ReactFormState
 }
 
@@ -32,18 +25,15 @@ async function handleRequest({
   getRoot: () => React.ReactNode
   nonce?: string
 }): Promise<Response> {
-  // differentiate RSC, SSR, action, etc.
   const renderRequest = parseRenderRequest(request)
   request = renderRequest.request
 
-  // handle server function request
   let returnValue: RscPayload['returnValue'] | undefined
   let formState: ReactFormState | undefined
   let temporaryReferences: unknown | undefined
   let actionStatus: number | undefined
   if (renderRequest.isAction === true) {
     if (renderRequest.actionId) {
-      // action is called via `ReactClient.setServerCallback`.
       const contentType = request.headers.get('content-type')
       const body = contentType?.startsWith('multipart/form-data')
         ? await request.formData()
@@ -59,17 +49,12 @@ async function handleRequest({
         actionStatus = 500
       }
     } else {
-      // otherwise server function is called via `<form action={...}>`
-      // before hydration (e.g. when javascript is disabled).
-      // aka progressive enhancement.
       const formData = await request.formData()
       const decodedAction = await decodeAction(formData)
       try {
         const result = await decodedAction()
         formState = await decodeFormState(result, formData)
       } catch (e) {
-        // there's no single general obvious way to surface this error,
-        // so explicitly return classic 500 response.
         return new Response('Internal Server Error: server action failed', {
           status: 500,
         })
@@ -92,7 +77,6 @@ async function handleRequest({
     return Response.json(debugClientReferences)
   }
 
-  // Respond RSC stream without HTML rendering as decided by `RenderRequest`
   if (renderRequest.isRsc) {
     return new Response(rscStream, {
       status: actionStatus,
@@ -102,21 +86,15 @@ async function handleRequest({
     })
   }
 
-  // Delegate to SSR environment for html rendering.
-  // The plugin provides `loadModule` helper to allow loading SSR environment entry module
-  // in RSC environment. however this can be customized by implementing own runtime communication
-  // e.g. `@cloudflare/vite-plugin`'s service binding.
   const ssrEntryModule = await import.meta.viteRsc.loadModule<
     typeof import('./entry.ssr.tsx')
   >('ssr', 'index')
   const ssrResult = await ssrEntryModule.renderHTML(rscStream, {
     formState,
     nonce,
-    // allow quick simulation of javascript disabled browser
     debugNojs: renderRequest.url.searchParams.has('__nojs'),
   })
 
-  // respond html
   return new Response(ssrResult.stream, {
     status: ssrResult.status,
     headers: {

--- a/packages/plugin-rsc/examples/basic/src/framework/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/basic/src/framework/entry.ssr.tsx
@@ -13,21 +13,14 @@ export async function renderHTML(
     debugNojs?: boolean
   },
 ): Promise<{ stream: ReadableStream<Uint8Array>; status?: number }> {
-  // duplicate one RSC stream into two.
-  // - one for SSR (ReactClient.createFromReadableStream below)
-  // - another for browser hydration payload by injecting <script>...FLIGHT_DATA...</script>.
   const [rscStream1, rscStream2] = rscStream.tee()
 
-  // deserialize RSC stream back to React VDOM
   let payload: Promise<RscPayload>
   function SsrRoot() {
-    // deserialization needs to be kicked off inside ReactDOMServer context
-    // for ReactDomServer preinit/preloading to work
     payload ??= createFromReadableStream<RscPayload>(rscStream1)
     return React.use(payload).root
   }
 
-  // render html (traditional SSR)
   const bootstrapScriptContent =
     await import.meta.viteRsc.loadBootstrapScriptContent('index')
   let htmlStream: ReadableStream<Uint8Array>
@@ -41,8 +34,6 @@ export async function renderHTML(
       formState: options?.formState,
     })
   } catch (e) {
-    // fallback to render an empty shell and run pure CSR on browser,
-    // which can replay server component error and trigger error boundary.
     status = 500
     htmlStream = await renderToReadableStream(
       <html>
@@ -61,7 +52,6 @@ export async function renderHTML(
 
   let responseStream: ReadableStream<Uint8Array> = htmlStream
   if (!options?.debugNojs) {
-    // initial RSC stream is injected in HTML stream as <script>...FLIGHT_DATA...</script>
     responseStream = responseStream.pipeThrough(
       injectRSCPayload(rscStream2, {
         nonce: options?.nonce,

--- a/packages/plugin-rsc/examples/basic/src/framework/error-boundary.tsx
+++ b/packages/plugin-rsc/examples/basic/src/framework/error-boundary.tsx
@@ -2,7 +2,6 @@
 
 import React from 'react'
 
-// Minimal ErrorBoundary example to handle errors globally on browser
 export function GlobalErrorBoundary(props: { children?: React.ReactNode }) {
   return (
     <ErrorBoundary errorComponent={DefaultGlobalErrorPage}>
@@ -11,8 +10,6 @@ export function GlobalErrorBoundary(props: { children?: React.ReactNode }) {
   )
 }
 
-// https://github.com/vercel/next.js/blob/33f8428f7066bf8b2ec61f025427ceb2a54c4bdf/packages/next/src/client/components/error-boundary.tsx
-// https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary
 class ErrorBoundary extends React.Component<{
   children?: React.ReactNode
   errorComponent: React.FC<{
@@ -39,8 +36,6 @@ class ErrorBoundary extends React.Component<{
   }
 }
 
-// https://github.com/vercel/next.js/blob/677c9b372faef680d17e9ba224743f44e1107661/packages/next/src/build/webpack/loaders/next-app-loader.ts#L73
-// https://github.com/vercel/next.js/blob/677c9b372faef680d17e9ba224743f44e1107661/packages/next/src/client/components/error-boundary.tsx#L145
 // https://github.com/vercel/next.js/blob/473ae4b70dd781cc8b2620c95766f827296e689a/packages/next/src/client/components/builtin/global-error.tsx
 function DefaultGlobalErrorPage(props: { error: Error; reset: () => void }) {
   return (

--- a/packages/plugin-rsc/examples/basic/src/framework/request.tsx
+++ b/packages/plugin-rsc/examples/basic/src/framework/request.tsx
@@ -1,17 +1,12 @@
-// Framework conventions (arbitrary choices for this demo):
-// - Use `_.rsc` URL suffix to differentiate RSC requests from SSR requests
-// - Use `x-rsc-action` header to pass server action ID
 const URL_POSTFIX = '_.rsc'
 const HEADER_ACTION_ID = 'x-rsc-action'
 
-// Parsed request information used to route between RSC/SSR rendering and action handling.
-// Created by parseRenderRequest() from incoming HTTP requests.
 type RenderRequest = {
-  isRsc: boolean // true if request should return RSC payload (via _.rsc suffix)
-  isAction: boolean // true if this is a server action call (POST request)
-  actionId?: string // server action ID from x-rsc-action header
-  request: Request // normalized Request with _.rsc suffix removed from URL
-  url: URL // normalized URL with _.rsc suffix removed
+  isRsc: boolean
+  isAction: boolean
+  actionId?: string
+  request: Request
+  url: URL
 }
 
 export function createRscRenderRequest(

--- a/packages/plugin-rsc/examples/custom-server-function/src/framework/entry.browser.tsx
+++ b/packages/plugin-rsc/examples/custom-server-function/src/framework/entry.browser.tsx
@@ -13,17 +13,10 @@ import { GlobalErrorBoundary } from './error-boundary'
 import { createRscRenderRequest } from './request'
 
 async function main() {
-  // stash `setPayload` function to trigger re-rendering
-  // from outside of `BrowserRoot` component (e.g. server function call, navigation, hmr)
   let setPayload: (v: RscPayload) => void
 
-  // deserialize RSC stream back to React VDOM for CSR
-  const initialPayload = await createFromReadableStream<RscPayload>(
-    // initial RSC stream is injected in SSR stream as <script>...FLIGHT_DATA...</script>
-    rscStream,
-  )
+  const initialPayload = await createFromReadableStream<RscPayload>(rscStream)
 
-  // browser root component to (re-)render RSC payload as state
   function BrowserRoot() {
     const [payload, setPayload_] = React.useState(initialPayload)
 
@@ -31,7 +24,6 @@ async function main() {
       setPayload = (v) => React.startTransition(() => setPayload_(v))
     }, [setPayload_])
 
-    // re-fetch/render on client side navigation
     React.useEffect(() => {
       return listenNavigation(() => fetchRscPayload())
     }, [])
@@ -39,15 +31,12 @@ async function main() {
     return payload.root
   }
 
-  // re-fetch RSC and trigger re-rendering
   async function fetchRscPayload() {
     const renderRequest = createRscRenderRequest(window.location.href)
     const payload = await createFromFetch<RscPayload>(fetch(renderRequest))
     setPayload(payload)
   }
 
-  // register a handler which will be internally called by React
-  // on server function request after hydration.
   setServerCallback(async (id, args) => {
     const temporaryReferences = createTemporaryReferenceSet()
     const renderRequest = createRscRenderRequest(window.location.href, {
@@ -63,7 +52,6 @@ async function main() {
     return data
   })
 
-  // hydration
   const browserRoot = (
     <React.StrictMode>
       <GlobalErrorBoundary>
@@ -79,7 +67,6 @@ async function main() {
     })
   }
 
-  // implement server HMR by triggering re-fetch/render of RSC upon server code change
   if (import.meta.hot) {
     import.meta.hot.on('rsc:update', () => {
       fetchRscPayload()
@@ -87,7 +74,6 @@ async function main() {
   }
 }
 
-// a little helper to setup events interception for client side navigation
 function listenNavigation(onNavigation: () => void) {
   window.addEventListener('popstate', onNavigation)
 
@@ -114,10 +100,10 @@ function listenNavigation(onNavigation: () => void) {
       (!link.target || link.target === '_self') &&
       link.origin === location.origin &&
       !link.hasAttribute('download') &&
-      e.button === 0 && // left clicks only
-      !e.metaKey && // open in new tab (mac)
-      !e.ctrlKey && // open in new tab (windows)
-      !e.altKey && // download
+      e.button === 0 &&
+      !e.metaKey &&
+      !e.ctrlKey &&
+      !e.altKey &&
       !e.shiftKey &&
       !e.defaultPrevented
     ) {

--- a/packages/plugin-rsc/examples/custom-server-function/src/framework/entry.rsc.tsx
+++ b/packages/plugin-rsc/examples/custom-server-function/src/framework/entry.rsc.tsx
@@ -10,36 +10,24 @@ import type { ReactFormState } from 'react-dom/client'
 import { Root } from '../root.tsx'
 import { parseRenderRequest } from './request.tsx'
 
-// The schema of payload which is serialized into RSC stream on rsc environment
-// and deserialized on ssr/client environments.
 export type RscPayload = {
-  // this demo renders/serializes/deserializes the entire root HTML element
-  // but this mechanism can be changed to render/fetch different parts of components
-  // based on your own route conventions.
   root: React.ReactNode
-  // server action return value of non-progressive enhancement case
   returnValue?: { ok: boolean; data: unknown }
-  // server action form state (e.g. useActionState) of progressive enhancement case
   formState?: ReactFormState
 }
 
-// The plugin assumes by default that the `rsc` entry has a default export of a request handler.
-// However, server entries can be executed differently by registering your own server handler.
 export default { fetch: handler }
 
 async function handler(request: Request): Promise<Response> {
-  // differentiate RSC, SSR, action, etc.
   const renderRequest = parseRenderRequest(request)
   request = renderRequest.request
 
-  // handle server function request
   let returnValue: RscPayload['returnValue'] | undefined
   let formState: ReactFormState | undefined
   let temporaryReferences: unknown | undefined
   let actionStatus: number | undefined
   if (renderRequest.isAction === true) {
     if (renderRequest.actionId) {
-      // action is called via `ReactClient.setServerCallback`.
       const contentType = request.headers.get('content-type')
       const body = contentType?.startsWith('multipart/form-data')
         ? await request.formData()
@@ -55,17 +43,12 @@ async function handler(request: Request): Promise<Response> {
         actionStatus = 500
       }
     } else {
-      // otherwise server function is called via `<form action={...}>`
-      // before hydration (e.g. when javascript is disabled).
-      // aka progressive enhancement.
       const formData = await request.formData()
       const decodedAction = await decodeAction(formData)
       try {
         const result = await decodedAction()
         formState = await decodeFormState(result, formData)
       } catch (e) {
-        // there's no single general obvious way to surface this error,
-        // so explicitly return classic 500 response.
         return new Response('Internal Server Error: server action failed', {
           status: 500,
         })
@@ -73,10 +56,6 @@ async function handler(request: Request): Promise<Response> {
     }
   }
 
-  // serialization from React VDOM tree to RSC stream.
-  // we render RSC stream after handling server function request
-  // so that new render reflects updated state from server function call
-  // to achieve single round trip to mutate and fetch from server.
   const rscPayload: RscPayload = {
     root: <Root url={renderRequest.url} />,
     formState,
@@ -85,7 +64,6 @@ async function handler(request: Request): Promise<Response> {
   const rscOptions = { temporaryReferences }
   const rscStream = renderToReadableStream<RscPayload>(rscPayload, rscOptions)
 
-  // Respond RSC stream without HTML rendering as decided by `RenderRequest`
   if (renderRequest.isRsc) {
     return new Response(rscStream, {
       status: actionStatus,
@@ -95,20 +73,14 @@ async function handler(request: Request): Promise<Response> {
     })
   }
 
-  // Delegate to SSR environment for html rendering.
-  // The plugin provides `loadModule` helper to allow loading SSR environment entry module
-  // in RSC environment. however this can be customized by implementing own runtime communication
-  // e.g. `@cloudflare/vite-plugin`'s service binding.
   const ssrEntryModule = await import.meta.viteRsc.loadModule<
     typeof import('./entry.ssr.tsx')
   >('ssr', 'index')
   const ssrResult = await ssrEntryModule.renderHTML(rscStream, {
     formState,
-    // allow quick simulation of javascript disabled browser
     debugNojs: renderRequest.url.searchParams.has('__nojs'),
   })
 
-  // respond html
   return new Response(ssrResult.stream, {
     status: ssrResult.status,
     headers: {

--- a/packages/plugin-rsc/examples/custom-server-function/src/framework/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/custom-server-function/src/framework/entry.ssr.tsx
@@ -13,21 +13,14 @@ export async function renderHTML(
     debugNojs?: boolean
   },
 ): Promise<{ stream: ReadableStream<Uint8Array>; status?: number }> {
-  // duplicate one RSC stream into two.
-  // - one for SSR (ReactClient.createFromReadableStream below)
-  // - another for browser hydration payload by injecting <script>...FLIGHT_DATA...</script>.
   const [rscStream1, rscStream2] = rscStream.tee()
 
-  // deserialize RSC stream back to React VDOM
   let payload: Promise<RscPayload> | undefined
   function SsrRoot() {
-    // deserialization needs to be kicked off inside ReactDOMServer context
-    // for ReactDomServer preinit/preloading to work
     payload ??= createFromReadableStream<RscPayload>(rscStream1)
     return React.use(payload).root
   }
 
-  // render html (traditional SSR)
   const bootstrapScriptContent =
     await import.meta.viteRsc.loadBootstrapScriptContent('index')
   let htmlStream: ReadableStream<Uint8Array>
@@ -41,8 +34,6 @@ export async function renderHTML(
       formState: options?.formState,
     })
   } catch (e) {
-    // fallback to render an empty shell and run pure CSR on browser,
-    // which can replay server component error and trigger error boundary.
     status = 500
     htmlStream = await renderToReadableStream(
       <html>
@@ -61,8 +52,6 @@ export async function renderHTML(
 
   let responseStream: ReadableStream<Uint8Array> = htmlStream
   if (!options?.debugNojs) {
-    // initial RSC stream is injected in HTML stream as <script>...FLIGHT_DATA...</script>
-    // using utility made by devongovett https://github.com/devongovett/rsc-html-stream
     responseStream = responseStream.pipeThrough(
       injectRSCPayload(rscStream2, {
         nonce: options?.nonce,

--- a/packages/plugin-rsc/examples/custom-server-function/src/framework/error-boundary.tsx
+++ b/packages/plugin-rsc/examples/custom-server-function/src/framework/error-boundary.tsx
@@ -2,7 +2,6 @@
 
 import React from 'react'
 
-// Minimal ErrorBoundary example to handle errors globally on browser
 export function GlobalErrorBoundary(props: { children?: React.ReactNode }) {
   return (
     <ErrorBoundary errorComponent={DefaultGlobalErrorPage}>
@@ -11,8 +10,6 @@ export function GlobalErrorBoundary(props: { children?: React.ReactNode }) {
   )
 }
 
-// https://github.com/vercel/next.js/blob/33f8428f7066bf8b2ec61f025427ceb2a54c4bdf/packages/next/src/client/components/error-boundary.tsx
-// https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary
 class ErrorBoundary extends React.Component<{
   children?: React.ReactNode
   errorComponent: React.FC<{
@@ -39,8 +36,6 @@ class ErrorBoundary extends React.Component<{
   }
 }
 
-// https://github.com/vercel/next.js/blob/677c9b372faef680d17e9ba224743f44e1107661/packages/next/src/build/webpack/loaders/next-app-loader.ts#L73
-// https://github.com/vercel/next.js/blob/677c9b372faef680d17e9ba224743f44e1107661/packages/next/src/client/components/error-boundary.tsx#L145
 function DefaultGlobalErrorPage(props: { error: Error; reset: () => void }) {
   return (
     <html>

--- a/packages/plugin-rsc/examples/custom-server-function/src/framework/request.tsx
+++ b/packages/plugin-rsc/examples/custom-server-function/src/framework/request.tsx
@@ -1,17 +1,12 @@
-// Framework conventions (arbitrary choices for this demo):
-// - Use `_.rsc` URL suffix to differentiate RSC requests from SSR requests
-// - Use `x-rsc-action` header to pass server action ID
 const URL_POSTFIX = '_.rsc'
 const HEADER_ACTION_ID = 'x-rsc-action'
 
-// Parsed request information used to route between RSC/SSR rendering and action handling.
-// Created by parseRenderRequest() from incoming HTTP requests.
 type RenderRequest = {
-  isRsc: boolean // true if request should return RSC payload (via _.rsc suffix)
-  isAction: boolean // true if this is a server action call (POST request)
-  actionId?: string // server action ID from x-rsc-action header
-  request: Request // normalized Request with _.rsc suffix removed from URL
-  url: URL // normalized URL with _.rsc suffix removed
+  isRsc: boolean
+  isAction: boolean
+  actionId?: string
+  request: Request
+  url: URL
 }
 
 export function createRscRenderRequest(

--- a/packages/plugin-rsc/examples/starter-extra/README.md
+++ b/packages/plugin-rsc/examples/starter-extra/README.md
@@ -2,6 +2,8 @@
 
 This fixture starts as a copy of [`examples/starter`](../starter) and is reserved for focused e2e scenarios that should not make the public starter demo harder to read.
 
+Its [`src/framework`](./src/framework) directory is the comment-light maintenance baseline for conventional RSC examples. Keep those examples aligned with this shape except where their demonstrated behavior requires a difference. The public starter retains the equivalent instructional implementation with inline commentary.
+
 Use this when a scenario needs a small starter-like app but requires extra test-only routes, components, styles, or deployment variants.
 
 ```sh

--- a/packages/plugin-rsc/examples/starter-extra/src/framework/entry.browser.tsx
+++ b/packages/plugin-rsc/examples/starter-extra/src/framework/entry.browser.tsx
@@ -13,17 +13,10 @@ import { GlobalErrorBoundary } from './error-boundary'
 import { createRscRenderRequest } from './request'
 
 async function main() {
-  // stash `setPayload` function to trigger re-rendering
-  // from outside of `BrowserRoot` component (e.g. server function call, navigation, hmr)
   let setPayload: (v: RscPayload) => void
 
-  // deserialize RSC stream back to React VDOM for CSR
-  const initialPayload = await createFromReadableStream<RscPayload>(
-    // initial RSC stream is injected in SSR stream as <script>...FLIGHT_DATA...</script>
-    rscStream,
-  )
+  const initialPayload = await createFromReadableStream<RscPayload>(rscStream)
 
-  // browser root component to (re-)render RSC payload as state
   function BrowserRoot() {
     const [payload, setPayload_] = React.useState(initialPayload)
 
@@ -31,7 +24,6 @@ async function main() {
       setPayload = (v) => React.startTransition(() => setPayload_(v))
     }, [setPayload_])
 
-    // re-fetch/render on client side navigation
     React.useEffect(() => {
       return listenNavigation(() => fetchRscPayload())
     }, [])
@@ -39,15 +31,12 @@ async function main() {
     return payload.root
   }
 
-  // re-fetch RSC and trigger re-rendering
   async function fetchRscPayload() {
     const renderRequest = createRscRenderRequest(window.location.href)
     const payload = await createFromFetch<RscPayload>(fetch(renderRequest))
     setPayload(payload)
   }
 
-  // register a handler which will be internally called by React
-  // on server function request after hydration.
   setServerCallback(async (id, args) => {
     const temporaryReferences = createTemporaryReferenceSet()
     const renderRequest = createRscRenderRequest(window.location.href, {
@@ -63,7 +52,6 @@ async function main() {
     return data
   })
 
-  // hydration
   const browserRoot = (
     <React.StrictMode>
       <GlobalErrorBoundary>
@@ -79,7 +67,6 @@ async function main() {
     })
   }
 
-  // implement server HMR by triggering re-fetch/render of RSC upon server code change
   if (import.meta.hot) {
     import.meta.hot.on('rsc:update', () => {
       fetchRscPayload()
@@ -87,7 +74,6 @@ async function main() {
   }
 }
 
-// a little helper to setup events interception for client side navigation
 function listenNavigation(onNavigation: () => void) {
   window.addEventListener('popstate', onNavigation)
 
@@ -114,10 +100,10 @@ function listenNavigation(onNavigation: () => void) {
       (!link.target || link.target === '_self') &&
       link.origin === location.origin &&
       !link.hasAttribute('download') &&
-      e.button === 0 && // left clicks only
-      !e.metaKey && // open in new tab (mac)
-      !e.ctrlKey && // open in new tab (windows)
-      !e.altKey && // download
+      e.button === 0 &&
+      !e.metaKey &&
+      !e.ctrlKey &&
+      !e.altKey &&
       !e.shiftKey &&
       !e.defaultPrevented
     ) {

--- a/packages/plugin-rsc/examples/starter-extra/src/framework/entry.rsc.tsx
+++ b/packages/plugin-rsc/examples/starter-extra/src/framework/entry.rsc.tsx
@@ -10,36 +10,24 @@ import type { ReactFormState } from 'react-dom/client'
 import { Root } from '../root.tsx'
 import { parseRenderRequest } from './request.tsx'
 
-// The schema of payload which is serialized into RSC stream on rsc environment
-// and deserialized on ssr/client environments.
 export type RscPayload = {
-  // this demo renders/serializes/deserializes the entire root HTML element
-  // but this mechanism can be changed to render/fetch different parts of components
-  // based on your own route conventions.
   root: React.ReactNode
-  // server action return value of non-progressive enhancement case
   returnValue?: { ok: boolean; data: unknown }
-  // server action form state (e.g. useActionState) of progressive enhancement case
   formState?: ReactFormState
 }
 
-// The plugin assumes by default that the `rsc` entry has a default export of a request handler.
-// However, server entries can be executed differently by registering your own server handler.
 export default { fetch: handler }
 
 async function handler(request: Request): Promise<Response> {
-  // differentiate RSC, SSR, action, etc.
   const renderRequest = parseRenderRequest(request)
   request = renderRequest.request
 
-  // handle server function request
   let returnValue: RscPayload['returnValue'] | undefined
   let formState: ReactFormState | undefined
   let temporaryReferences: unknown | undefined
   let actionStatus: number | undefined
   if (renderRequest.isAction === true) {
     if (renderRequest.actionId) {
-      // action is called via `ReactClient.setServerCallback`.
       const contentType = request.headers.get('content-type')
       const body = contentType?.startsWith('multipart/form-data')
         ? await request.formData()
@@ -55,17 +43,12 @@ async function handler(request: Request): Promise<Response> {
         actionStatus = 500
       }
     } else {
-      // otherwise server function is called via `<form action={...}>`
-      // before hydration (e.g. when javascript is disabled).
-      // aka progressive enhancement.
       const formData = await request.formData()
       const decodedAction = await decodeAction(formData)
       try {
         const result = await decodedAction()
         formState = await decodeFormState(result, formData)
       } catch (e) {
-        // there's no single general obvious way to surface this error,
-        // so explicitly return classic 500 response.
         return new Response('Internal Server Error: server action failed', {
           status: 500,
         })
@@ -73,10 +56,6 @@ async function handler(request: Request): Promise<Response> {
     }
   }
 
-  // serialization from React VDOM tree to RSC stream.
-  // we render RSC stream after handling server function request
-  // so that new render reflects updated state from server function call
-  // to achieve single round trip to mutate and fetch from server.
   const rscPayload: RscPayload = {
     root: <Root url={renderRequest.url} />,
     formState,
@@ -85,7 +64,6 @@ async function handler(request: Request): Promise<Response> {
   const rscOptions = { temporaryReferences }
   const rscStream = renderToReadableStream<RscPayload>(rscPayload, rscOptions)
 
-  // Respond RSC stream without HTML rendering as decided by `RenderRequest`
   if (renderRequest.isRsc) {
     return new Response(rscStream, {
       status: actionStatus,
@@ -95,20 +73,14 @@ async function handler(request: Request): Promise<Response> {
     })
   }
 
-  // Delegate to SSR environment for html rendering.
-  // The plugin provides `loadModule` helper to allow loading SSR environment entry module
-  // in RSC environment. however this can be customized by implementing own runtime communication
-  // e.g. `@cloudflare/vite-plugin`'s service binding.
   const ssrEntryModule = await import.meta.viteRsc.loadModule<
     typeof import('./entry.ssr.tsx')
   >('ssr', 'index')
   const ssrResult = await ssrEntryModule.renderHTML(rscStream, {
     formState,
-    // allow quick simulation of javascript disabled browser
     debugNojs: renderRequest.url.searchParams.has('__nojs'),
   })
 
-  // respond html
   return new Response(ssrResult.stream, {
     status: ssrResult.status,
     headers: {

--- a/packages/plugin-rsc/examples/starter-extra/src/framework/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/starter-extra/src/framework/entry.ssr.tsx
@@ -13,21 +13,14 @@ export async function renderHTML(
     debugNojs?: boolean
   },
 ): Promise<{ stream: ReadableStream<Uint8Array>; status?: number }> {
-  // duplicate one RSC stream into two.
-  // - one for SSR (ReactClient.createFromReadableStream below)
-  // - another for browser hydration payload by injecting <script>...FLIGHT_DATA...</script>.
   const [rscStream1, rscStream2] = rscStream.tee()
 
-  // deserialize RSC stream back to React VDOM
   let payload: Promise<RscPayload> | undefined
   function SsrRoot() {
-    // deserialization needs to be kicked off inside ReactDOMServer context
-    // for ReactDomServer preinit/preloading to work
     payload ??= createFromReadableStream<RscPayload>(rscStream1)
     return React.use(payload).root
   }
 
-  // render html (traditional SSR)
   const bootstrapScriptContent =
     await import.meta.viteRsc.loadBootstrapScriptContent('index')
   let htmlStream: ReadableStream<Uint8Array>
@@ -41,8 +34,6 @@ export async function renderHTML(
       formState: options?.formState,
     })
   } catch (e) {
-    // fallback to render an empty shell and run pure CSR on browser,
-    // which can replay server component error and trigger error boundary.
     status = 500
     htmlStream = await renderToReadableStream(
       <html>
@@ -61,8 +52,6 @@ export async function renderHTML(
 
   let responseStream: ReadableStream<Uint8Array> = htmlStream
   if (!options?.debugNojs) {
-    // initial RSC stream is injected in HTML stream as <script>...FLIGHT_DATA...</script>
-    // using utility made by devongovett https://github.com/devongovett/rsc-html-stream
     responseStream = responseStream.pipeThrough(
       injectRSCPayload(rscStream2, {
         nonce: options?.nonce,

--- a/packages/plugin-rsc/examples/starter-extra/src/framework/error-boundary.tsx
+++ b/packages/plugin-rsc/examples/starter-extra/src/framework/error-boundary.tsx
@@ -2,7 +2,6 @@
 
 import React from 'react'
 
-// Minimal ErrorBoundary example to handle errors globally on browser
 export function GlobalErrorBoundary(props: { children?: React.ReactNode }) {
   return (
     <ErrorBoundary errorComponent={DefaultGlobalErrorPage}>
@@ -11,8 +10,6 @@ export function GlobalErrorBoundary(props: { children?: React.ReactNode }) {
   )
 }
 
-// https://github.com/vercel/next.js/blob/33f8428f7066bf8b2ec61f025427ceb2a54c4bdf/packages/next/src/client/components/error-boundary.tsx
-// https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary
 class ErrorBoundary extends React.Component<{
   children?: React.ReactNode
   errorComponent: React.FC<{
@@ -39,8 +36,6 @@ class ErrorBoundary extends React.Component<{
   }
 }
 
-// https://github.com/vercel/next.js/blob/677c9b372faef680d17e9ba224743f44e1107661/packages/next/src/build/webpack/loaders/next-app-loader.ts#L73
-// https://github.com/vercel/next.js/blob/677c9b372faef680d17e9ba224743f44e1107661/packages/next/src/client/components/error-boundary.tsx#L145
 function DefaultGlobalErrorPage(props: { error: Error; reset: () => void }) {
   return (
     <html>

--- a/packages/plugin-rsc/examples/starter-extra/src/framework/request.tsx
+++ b/packages/plugin-rsc/examples/starter-extra/src/framework/request.tsx
@@ -1,17 +1,12 @@
-// Framework conventions (arbitrary choices for this demo):
-// - Use `_.rsc` URL suffix to differentiate RSC requests from SSR requests
-// - Use `x-rsc-action` header to pass server action ID
 const URL_POSTFIX = '_.rsc'
 const HEADER_ACTION_ID = 'x-rsc-action'
 
-// Parsed request information used to route between RSC/SSR rendering and action handling.
-// Created by parseRenderRequest() from incoming HTTP requests.
 type RenderRequest = {
-  isRsc: boolean // true if request should return RSC payload (via _.rsc suffix)
-  isAction: boolean // true if this is a server action call (POST request)
-  actionId?: string // server action ID from x-rsc-action header
-  request: Request // normalized Request with _.rsc suffix removed from URL
-  url: URL // normalized URL with _.rsc suffix removed
+  isRsc: boolean
+  isAction: boolean
+  actionId?: string
+  request: Request
+  url: URL
 }
 
 export function createRscRenderRequest(

--- a/packages/plugin-rsc/examples/use-cache/src/framework/entry.browser.tsx
+++ b/packages/plugin-rsc/examples/use-cache/src/framework/entry.browser.tsx
@@ -13,17 +13,10 @@ import { GlobalErrorBoundary } from './error-boundary'
 import { createRscRenderRequest } from './request'
 
 async function main() {
-  // stash `setPayload` function to trigger re-rendering
-  // from outside of `BrowserRoot` component (e.g. server function call, navigation, hmr)
   let setPayload: (v: RscPayload) => void
 
-  // deserialize RSC stream back to React VDOM for CSR
-  const initialPayload = await createFromReadableStream<RscPayload>(
-    // initial RSC stream is injected in SSR stream as <script>...FLIGHT_DATA...</script>
-    rscStream,
-  )
+  const initialPayload = await createFromReadableStream<RscPayload>(rscStream)
 
-  // browser root component to (re-)render RSC payload as state
   function BrowserRoot() {
     const [payload, setPayload_] = React.useState(initialPayload)
 
@@ -31,7 +24,6 @@ async function main() {
       setPayload = (v) => React.startTransition(() => setPayload_(v))
     }, [setPayload_])
 
-    // re-fetch/render on client side navigation
     React.useEffect(() => {
       return listenNavigation(() => fetchRscPayload())
     }, [])
@@ -39,15 +31,12 @@ async function main() {
     return payload.root
   }
 
-  // re-fetch RSC and trigger re-rendering
   async function fetchRscPayload() {
     const renderRequest = createRscRenderRequest(window.location.href)
     const payload = await createFromFetch<RscPayload>(fetch(renderRequest))
     setPayload(payload)
   }
 
-  // register a handler which will be internally called by React
-  // on server function request after hydration.
   setServerCallback(async (id, args) => {
     const temporaryReferences = createTemporaryReferenceSet()
     const renderRequest = createRscRenderRequest(window.location.href, {
@@ -63,7 +52,6 @@ async function main() {
     return data
   })
 
-  // hydration
   const browserRoot = (
     <React.StrictMode>
       <GlobalErrorBoundary>
@@ -79,7 +67,6 @@ async function main() {
     })
   }
 
-  // implement server HMR by triggering re-fetch/render of RSC upon server code change
   if (import.meta.hot) {
     import.meta.hot.on('rsc:update', () => {
       fetchRscPayload()
@@ -87,7 +74,6 @@ async function main() {
   }
 }
 
-// a little helper to setup events interception for client side navigation
 function listenNavigation(onNavigation: () => void) {
   window.addEventListener('popstate', onNavigation)
 
@@ -114,10 +100,10 @@ function listenNavigation(onNavigation: () => void) {
       (!link.target || link.target === '_self') &&
       link.origin === location.origin &&
       !link.hasAttribute('download') &&
-      e.button === 0 && // left clicks only
-      !e.metaKey && // open in new tab (mac)
-      !e.ctrlKey && // open in new tab (windows)
-      !e.altKey && // download
+      e.button === 0 &&
+      !e.metaKey &&
+      !e.ctrlKey &&
+      !e.altKey &&
       !e.shiftKey &&
       !e.defaultPrevented
     ) {

--- a/packages/plugin-rsc/examples/use-cache/src/framework/entry.rsc.tsx
+++ b/packages/plugin-rsc/examples/use-cache/src/framework/entry.rsc.tsx
@@ -10,36 +10,24 @@ import type { ReactFormState } from 'react-dom/client'
 import { Root } from '../root.tsx'
 import { parseRenderRequest } from './request.tsx'
 
-// The schema of payload which is serialized into RSC stream on rsc environment
-// and deserialized on ssr/client environments.
 export type RscPayload = {
-  // this demo renders/serializes/deserializes the entire root HTML element
-  // but this mechanism can be changed to render/fetch different parts of components
-  // based on your own route conventions.
   root: React.ReactNode
-  // server action return value of non-progressive enhancement case
   returnValue?: { ok: boolean; data: unknown }
-  // server action form state (e.g. useActionState) of progressive enhancement case
   formState?: ReactFormState
 }
 
-// The plugin assumes by default that the `rsc` entry has a default export of a request handler.
-// However, server entries can be executed differently by registering your own server handler.
 export default { fetch: handler }
 
 async function handler(request: Request): Promise<Response> {
-  // differentiate RSC, SSR, action, etc.
   const renderRequest = parseRenderRequest(request)
   request = renderRequest.request
 
-  // handle server function request
   let returnValue: RscPayload['returnValue'] | undefined
   let formState: ReactFormState | undefined
   let temporaryReferences: unknown | undefined
   let actionStatus: number | undefined
   if (renderRequest.isAction === true) {
     if (renderRequest.actionId) {
-      // action is called via `ReactClient.setServerCallback`.
       const contentType = request.headers.get('content-type')
       const body = contentType?.startsWith('multipart/form-data')
         ? await request.formData()
@@ -55,17 +43,12 @@ async function handler(request: Request): Promise<Response> {
         actionStatus = 500
       }
     } else {
-      // otherwise server function is called via `<form action={...}>`
-      // before hydration (e.g. when javascript is disabled).
-      // aka progressive enhancement.
       const formData = await request.formData()
       const decodedAction = await decodeAction(formData)
       try {
         const result = await decodedAction()
         formState = await decodeFormState(result, formData)
       } catch (e) {
-        // there's no single general obvious way to surface this error,
-        // so explicitly return classic 500 response.
         return new Response('Internal Server Error: server action failed', {
           status: 500,
         })
@@ -73,10 +56,6 @@ async function handler(request: Request): Promise<Response> {
     }
   }
 
-  // serialization from React VDOM tree to RSC stream.
-  // we render RSC stream after handling server function request
-  // so that new render reflects updated state from server function call
-  // to achieve single round trip to mutate and fetch from server.
   const rscPayload: RscPayload = {
     root: <Root url={renderRequest.url} />,
     formState,
@@ -85,7 +64,6 @@ async function handler(request: Request): Promise<Response> {
   const rscOptions = { temporaryReferences }
   const rscStream = renderToReadableStream<RscPayload>(rscPayload, rscOptions)
 
-  // Respond RSC stream without HTML rendering as decided by `RenderRequest`
   if (renderRequest.isRsc) {
     return new Response(rscStream, {
       status: actionStatus,
@@ -95,20 +73,14 @@ async function handler(request: Request): Promise<Response> {
     })
   }
 
-  // Delegate to SSR environment for html rendering.
-  // The plugin provides `loadModule` helper to allow loading SSR environment entry module
-  // in RSC environment. however this can be customized by implementing own runtime communication
-  // e.g. `@cloudflare/vite-plugin`'s service binding.
   const ssrEntryModule = await import.meta.viteRsc.loadModule<
     typeof import('./entry.ssr.tsx')
   >('ssr', 'index')
   const ssrResult = await ssrEntryModule.renderHTML(rscStream, {
     formState,
-    // allow quick simulation of javascript disabled browser
     debugNojs: renderRequest.url.searchParams.has('__nojs'),
   })
 
-  // respond html
   return new Response(ssrResult.stream, {
     status: ssrResult.status,
     headers: {

--- a/packages/plugin-rsc/examples/use-cache/src/framework/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/use-cache/src/framework/entry.ssr.tsx
@@ -13,21 +13,14 @@ export async function renderHTML(
     debugNojs?: boolean
   },
 ): Promise<{ stream: ReadableStream<Uint8Array>; status?: number }> {
-  // duplicate one RSC stream into two.
-  // - one for SSR (ReactClient.createFromReadableStream below)
-  // - another for browser hydration payload by injecting <script>...FLIGHT_DATA...</script>.
   const [rscStream1, rscStream2] = rscStream.tee()
 
-  // deserialize RSC stream back to React VDOM
   let payload: Promise<RscPayload> | undefined
   function SsrRoot() {
-    // deserialization needs to be kicked off inside ReactDOMServer context
-    // for ReactDomServer preinit/preloading to work
     payload ??= createFromReadableStream<RscPayload>(rscStream1)
     return React.use(payload).root
   }
 
-  // render html (traditional SSR)
   const bootstrapScriptContent =
     await import.meta.viteRsc.loadBootstrapScriptContent('index')
   let htmlStream: ReadableStream<Uint8Array>
@@ -41,8 +34,6 @@ export async function renderHTML(
       formState: options?.formState,
     })
   } catch (e) {
-    // fallback to render an empty shell and run pure CSR on browser,
-    // which can replay server component error and trigger error boundary.
     status = 500
     htmlStream = await renderToReadableStream(
       <html>
@@ -61,8 +52,6 @@ export async function renderHTML(
 
   let responseStream: ReadableStream<Uint8Array> = htmlStream
   if (!options?.debugNojs) {
-    // initial RSC stream is injected in HTML stream as <script>...FLIGHT_DATA...</script>
-    // using utility made by devongovett https://github.com/devongovett/rsc-html-stream
     responseStream = responseStream.pipeThrough(
       injectRSCPayload(rscStream2, {
         nonce: options?.nonce,

--- a/packages/plugin-rsc/examples/use-cache/src/framework/error-boundary.tsx
+++ b/packages/plugin-rsc/examples/use-cache/src/framework/error-boundary.tsx
@@ -2,7 +2,6 @@
 
 import React from 'react'
 
-// Minimal ErrorBoundary example to handle errors globally on browser
 export function GlobalErrorBoundary(props: { children?: React.ReactNode }) {
   return (
     <ErrorBoundary errorComponent={DefaultGlobalErrorPage}>
@@ -11,8 +10,6 @@ export function GlobalErrorBoundary(props: { children?: React.ReactNode }) {
   )
 }
 
-// https://github.com/vercel/next.js/blob/33f8428f7066bf8b2ec61f025427ceb2a54c4bdf/packages/next/src/client/components/error-boundary.tsx
-// https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary
 class ErrorBoundary extends React.Component<{
   children?: React.ReactNode
   errorComponent: React.FC<{
@@ -39,8 +36,6 @@ class ErrorBoundary extends React.Component<{
   }
 }
 
-// https://github.com/vercel/next.js/blob/677c9b372faef680d17e9ba224743f44e1107661/packages/next/src/build/webpack/loaders/next-app-loader.ts#L73
-// https://github.com/vercel/next.js/blob/677c9b372faef680d17e9ba224743f44e1107661/packages/next/src/client/components/error-boundary.tsx#L145
 function DefaultGlobalErrorPage(props: { error: Error; reset: () => void }) {
   return (
     <html>

--- a/packages/plugin-rsc/examples/use-cache/src/framework/request.tsx
+++ b/packages/plugin-rsc/examples/use-cache/src/framework/request.tsx
@@ -1,17 +1,12 @@
-// Framework conventions (arbitrary choices for this demo):
-// - Use `_.rsc` URL suffix to differentiate RSC requests from SSR requests
-// - Use `x-rsc-action` header to pass server action ID
 const URL_POSTFIX = '_.rsc'
 const HEADER_ACTION_ID = 'x-rsc-action'
 
-// Parsed request information used to route between RSC/SSR rendering and action handling.
-// Created by parseRenderRequest() from incoming HTTP requests.
 type RenderRequest = {
-  isRsc: boolean // true if request should return RSC payload (via _.rsc suffix)
-  isAction: boolean // true if this is a server action call (POST request)
-  actionId?: string // server action ID from x-rsc-action header
-  request: Request // normalized Request with _.rsc suffix removed from URL
-  url: URL // normalized URL with _.rsc suffix removed
+  isRsc: boolean
+  isAction: boolean
+  actionId?: string
+  request: Request
+  url: URL
 }
 
 export function createRscRenderRequest(


### PR DESCRIPTION
We want to standardize e2e examples but `starter/framework` has too much narration and that's too much. This PR updates `starter-extra` to be comment-less version of `starter` and recommend as all example's baseline. 
