### PR TITLE
refactor(rsc): use Vite ESTree types

### DIFF
--- a/packages/plugin-rsc/package.json
+++ b/packages/plugin-rsc/package.json
@@ -52,7 +52,6 @@
     "@hiogawa/utils": "^1.7.0",
     "@playwright/test": "^1.62.0",
     "@tsconfig/strictest": "^2.0.8",
-    "@types/estree": "^1.0.9",
     "@types/node": "^24.13.3",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/packages/plugin-rsc/src/plugins/scan.ts
+++ b/packages/plugin-rsc/src/plugins/scan.ts
@@ -1,8 +1,8 @@
 import { exactRegex } from '@rolldown/pluginutils'
 import * as esModuleLexer from 'es-module-lexer'
-import { walk } from 'estree-walker'
 import { parseAstAsync, type Plugin } from 'vite'
 import type { RscPluginManager } from '../plugin'
+import { walk } from '../transforms/estree'
 
 // During scan build, we strip all code but imports to
 // traverse module graph faster and just discover client/server references.

--- a/packages/plugin-rsc/src/transforms/cjs.ts
+++ b/packages/plugin-rsc/src/transforms/cjs.ts
@@ -1,8 +1,7 @@
 import path from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
-import type { Program, Node } from 'estree'
-import { walk } from 'estree-walker'
 import MagicString from 'magic-string'
+import { walk, type Node, type Program } from './estree'
 import { buildScopeTree } from './scope'
 
 // TODO:

--- a/packages/plugin-rsc/src/transforms/estree.ts
+++ b/packages/plugin-rsc/src/transforms/estree.ts
@@ -1,9 +1,48 @@
-import type {} from 'estree'
+import { walk as walkEstree } from 'estree-walker'
+import type { ESTree } from 'vite'
 
-// rollup ast has node position
-declare module 'estree' {
-  interface BaseNode {
-    start: number
-    end: number
-  }
+export type ArrowFunctionExpression = ESTree.ArrowFunctionExpression
+export type ExportAllDeclaration = ESTree.ExportAllDeclaration
+export type ExportDefaultDeclaration = ESTree.ExportDefaultDeclaration
+export type FunctionDeclaration = ESTree.Function & {
+  type: 'FunctionDeclaration'
+  id: ESTree.BindingIdentifier
 }
+export type FunctionExpression = ESTree.Function & {
+  type: 'FunctionExpression'
+}
+export type Identifier =
+  | ESTree.BindingIdentifier
+  | ESTree.IdentifierName
+  | ESTree.IdentifierReference
+  | ESTree.LabelIdentifier
+export type Literal = Extract<ESTree.Node, { type: 'Literal' }>
+export type MemberExpression = ESTree.MemberExpression
+export type Node = ESTree.Node
+export type Pattern =
+  | ESTree.BindingPattern
+  | ESTree.BindingRestElement
+  | ESTree.FormalParameterRest
+  | ESTree.MemberExpression
+  | ESTree.TSParameterProperty
+export type Program = ESTree.Program
+
+type WalkerContext = {
+  skip: () => void
+  remove: () => void
+  replace: (node: Node) => void
+}
+
+type WalkerHandler = (
+  this: WalkerContext,
+  node: Node,
+  parent: Node | null,
+  key: string | number | symbol | null | undefined,
+  index: number | null | undefined,
+) => void
+
+// estree-walker supports these nodes at runtime but types them with @types/estree.
+export const walk = walkEstree as unknown as (
+  ast: Node,
+  walker: { enter?: WalkerHandler; leave?: WalkerHandler },
+) => Node | null

--- a/packages/plugin-rsc/src/transforms/expand-export-all.ts
+++ b/packages/plugin-rsc/src/transforms/expand-export-all.ts
@@ -1,5 +1,5 @@
-import type { ExportAllDeclaration, Program } from 'estree'
 import MagicString from 'magic-string'
+import type { ExportAllDeclaration, Program } from './estree'
 import { extractNames } from './utils'
 
 export interface TransformExpandExportAllContext {

--- a/packages/plugin-rsc/src/transforms/hoist.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.ts
@@ -1,13 +1,13 @@
 import { tinyassert } from '@hiogawa/utils'
-import type {
-  Program,
-  Literal,
-  Node,
-  MemberExpression,
-  Identifier,
-} from 'estree'
-import { walk } from 'estree-walker'
 import MagicString from 'magic-string'
+import {
+  walk,
+  type Identifier,
+  type Literal,
+  type MemberExpression,
+  type Node,
+  type Program,
+} from './estree'
 import { buildScopeTree, type ScopeTree } from './scope'
 
 /**
@@ -109,7 +109,7 @@ export function transformHoistInlineDirective(
         (node.type === 'FunctionExpression' ||
           node.type === 'FunctionDeclaration' ||
           node.type === 'ArrowFunctionExpression') &&
-        node.body.type === 'BlockStatement'
+        node.body?.type === 'BlockStatement'
       ) {
         // Only transform functions whose block contains the requested
         // directive. Other function shapes cannot contain directive prologues.
@@ -127,7 +127,7 @@ export function transformHoistInlineDirective(
         // Capture the source-level name so the hoisted function can preserve it
         // with Object.defineProperty below. Anonymous functions get a stable
         // fallback for registration and diagnostics.
-        const declName = node.type === 'FunctionDeclaration' && node.id.name
+        const declName = node.type === 'FunctionDeclaration' && node.id?.name
         const originalName =
           declName ||
           (parent?.type === 'VariableDeclarator' &&

--- a/packages/plugin-rsc/src/transforms/proxy-export.ts
+++ b/packages/plugin-rsc/src/transforms/proxy-export.ts
@@ -1,5 +1,5 @@
-import type { Node, Program } from 'estree'
 import MagicString from 'magic-string'
+import type { Node, Program } from './estree'
 import { extractNames, hasDirective, validateNonAsyncFunction } from './utils'
 
 export type TransformProxyExportOptions = {
@@ -68,7 +68,7 @@ export function transformProxyExport(
            * export function foo() {}
            */
           validateNonAsyncFunction(options, node.declaration)
-          createExport(node, [node.declaration.id.name])
+          createExport(node, [node.declaration.id!.name])
         } else if (node.declaration.type === 'VariableDeclaration') {
           /**
            * export const foo = 1, bar = 2
@@ -96,8 +96,6 @@ export function transformProxyExport(
             extractNames(decl.id),
           )
           createExport(node, names)
-        } else {
-          node.declaration satisfies never
         }
       } else {
         /**

--- a/packages/plugin-rsc/src/transforms/scope.test.ts
+++ b/packages/plugin-rsc/src/transforms/scope.test.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
-import type { Identifier, MemberExpression, Node } from 'estree'
 import { parseAstAsync } from 'vite'
 import { describe, expect, it } from 'vitest'
+import type { Identifier, MemberExpression, Node } from './estree'
 import { type Scope, type ScopeTree, buildScopeTree } from './scope'
 
 // TODO:

--- a/packages/plugin-rsc/src/transforms/scope.ts
+++ b/packages/plugin-rsc/src/transforms/scope.ts
@@ -1,14 +1,14 @@
 import { tinyassert } from '@hiogawa/utils'
-import type {
-  Program,
-  Identifier,
-  MemberExpression,
-  Node,
-  FunctionDeclaration,
-  FunctionExpression,
-  ArrowFunctionExpression,
-} from 'estree'
-import { walk } from 'estree-walker'
+import {
+  walk,
+  type ArrowFunctionExpression,
+  type FunctionDeclaration,
+  type FunctionExpression,
+  type Identifier,
+  type MemberExpression,
+  type Node,
+  type Program,
+} from './estree'
 import { extractNames } from './utils'
 
 // Replacement for periscopic to correctly handle variable shadowing

--- a/packages/plugin-rsc/src/transforms/server-action.ts
+++ b/packages/plugin-rsc/src/transforms/server-action.ts
@@ -1,5 +1,5 @@
-import type { Program } from 'estree'
 import type MagicString from 'magic-string'
+import type { Program } from './estree'
 import { transformHoistInlineDirective } from './hoist'
 import { hasDirective } from './utils'
 import { transformWrapExport } from './wrap-export'

--- a/packages/plugin-rsc/src/transforms/utils.ts
+++ b/packages/plugin-rsc/src/transforms/utils.ts
@@ -1,5 +1,10 @@
-import type { ExportDefaultDeclaration } from 'estree'
-import type { Identifier, Node, Pattern, Program } from 'estree'
+import type {
+  ExportDefaultDeclaration,
+  Identifier,
+  Node,
+  Pattern,
+  Program,
+} from './estree'
 
 export function hasDirective(
   body: Program['body'],
@@ -66,6 +71,9 @@ export function extractIdentifiers(
       break
     case 'AssignmentPattern':
       extractIdentifiers(param.left, nodes)
+      break
+    case 'TSParameterProperty':
+      extractIdentifiers(param.parameter, nodes)
       break
   }
   return nodes

--- a/packages/plugin-rsc/src/transforms/wrap-export.ts
+++ b/packages/plugin-rsc/src/transforms/wrap-export.ts
@@ -1,6 +1,6 @@
 import { tinyassert } from '@hiogawa/utils'
-import type { ExportDefaultDeclaration, Node, Program } from 'estree'
 import MagicString from 'magic-string'
+import type { ExportDefaultDeclaration, Node, Program } from './estree'
 import { extractNames, validateNonAsyncFunction } from './utils'
 
 type ExportMeta = {
@@ -125,7 +125,7 @@ export function transformWrapExport(
           /**
            * export function foo() {}
            */
-          const name = node.declaration.id.name
+          const name = node.declaration.id!.name
           const meta: ExportMeta = {
             isFunction: getIsFunction(node.declaration),
             declName: name,
@@ -166,8 +166,6 @@ export function transformWrapExport(
             }
           }
           wrapSimple(node.start, node.declaration.start, exports)
-        } else {
-          node.declaration satisfies never
         }
       } else {
         if (node.source) {

--- a/packages/plugin-rsc/tsconfig.base.json
+++ b/packages/plugin-rsc/tsconfig.base.json
@@ -1,9 +1,6 @@
 {
   "extends": "@tsconfig/strictest/tsconfig.json",
   "compilerOptions": {
-    "paths": {
-      "@oxc-project/types": ["./node_modules/@types/estree"]
-    },
     "noImplicitReturns": false,
     "exactOptionalPropertyTypes": false,
     "verbatimModuleSyntax": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
-overrides:
-  '@types/estree': ^1.0.9
-
 importers:
 
   .:
@@ -445,9 +442,6 @@ importers:
       '@tsconfig/strictest':
         specifier: ^2.0.8
         version: 2.0.8
-      '@types/estree':
-        specifier: ^1.0.9
-        version: 1.0.9
       '@types/node':
         specifier: ^24.13.3
         version: 24.13.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,9 +16,6 @@ onlyBuiltDependencies:
   - unrs-resolver
   - workerd
 
-overrides:
-  '@types/estree': ^1.0.9
-
 peerDependencyRules:
   ignoreMissing:
     # ignore react-server-dom-webpack -> webpack


### PR DESCRIPTION
A bit of churns with custom `packages/plugin-rsc/src/transforms/estree.ts` but probably good first step. 

Summary:
- consolidate ast types used by rsc transforms against Vite 8’s exported `ESTree` namespace instead of `@types/estree`.
- we still rely on `estree-walker` but uses it by wrapping with Vite AST types.

TODO:
- can we replace deprecated `parseAstAsync`? (need to check if Vite 7 exports)
- should be able to remove `as Parameters<typeof transformXxx>` like https://github.com/vitejs/vite-plugin-react/blob/b8c9264fe3bec509f64297e14fc0780417acf697/packages/plugin-rsc/examples/custom-server-function/custom-server-function-plugin.ts#L34-L36
