### PR TITLE
fix(rsc): align transform API types with Vite AST

### DIFF
--- a/packages/plugin-rsc/e2e/fixture.ts
+++ b/packages/plugin-rsc/e2e/fixture.ts
@@ -185,7 +185,9 @@ export async function setupIsolatedFixture(options: {
     ['config', 'get', 'overrides', '--json', '--location', 'project'],
     { throwOnError: true, nodeOptions: { cwd: rootDir } },
   )
-  const workspaceOverrides: Record<string, string> = JSON.parse(overridesJson)
+  const workspaceOverrides: Record<string, string> = JSON.parse(
+    overridesJson || '{}',
+  )
   const overrides: Record<string, string> = {
     '@vitejs/plugin-rsc': `file:${path.join(rootDir, 'packages/plugin-rsc')}`,
     '@vitejs/plugin-react': `file:${path.join(rootDir, 'packages/plugin-react')}`,

--- a/packages/plugin-rsc/examples/custom-server-function/custom-server-function-plugin.ts
+++ b/packages/plugin-rsc/examples/custom-server-function/custom-server-function-plugin.ts
@@ -31,9 +31,7 @@ export function customServerFunctionPlugin(): Plugin {
       }
 
       const reference = manager.serverReferences.resolve(id, 'rsc')
-      const ast = (await parseAstAsync(code)) as unknown as Parameters<
-        typeof transformHoistInlineDirective
-      >[1]
+      const ast = await parseAstAsync(code)
 
       if (environmentName === 'rsc') {
         const runtime = (value: string, name: string) =>

--- a/packages/plugin-rsc/examples/use-cache-callable/callable-cache-plugin.ts
+++ b/packages/plugin-rsc/examples/use-cache-callable/callable-cache-plugin.ts
@@ -25,9 +25,7 @@ export function callableCachePlugin(): Plugin {
       }
 
       const reference = manager.serverReferences.resolve(id, 'rsc')
-      const ast = (await parseAstAsync(code)) as unknown as Parameters<
-        typeof transformHoistInlineDirective
-      >[1]
+      const ast = await parseAstAsync(code)
       const environmentName = this.environment.name
 
       if (environmentName === 'rsc') {

--- a/packages/plugin-rsc/examples/use-cache/vite.config.ts
+++ b/packages/plugin-rsc/examples/use-cache/vite.config.ts
@@ -24,7 +24,6 @@ function vitePluginUseCache(): Plugin[] {
       async transform(code) {
         if (!code.includes('use cache')) return
         const ast = await parseAstAsync(code)
-        // @ts-ignore for rolldown-vite ci estree/oxc mismatch
         const result = transformHoistInlineDirective(code, ast, {
           runtime: (value) => `__vite_rsc_cache(${value})`,
           directive: 'use cache',

--- a/packages/plugin-rsc/src/plugins/scan.ts
+++ b/packages/plugin-rsc/src/plugins/scan.ts
@@ -1,5 +1,6 @@
 import { exactRegex } from '@rolldown/pluginutils'
 import * as esModuleLexer from 'es-module-lexer'
+import type { Program } from 'estree'
 import { walk } from 'estree-walker'
 import { parseAstAsync, type Plugin } from 'vite'
 import type { RscPluginManager } from '../plugin'
@@ -41,8 +42,9 @@ export async function transformScanBuildStrip(code: string): Promise<string> {
   // preserve import.meta.glob for rolldown-vite
   // https://github.com/vitejs/rolldown-vite/issues/373
   if (importGlobRE.test(code)) {
-    const ast = await parseAstAsync(code)
-    walk(ast as unknown as Parameters<typeof walk>[0], {
+    const viteAst = await parseAstAsync(code)
+    const ast = viteAst as unknown as Program
+    walk(ast, {
       enter(node) {
         if (
           node.type === 'CallExpression' &&

--- a/packages/plugin-rsc/src/plugins/scan.ts
+++ b/packages/plugin-rsc/src/plugins/scan.ts
@@ -42,7 +42,7 @@ export async function transformScanBuildStrip(code: string): Promise<string> {
   // https://github.com/vitejs/rolldown-vite/issues/373
   if (importGlobRE.test(code)) {
     const ast = await parseAstAsync(code)
-    walk(ast, {
+    walk(ast as unknown as Parameters<typeof walk>[0], {
       enter(node) {
         if (
           node.type === 'CallExpression' &&

--- a/packages/plugin-rsc/src/transforms/cjs.ts
+++ b/packages/plugin-rsc/src/transforms/cjs.ts
@@ -3,6 +3,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 import type { Program, Node } from 'estree'
 import { walk } from 'estree-walker'
 import MagicString from 'magic-string'
+import type { ESTree } from 'vite'
 import { buildScopeTree } from './scope'
 
 // TODO:
@@ -29,9 +30,10 @@ const CJS_INTEROP_HELPER = __cjs_interop__.toString().replace(/\n\s*/g, '')
 
 export function transformCjsToEsm(
   code: string,
-  ast: Program,
+  viteAst: ESTree.Program,
   options: { id: string },
 ): { output: MagicString } {
+  const ast = viteAst as unknown as Program
   const output = new MagicString(code)
   const scopeTree = buildScopeTree(ast)
 

--- a/packages/plugin-rsc/src/transforms/expand-export-all.ts
+++ b/packages/plugin-rsc/src/transforms/expand-export-all.ts
@@ -1,15 +1,16 @@
 import type { ExportAllDeclaration, Program } from 'estree'
 import MagicString from 'magic-string'
+import type { ESTree } from 'vite'
 import { extractNames } from './utils'
 
 export interface TransformExpandExportAllContext {
   resolve: (source: string, importer: string) => Promise<string | undefined>
-  load: (id: string) => Promise<Program>
+  load: (id: string) => Promise<ESTree.Program>
 }
 
 export interface TransformExpandExportAllOptions extends TransformExpandExportAllContext {
   code: string
-  ast: Program
+  ast: ESTree.Program
   importer: string
 }
 
@@ -46,7 +47,9 @@ type StarExportRewritePlan = {
 export async function transformExpandExportAll(
   options: TransformExpandExportAllOptions,
 ): Promise<{ code: string } | undefined> {
-  const scan = await scanModuleExports(options.ast, options.importer, options)
+  const ast = options.ast as unknown as Program
+  const context = options as unknown as EstreeTransformExpandExportAllContext
+  const scan = await scanModuleExports(ast, options.importer, context)
   const { plans } = resolveStarExports(scan)
   if (plans.length === 0) {
     return
@@ -61,12 +64,17 @@ export async function transformExpandExportAll(
   return { code: output.toString() }
 }
 
+type EstreeTransformExpandExportAllContext = {
+  resolve: TransformExpandExportAllContext['resolve']
+  load: (id: string) => Promise<Program>
+}
+
 // Scan a module into local explicit exports and recursively scanned direct
 // `export *` sources. This does not decide conflicts; resolveStarExports does.
 async function scanModuleExports(
   ast: Program,
   importer: string,
-  context: TransformExpandExportAllContext,
+  context: EstreeTransformExpandExportAllContext,
   seen = new Set<string>(),
 ): Promise<ModuleExportScan> {
   const starSources: StarExportSource[] = []
@@ -100,7 +108,7 @@ async function scanModuleExports(
 // resolution is ambiguous and must continue to poison parent star resolution.
 async function collectExportScan(
   resolvedId: string,
-  context: TransformExpandExportAllContext,
+  context: EstreeTransformExpandExportAllContext,
   seen: Set<string>,
 ): Promise<ExportNameScan> {
   if (seen.has(resolvedId)) {

--- a/packages/plugin-rsc/src/transforms/expand-export-all.ts
+++ b/packages/plugin-rsc/src/transforms/expand-export-all.ts
@@ -8,6 +8,11 @@ export interface TransformExpandExportAllContext {
   load: (id: string) => Promise<ESTree.Program>
 }
 
+type EstreeTransformExpandExportAllContext = {
+  resolve: TransformExpandExportAllContext['resolve']
+  load: (id: string) => Promise<Program>
+}
+
 export interface TransformExpandExportAllOptions extends TransformExpandExportAllContext {
   code: string
   ast: ESTree.Program
@@ -62,11 +67,6 @@ export async function transformExpandExportAll(
   // TODO: return a sourcemap so callers can compose this pre-rewrite with
   // their follow-up proxy/wrap transform maps.
   return { code: output.toString() }
-}
-
-type EstreeTransformExpandExportAllContext = {
-  resolve: TransformExpandExportAllContext['resolve']
-  load: (id: string) => Promise<Program>
 }
 
 // Scan a module into local explicit exports and recursively scanned direct

--- a/packages/plugin-rsc/src/transforms/hoist.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.ts
@@ -8,6 +8,7 @@ import type {
 } from 'estree'
 import { walk } from 'estree-walker'
 import MagicString from 'magic-string'
+import type { ESTree } from 'vite'
 import { buildScopeTree, type ScopeTree } from './scope'
 
 /**
@@ -83,7 +84,7 @@ import { buildScopeTree, type ScopeTree } from './scope'
  */
 export function transformHoistInlineDirective(
   input: string,
-  ast: Program,
+  viteAst: ESTree.Program,
   {
     runtime,
     rejectNonAsyncFunction,
@@ -111,6 +112,7 @@ export function transformHoistInlineDirective(
   output: MagicString
   names: string[]
 } {
+  const ast = viteAst as unknown as Program
   // MagicString needs an existing boundary at the move destination. The newline
   // also keeps the first appended declaration separate from the original source.
   if (!input.endsWith('\n')) {
@@ -293,7 +295,11 @@ function matchDirective(
   }
 }
 
-export function findDirectives(ast: Program, directive: string): Literal[] {
+export function findDirectives(
+  viteAst: ESTree.Program,
+  directive: string,
+): Literal[] {
+  const ast = viteAst as unknown as Program
   const directiveRE = exactRegex(directive)
   const nodes: Literal[] = []
   walk(ast, {

--- a/packages/plugin-rsc/src/transforms/proxy-export.ts
+++ b/packages/plugin-rsc/src/transforms/proxy-export.ts
@@ -1,5 +1,6 @@
 import type { Node, Program } from 'estree'
 import MagicString from 'magic-string'
+import type { ESTree } from 'vite'
 import { extractNames, hasDirective, validateNonAsyncFunction } from './utils'
 
 export type TransformProxyExportOptions = {
@@ -16,7 +17,7 @@ export type TransformProxyExportOptions = {
 }
 
 export function transformDirectiveProxyExport(
-  ast: Program,
+  ast: ESTree.Program,
   options: {
     directive: string
   } & TransformProxyExportOptions,
@@ -33,12 +34,13 @@ export function transformDirectiveProxyExport(
 }
 
 export function transformProxyExport(
-  ast: Program,
+  viteAst: ESTree.Program,
   options: TransformProxyExportOptions,
 ): {
   exportNames: string[]
   output: MagicString
 } {
+  const ast = viteAst as unknown as Program
   if (options.keep && typeof options.code !== 'string') {
     throw new Error('`keep` option requires `code`')
   }

--- a/packages/plugin-rsc/src/transforms/scope.test.ts
+++ b/packages/plugin-rsc/src/transforms/scope.test.ts
@@ -15,7 +15,9 @@ describe('fixtures', () => {
     it(path.basename(file), async () => {
       const input = ((await mod()) as any).default as string
       const ast = await parseAstAsync(input)
-      const scopeTree = buildScopeTree(ast)
+      const scopeTree = buildScopeTree(
+        ast as unknown as Parameters<typeof buildScopeTree>[0],
+      )
       const showReferenceNode = file.includes('/scope/reference-node/')
       const serialized = serializeScopeTree(scopeTree, { showReferenceNode })
       await expect(

--- a/packages/plugin-rsc/src/transforms/scope.test.ts
+++ b/packages/plugin-rsc/src/transforms/scope.test.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import type { Identifier, MemberExpression, Node } from 'estree'
+import type { Identifier, MemberExpression, Node, Program } from 'estree'
 import { parseAstAsync } from 'vite'
 import { describe, expect, it } from 'vitest'
 import { type Scope, type ScopeTree, buildScopeTree } from './scope'
@@ -14,10 +14,9 @@ describe('fixtures', () => {
   for (const [file, mod] of Object.entries(fixtures)) {
     it(path.basename(file), async () => {
       const input = ((await mod()) as any).default as string
-      const ast = await parseAstAsync(input)
-      const scopeTree = buildScopeTree(
-        ast as unknown as Parameters<typeof buildScopeTree>[0],
-      )
+      const viteAst = await parseAstAsync(input)
+      const ast = viteAst as unknown as Program
+      const scopeTree = buildScopeTree(ast)
       const showReferenceNode = file.includes('/scope/reference-node/')
       const serialized = serializeScopeTree(scopeTree, { showReferenceNode })
       await expect(

--- a/packages/plugin-rsc/src/transforms/server-action.ts
+++ b/packages/plugin-rsc/src/transforms/server-action.ts
@@ -1,5 +1,5 @@
-import type { Program } from 'estree'
 import type MagicString from 'magic-string'
+import type { ESTree } from 'vite'
 import { transformHoistInlineDirective } from './hoist'
 import { hasDirective } from './utils'
 import { transformWrapExport } from './wrap-export'
@@ -9,7 +9,7 @@ import { transformWrapExport } from './wrap-export'
 // needs to match original position.
 export function transformServerActionServer(
   input: string,
-  ast: Program,
+  ast: ESTree.Program,
   options: {
     runtime: (value: string, name: string) => string
     rejectNonAsyncFunction?: boolean

--- a/packages/plugin-rsc/src/transforms/utils.ts
+++ b/packages/plugin-rsc/src/transforms/utils.ts
@@ -1,10 +1,12 @@
 import type { ExportDefaultDeclaration } from 'estree'
 import type { Identifier, Node, Pattern, Program } from 'estree'
+import type { ESTree } from 'vite'
 
 export function hasDirective(
-  body: Program['body'],
+  viteBody: ESTree.Program['body'],
   directive: string,
 ): boolean {
+  const body = viteBody as unknown as Program['body']
   return !!body.find(
     (stmt) =>
       stmt.type === 'ExpressionStatement' &&

--- a/packages/plugin-rsc/src/transforms/wrap-export.ts
+++ b/packages/plugin-rsc/src/transforms/wrap-export.ts
@@ -1,6 +1,7 @@
 import { tinyassert } from '@hiogawa/utils'
 import type { ExportDefaultDeclaration, Node, Program } from 'estree'
 import MagicString from 'magic-string'
+import type { ESTree } from 'vite'
 import { extractNames, validateNonAsyncFunction } from './utils'
 
 type ExportMeta = {
@@ -50,12 +51,13 @@ export type TransformWrapExportOptions = {
 
 export function transformWrapExport(
   input: string,
-  ast: Program,
+  viteAst: ESTree.Program,
   options: TransformWrapExportOptions,
 ): {
   exportNames: string[]
   output: MagicString
 } {
+  const ast = viteAst as unknown as Program
   const output = new MagicString(input)
   const exportNames: string[] = []
   const toAppend: string[] = []

--- a/packages/plugin-rsc/tsconfig.base.json
+++ b/packages/plugin-rsc/tsconfig.base.json
@@ -1,9 +1,6 @@
 {
   "extends": "@tsconfig/strictest/tsconfig.json",
   "compilerOptions": {
-    "paths": {
-      "@oxc-project/types": ["./node_modules/@types/estree"]
-    },
     "noImplicitReturns": false,
     "exactOptionalPropertyTypes": false,
     "verbatimModuleSyntax": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
-overrides:
-  '@types/estree': ^1.0.9
-
 importers:
 
   .:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,9 +16,6 @@ onlyBuiltDependencies:
   - unrs-resolver
   - workerd
 
-overrides:
-  '@types/estree': ^1.0.9
-
 peerDependencyRules:
   ignoreMissing:
     # ignore react-server-dom-webpack -> webpack


### PR DESCRIPTION
This is a simpler and actually useful enough alternative of:
- https://github.com/vitejs/vite-plugin-react/pull/1347

This tweaks transform utility input/output to be Vite 8 `ESTree` AST type, then immediately cast to old `@types/estree` type to preserve main transform logic as is.

It also removes the old `@oxc-project/types` path mapping and workspace `@types/estree` override, which was for Vite 7 / Rollup AST type era workaround.