### PR TITLE
fix(react): make the react compiler preset filter linear

### DIFF
--- a/packages/plugin-react/CHANGELOG.md
+++ b/packages/plugin-react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed the react compiler preset filter to be linear
+
+The improved filter in v6.0.3 was non-linear and caused a performance regression ([#1349](https://github.com/vitejs/vite-plugin-react/issues/1349)). The filter was changed to be linear to avoid that.
+
 ## 6.0.4 (2026-07-22)
 
 ### Fixed `$RefreshSig$ is not defined` error when running `vite dev` with `NODE_ENV=production`
@@ -10,6 +14,10 @@ When running `vite dev` with `NODE_ENV=production`, the app errored with `$Refre
 This error is now fixed.
 
 ## 6.0.3 (2026-06-23)
+
+### Improve the react compiler preset filter to reduce false-positives ([#1138](https://github.com/vitejs/vite-plugin-react/pull/1138))
+
+Improved the filter in the react compiler babel preset to reduce the false-positives so that less modules are processed by the react compiler.
 
 ## 6.0.2 (2026-05-14)
 

--- a/packages/plugin-react/CHANGELOG.md
+++ b/packages/plugin-react/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-### Fixed the react compiler preset filter to be linear
+### Fixed the react compiler preset filter to be linear ([#1353](https://github.com/vitejs/vite-plugin-react/pull/1353))
 
 The improved filter in v6.0.3 was non-linear and caused a performance regression ([#1349](https://github.com/vitejs/vite-plugin-react/issues/1349)). The filter was changed to be linear to avoid that.
 

--- a/packages/plugin-react/src/reactCompilerPreset.test.ts
+++ b/packages/plugin-react/src/reactCompilerPreset.test.ts
@@ -150,12 +150,19 @@ export default memo(() => {
     'simple variable': ['const foo = 1', false],
     'lowercase function': ['function bar() {}', false],
     'lowercase arrow function': ['let baz = () => {}', false],
-    'non assignments (1)': ['(0,useState)()', false],
-    'non assignments (2)': ['[useState][0]()', false],
-    'non assignments (3)': ['useState;s()', false],
-    'non assignments (4)': ['useState,s()', false],
-    'object without methods (1)': ['const obj = { useState: 1 }', false],
-    'object without methods (2)': ['const obj = { Foo: 1 }', false],
+    'lowercase use prefix': ['const useful = true', false],
+
+    // these are false positives
+    // it is better to have false positives than false negatives,
+    // because false negatives will cause those files to not be processed by the react compiler
+    'false positive: hook reference (1)': ['(0,useState)()', true],
+    'false positive: hook reference (2)': ['[useState][0]()', true],
+    'false positive: hook reference (3)': ['useState;s()', true],
+    'false positive: hook reference (4)': ['useState,s()', true],
+    'false positive: hook property': ['const obj = { useState: 1 }', true],
+    'false positive: component property': ['const obj = { Foo: 1 }', true],
+    // https://github.com/vitejs/vite-plugin-react/issues/1349
+    'false positive: long component name': ['A'.repeat(50_000), true],
   }
 
   for (const [name, [code, expected]] of Object.entries(cases)) {

--- a/packages/plugin-react/src/reactCompilerPreset.ts
+++ b/packages/plugin-react/src/reactCompilerPreset.ts
@@ -4,8 +4,7 @@ import type {
   RolldownBabelPreset,
 } from '#optionalTypes'
 
-export const defaultCodeFilter =
-  /forwardRef|memo|(?:const|let|var|function)\s+(?:[A-Z]|use[A-Z0-9])|(?:[A-Z]|use[A-Z0-9])[^\s:=(){}[\],;]*\s*(?:\(|[:=]\s*(?:function|\())/
+export const defaultCodeFilter = /forwardRef|memo|\b(?:[A-Z]|use[A-Z0-9])/
 
 export const reactCompilerPreset = (
   options: ReactCompilerBabelPluginOptions = {},


### PR DESCRIPTION
### Description

```js
/forwardRef|memo|(?:const|let|var|function)\s+(?:[A-Z]|use[A-Z0-9])|(?:^|[^\w$\u0080-\uFFFF])(?:[A-Z]|use[A-Z0-9])[\w$\u0080-\uFFFF]*\s*(?:\(|[:=]\s*(?:function|\())/
/forwardRef|memo|(?:const|let|var|function)\s+(?:[A-Z]|use[A-Z0-9])|(?:^|[^\p{ID_Continue}$\u200C\u200D])(?:[A-Z]|use[A-Z0-9])[\p{ID_Continue}$\u200C\u200D]*\s*(?:\(|[:=]\s*(?:function|\())/u
```

AI initially suggested these, but I think it's too complex and is better to accept false-positives here.

fixes https://github.com/vitejs/vite-plugin-react/issues/1349
refs https://github.com/vitejs/vite-plugin-react/pull/1138
