### PR TITLE
chore(rsc): remove stale source map todo in `transformServerActionServer`

### DIFF
--- a/packages/plugin-rsc/src/transforms/server-action.ts
+++ b/packages/plugin-rsc/src/transforms/server-action.ts
@@ -4,9 +4,6 @@ import { transformHoistInlineDirective } from './hoist'
 import { hasDirective } from './utils'
 import { transformWrapExport } from './wrap-export'
 
-// TODO
-// source map for `options.runtime` (registerServerReference) call
-// needs to match original position.
 export function transformServerActionServer(
   input: string,
   ast: ESTree.Program,


### PR DESCRIPTION
As part of digging into https://github.com/vitejs/vite-plugin-react/issues/1350, it appears this TODO comment has been stale for a long time.

## Summary

Remove the stale source-map TODO above `transformServerActionServer`. The source-map behavior it requested was implemented and subsequently verified before `@vitejs/plugin-rsc` moved into this repository.

## Context

The TODO was originally added in [`hi-ogawa/vite-plugins@4593b255`](https://github.com/hi-ogawa/vite-plugins/commit/4593b255496339da96acbb0193584e309bcb1f13) as part of [hi-ogawa/vite-plugins#797](https://github.com/hi-ogawa/vite-plugins/pull/797). At that point, issue [hi-ogawa/vite-plugins#780](https://github.com/hi-ogawa/vite-plugins/issues/780) tracked that the unwrapped `registerServerReference` call did not yet preserve its original source position.

The immediately following [hi-ogawa/vite-plugins#798](https://github.com/hi-ogawa/vite-plugins/pull/798) implemented the current `MagicString.update(...).move(...)` lowering in `transformWrapExport`. Its adjacent comment documents that generated registration code maps to the original `export` token. Issue #780 then recorded that work as complete.

The user-facing behavior was verified in [hi-ogawa/vite-plugins#781](https://github.com/hi-ogawa/vite-plugins/issues/781), with the remaining Vite module-runner line offset fixed by [hi-ogawa/vite-plugins#810](https://github.com/hi-ogawa/vite-plugins/pull/810). This supports the React development behavior described in [facebook/react#30741](https://github.com/facebook/react/pull/30741), where the `registerServerReference` callsite identifies the server function source location.

The already-stale TODO was later copied into this repository with [vitejs/vite-plugin-react#521](https://github.com/vitejs/vite-plugin-react/pull/521). Removing it does not change transformation or source-map behavior.

## Test

- `pnpm test --run src/transforms/server-action.test.ts src/transforms/wrap-export.test.ts`