### PR TITLE
feat(rsc): add ability to access client entry URL from ssr environment and deprecate `loadBootstrapScriptContent`

### DIFF
--- a/packages/plugin-rsc/README.md
+++ b/packages/plugin-rsc/README.md
@@ -335,9 +335,7 @@ export function UserApp() {
 
 #### `getClientEntryUrl()`
 
-This returns the URL used to load the client entry specified by `environments.client.build.rollupOptions.input.index`.
-
-This can be used with React DOM SSR APIs such as [`renderToReadableStream`](https://react.dev/reference/react-dom/server/renderToReadableStream).
+This returns the URL used to load the client entry specified by `environments.client.build.rollupOptions.input.index`. This can be used with React DOM SSR APIs such as [`renderToReadableStream`](https://react.dev/reference/react-dom/server/renderToReadableStream).
 
 ```js
 import { getClientEntryUrl } from '@vitejs/plugin-rsc/ssr'

--- a/packages/plugin-rsc/README.md
+++ b/packages/plugin-rsc/README.md
@@ -337,7 +337,7 @@ export function UserApp() {
 
 This returns the URL of the browser entry specified by `environments.client.build.rollupOptions.input.index`. Import it from `@vitejs/plugin-rsc/ssr`. During development, the URL points to a virtual wrapper which sets up React Refresh and RSC HMR before loading the configured entry. During production, it points to the built entry chunk.
 
-This can be used with React DOM SSR APIs such as [`renderToReadableStream`](https://react.dev/reference/react-dom/server/renderToReadableStream), or to implement custom loading and recovery behavior.
+This can be used with React DOM SSR APIs such as [`renderToReadableStream`](https://react.dev/reference/react-dom/server/renderToReadableStream).
 
 ```js
 import { getClientEntryUrl } from '@vitejs/plugin-rsc/ssr'

--- a/packages/plugin-rsc/README.md
+++ b/packages/plugin-rsc/README.md
@@ -335,7 +335,7 @@ export function UserApp() {
 
 #### `getClientEntryUrl()`
 
-This returns the URL of the browser entry specified by `environments.client.build.rollupOptions.input.index`. Import it from `@vitejs/plugin-rsc/ssr`. During development, the URL points to a virtual wrapper which sets up React Refresh and RSC HMR before loading the configured entry. During production, it points to the built entry chunk.
+This returns the URL used to load the client entry specified by `environments.client.build.rollupOptions.input.index`.
 
 This can be used with React DOM SSR APIs such as [`renderToReadableStream`](https://react.dev/reference/react-dom/server/renderToReadableStream).
 

--- a/packages/plugin-rsc/README.md
+++ b/packages/plugin-rsc/README.md
@@ -348,7 +348,7 @@ const htmlStream = await renderToReadableStream(reactNode, {
 })
 ```
 
-`getClientEntryUrl()` throws when the default client entry is unavailable, such as when using the `customClientEntry` plugin option.
+`getClientEntryUrl()` cannot be used when the `customClientEntry` plugin option is enabled.
 
 ### Available on `client` environment
 

--- a/packages/plugin-rsc/README.md
+++ b/packages/plugin-rsc/README.md
@@ -186,20 +186,19 @@ if (import.meta.hot) {
 - [`entry.ssr.tsx`](./examples/starter/src/framework/entry.ssr.tsx)
 
 ```tsx
-import { createFromReadableStream } from '@vitejs/plugin-rsc/ssr'
+import {
+  createFromReadableStream,
+  getClientEntryUrl,
+} from '@vitejs/plugin-rsc/ssr'
 import { renderToReadableStream } from 'react-dom/server.edge'
 
 export async function handleSsr(rscStream: ReadableStream) {
   // deserialize RSC stream back to React VDOM
   const root = await createFromReadableStream(rscStream)
 
-  // helper API to allow referencing browser entry content from SSR environment
-  const bootstrapScriptContent =
-    await import.meta.viteRsc.loadBootstrapScriptContent('index')
-
   // render html (traditional SSR)
   const htmlStream = renderToReadableStream(root, {
-    bootstrapScriptContent,
+    bootstrapModules: [getClientEntryUrl()],
   })
 
   return htmlStream
@@ -334,19 +333,22 @@ export function UserApp() {
 
 ### Available on `ssr` environment
 
-#### `import.meta.viteRsc.loadBootstrapScriptContent("index")`
+#### `getClientEntryUrl()`
 
-This provides a raw js code to execute a browser entry file specified by `environments.client.build.rollupOptions.input.index`. This is intended to be used with React DOM SSR API, such as [`renderToReadableStream`](https://react.dev/reference/react-dom/server/renderToReadableStream)
+This returns the URL of the browser entry specified by `environments.client.build.rollupOptions.input.index`. Import it from `@vitejs/plugin-rsc/ssr`. During development, the URL points to a virtual wrapper which sets up React Refresh and RSC HMR before loading the configured entry. During production, it points to the built entry chunk.
+
+This can be used with React DOM SSR APIs such as [`renderToReadableStream`](https://react.dev/reference/react-dom/server/renderToReadableStream), or to implement custom loading and recovery behavior.
 
 ```js
+import { getClientEntryUrl } from '@vitejs/plugin-rsc/ssr'
 import { renderToReadableStream } from 'react-dom/server.edge'
 
-const bootstrapScriptContent =
-  await import.meta.viteRsc.loadBootstrapScriptContent('index')
 const htmlStream = await renderToReadableStream(reactNode, {
-  bootstrapScriptContent,
+  bootstrapModules: [getClientEntryUrl()],
 })
 ```
+
+`getClientEntryUrl()` throws when the default client entry is unavailable, such as when using the `customClientEntry` plugin option.
 
 ### Available on `client` environment
 

--- a/packages/plugin-rsc/e2e/client-entry-url.test.ts
+++ b/packages/plugin-rsc/e2e/client-entry-url.test.ts
@@ -81,10 +81,10 @@ test.describe('getClientEntryUrl with customClientEntry', () => {
 
   const f = useFixture({ root, mode: 'build' })
 
-  test('throws when the default entry is unavailable', async ({ request }) => {
+  test('throws with customClientEntry', async ({ request }) => {
     const response = await request.get(f.url())
     await expect(response.text()).resolves.toContain(
-      '[vite-rsc] default client entry is not configured',
+      `[vite-rsc] getClientEntryUrl() cannot be used with the 'customClientEntry' option`,
     )
   })
 })

--- a/packages/plugin-rsc/e2e/client-entry-url.test.ts
+++ b/packages/plugin-rsc/e2e/client-entry-url.test.ts
@@ -1,0 +1,90 @@
+import { expect, test } from '@playwright/test'
+import { setupInlineFixture, useFixture } from './fixture'
+
+test.describe('getClientEntryUrl', () => {
+  const root = 'examples/e2e/temp/client-entry-url'
+
+  test.beforeAll(async () => {
+    await setupInlineFixture({
+      src: 'examples/starter-extra',
+      dest: root,
+      files: {
+        'src/framework/entry.ssr.tsx': /* tsx */ `
+          import { getClientEntryUrl } from '@vitejs/plugin-rsc/ssr'
+
+          export async function renderHTML() {
+            const clientEntryUrl = getClientEntryUrl()
+            const legacyBootstrapScriptContent =
+              await import.meta.viteRsc.loadBootstrapScriptContent('index')
+            const content = JSON.stringify({
+              clientEntryUrl,
+              legacyBootstrapScriptContent,
+            })
+            return { stream: new Response(content).body! }
+          }
+        `,
+      },
+    })
+  })
+
+  function defineTest(mode: 'dev' | 'build') {
+    const f = useFixture({ root, mode })
+
+    test('returns the client entry URL', async ({ request }) => {
+      const response = await request.get(f.url())
+      const result = await response.json()
+      expect(result.legacyBootstrapScriptContent).toBe(
+        `import(${JSON.stringify(result.clientEntryUrl)})`,
+      )
+      if (mode === 'dev') {
+        expect(result.clientEntryUrl).toContain(
+          '/@id/__x00__virtual:vite-rsc/entry-browser',
+        )
+      } else {
+        expect(result.clientEntryUrl).toMatch(/\/assets\/index-[\w-]+\.js$/)
+      }
+    })
+  }
+
+  test.describe('dev', () => defineTest('dev'))
+  test.describe('build', () => defineTest('build'))
+})
+
+test.describe('getClientEntryUrl with customClientEntry', () => {
+  const root = 'examples/e2e/temp/client-entry-url-custom'
+
+  test.beforeAll(async () => {
+    await setupInlineFixture({
+      src: 'examples/starter-extra',
+      dest: root,
+      files: {
+        'vite.config.ts': {
+          edit: (source) =>
+            source.replace('rsc()', 'rsc({ customClientEntry: true })'),
+        },
+        'src/framework/entry.ssr.tsx': /* tsx */ `
+          import { getClientEntryUrl } from '@vitejs/plugin-rsc/ssr'
+
+          export async function renderHTML() {
+            let content = 'unexpected success'
+            try {
+              getClientEntryUrl()
+            } catch (error) {
+              content = String(error)
+            }
+            return { stream: new Response(content).body! }
+          }
+        `,
+      },
+    })
+  })
+
+  const f = useFixture({ root, mode: 'build' })
+
+  test('throws when the default entry is unavailable', async ({ request }) => {
+    const response = await request.get(f.url())
+    await expect(response.text()).resolves.toContain(
+      '[vite-rsc] default client entry is not configured',
+    )
+  })
+})

--- a/packages/plugin-rsc/e2e/render-built-url.test.ts
+++ b/packages/plugin-rsc/e2e/render-built-url.test.ts
@@ -111,6 +111,9 @@ test.describe(() => {
       expect(manifestFileContent).toContain(
         `__dynamicBase + "assets/entry.rsc-`,
       )
+      expect(manifestFileContent).toMatch(
+        /"clientEntryUrl": __dynamicBase \+ "assets\/index-[\w-]+\.js"/,
+      )
     })
   })
 })

--- a/packages/plugin-rsc/examples/action-reachability/src/framework/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/action-reachability/src/framework/entry.ssr.tsx
@@ -1,4 +1,7 @@
-import { createFromReadableStream } from '@vitejs/plugin-rsc/ssr'
+import {
+  createFromReadableStream,
+  getClientEntryUrl,
+} from '@vitejs/plugin-rsc/ssr'
 import React from 'react'
 import type { ReactFormState } from 'react-dom/client'
 import { renderToReadableStream } from 'react-dom/server.edge'
@@ -21,8 +24,7 @@ export async function renderHTML(
     return React.use(payload).root
   }
 
-  const bootstrapScriptContent =
-    await import.meta.viteRsc.loadBootstrapScriptContent('index')
+  const bootstrapScriptContent = `import(${JSON.stringify(getClientEntryUrl())})`
   let htmlStream: ReadableStream<Uint8Array>
   let status: number | undefined
   try {

--- a/packages/plugin-rsc/examples/basic/src/framework/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/basic/src/framework/entry.ssr.tsx
@@ -1,4 +1,7 @@
-import { createFromReadableStream } from '@vitejs/plugin-rsc/ssr'
+import {
+  createFromReadableStream,
+  getClientEntryUrl,
+} from '@vitejs/plugin-rsc/ssr'
 import React from 'react'
 import type { ReactFormState } from 'react-dom/client'
 import { renderToReadableStream } from 'react-dom/server.edge'
@@ -21,8 +24,7 @@ export async function renderHTML(
     return React.use(payload).root
   }
 
-  const bootstrapScriptContent =
-    await import.meta.viteRsc.loadBootstrapScriptContent('index')
+  const bootstrapScriptContent = `import(${JSON.stringify(getClientEntryUrl())})`
   let htmlStream: ReadableStream<Uint8Array>
   let status: number | undefined
   try {

--- a/packages/plugin-rsc/examples/cache-replay/src/framework/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/cache-replay/src/framework/entry.ssr.tsx
@@ -1,4 +1,7 @@
-import { createFromReadableStream } from '@vitejs/plugin-rsc/ssr'
+import {
+  createFromReadableStream,
+  getClientEntryUrl,
+} from '@vitejs/plugin-rsc/ssr'
 import React from 'react'
 import type { ReactFormState } from 'react-dom/client'
 import { renderToReadableStream } from 'react-dom/server.edge'
@@ -21,8 +24,7 @@ export async function renderHTML(
     return React.use(payload).root
   }
 
-  const bootstrapScriptContent =
-    await import.meta.viteRsc.loadBootstrapScriptContent('index')
+  const bootstrapScriptContent = `import(${JSON.stringify(getClientEntryUrl())})`
   let htmlStream: ReadableStream<Uint8Array>
   let status: number | undefined
   try {

--- a/packages/plugin-rsc/examples/client-first/src/framework/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/client-first/src/framework/entry.ssr.tsx
@@ -1,11 +1,13 @@
-import { createFromReadableStream } from '@vitejs/plugin-rsc/ssr'
+import {
+  createFromReadableStream,
+  getClientEntryUrl,
+} from '@vitejs/plugin-rsc/ssr'
 import { renderToReadableStream } from 'react-dom/server.edge'
 import { Root } from '../root'
 import { setRscFnCaller, type RscFnCaller } from './runtime'
 
 export async function renderHtml() {
-  const bootstrapScriptContent =
-    await import.meta.viteRsc.loadBootstrapScriptContent('index')
+  const bootstrapScriptContent = `import(${JSON.stringify(getClientEntryUrl())})`
   return renderToReadableStream(<Root />, { bootstrapScriptContent })
 }
 

--- a/packages/plugin-rsc/examples/custom-server-function/src/framework/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/custom-server-function/src/framework/entry.ssr.tsx
@@ -1,4 +1,7 @@
-import { createFromReadableStream } from '@vitejs/plugin-rsc/ssr'
+import {
+  createFromReadableStream,
+  getClientEntryUrl,
+} from '@vitejs/plugin-rsc/ssr'
 import React from 'react'
 import type { ReactFormState } from 'react-dom/client'
 import { renderToReadableStream } from 'react-dom/server.edge'
@@ -21,8 +24,7 @@ export async function renderHTML(
     return React.use(payload).root
   }
 
-  const bootstrapScriptContent =
-    await import.meta.viteRsc.loadBootstrapScriptContent('index')
+  const bootstrapScriptContent = `import(${JSON.stringify(getClientEntryUrl())})`
   let htmlStream: ReadableStream<Uint8Array>
   let status: number | undefined
   try {

--- a/packages/plugin-rsc/examples/performance-track/src/framework/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/performance-track/src/framework/entry.ssr.tsx
@@ -1,4 +1,7 @@
-import { createFromReadableStream } from '@vitejs/plugin-rsc/ssr'
+import {
+  createFromReadableStream,
+  getClientEntryUrl,
+} from '@vitejs/plugin-rsc/ssr'
 import React from 'react'
 import { renderToReadableStream } from 'react-dom/server.edge'
 import { injectRSCPayload } from 'rsc-html-stream/server'
@@ -15,8 +18,7 @@ export async function renderHTML(
     return React.use(payload).root
   }
 
-  const bootstrapScriptContent =
-    await import.meta.viteRsc.loadBootstrapScriptContent('index')
+  const bootstrapScriptContent = `import(${JSON.stringify(getClientEntryUrl())})`
   const htmlStream = await renderToReadableStream(<SsrRoot />, {
     bootstrapScriptContent,
   })

--- a/packages/plugin-rsc/examples/ppr/src/framework/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/ppr/src/framework/entry.ssr.tsx
@@ -1,4 +1,7 @@
-import { createFromReadableStream } from '@vitejs/plugin-rsc/ssr'
+import {
+  createFromReadableStream,
+  getClientEntryUrl,
+} from '@vitejs/plugin-rsc/ssr'
 import React from 'react'
 import { resume } from 'react-dom/server.edge'
 import type { PrerenderResult } from 'react-dom/static'
@@ -11,8 +14,7 @@ export async function prerenderHtml(
   rscStream: ReadableStream<Uint8Array>,
 ): Promise<PrerenderResult> {
   const ssrRoot = createSsrRoot(preventStreamClose(rscStream))
-  const bootstrapScriptContent =
-    await import.meta.viteRsc.loadBootstrapScriptContent('index')
+  const bootstrapScriptContent = `import(${JSON.stringify(getClientEntryUrl())})`
   const controller = new AbortController()
   const pendingResult = prerender(ssrRoot, {
     bootstrapScriptContent,

--- a/packages/plugin-rsc/examples/react-router/react-router-vite/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/react-router/react-router-vite/entry.ssr.tsx
@@ -1,4 +1,7 @@
-import { createFromReadableStream } from '@vitejs/plugin-rsc/ssr'
+import {
+  createFromReadableStream,
+  getClientEntryUrl,
+} from '@vitejs/plugin-rsc/ssr'
 import { renderToReadableStream as renderHTMLToReadableStream } from 'react-dom/server.edge'
 import {
   unstable_routeRSCServerRequest as routeRSCServerRequest,
@@ -9,8 +12,7 @@ export default async function handler(
   request: Request,
   serverResponse: Response,
 ): Promise<Response> {
-  const bootstrapScriptContent =
-    await import.meta.viteRsc.loadBootstrapScriptContent('index')
+  const bootstrapScriptContent = `import(${JSON.stringify(getClientEntryUrl())})`
 
   return await routeRSCServerRequest({
     request,

--- a/packages/plugin-rsc/examples/ssg/src/framework/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/ssg/src/framework/entry.ssr.tsx
@@ -1,4 +1,7 @@
-import { createFromReadableStream } from '@vitejs/plugin-rsc/ssr'
+import {
+  createFromReadableStream,
+  getClientEntryUrl,
+} from '@vitejs/plugin-rsc/ssr'
 import React from 'react'
 import { renderToReadableStream } from 'react-dom/server.edge'
 import { prerender } from 'react-dom/static.edge'
@@ -19,8 +22,7 @@ export async function renderHtml(
     const root = React.use(payload).root
     return root
   }
-  const bootstrapScriptContent =
-    await import.meta.viteRsc.loadBootstrapScriptContent('index')
+  const bootstrapScriptContent = `import(${JSON.stringify(getClientEntryUrl())})`
 
   let htmlStream: ReadableStream<Uint8Array>
   let status: number | undefined

--- a/packages/plugin-rsc/examples/starter-extra/src/framework/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/starter-extra/src/framework/entry.ssr.tsx
@@ -1,4 +1,7 @@
-import { createFromReadableStream } from '@vitejs/plugin-rsc/ssr'
+import {
+  createFromReadableStream,
+  getClientEntryUrl,
+} from '@vitejs/plugin-rsc/ssr'
 import React from 'react'
 import type { ReactFormState } from 'react-dom/client'
 import { renderToReadableStream } from 'react-dom/server.edge'
@@ -21,8 +24,7 @@ export async function renderHTML(
     return React.use(payload).root
   }
 
-  const bootstrapScriptContent =
-    await import.meta.viteRsc.loadBootstrapScriptContent('index')
+  const bootstrapScriptContent = `import(${JSON.stringify(getClientEntryUrl())})`
   let htmlStream: ReadableStream<Uint8Array>
   let status: number | undefined
   try {

--- a/packages/plugin-rsc/examples/starter/README.md
+++ b/packages/plugin-rsc/examples/starter/README.md
@@ -24,7 +24,7 @@ See [`@vitejs/plugin-rsc`](https://github.com/vitejs/vite-plugin-react/tree/main
   - `import.meta.viteRsc.loadModule`
 - [`./src/framework/entry.ssr.tsx`](./src/framework/entry.ssr.tsx)
   - `@vitejs/plugin-rsc/ssr`
-  - `import.meta.viteRsc.loadBootstrapScriptContent`
+  - `getClientEntryUrl`
   - `rsc-html-stream/server`
 - [`./src/framework/entry.browser.tsx`](./src/framework/entry.browser.tsx)
   - `@vitejs/plugin-rsc/browser`

--- a/packages/plugin-rsc/examples/starter/src/framework/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/starter/src/framework/entry.ssr.tsx
@@ -1,4 +1,7 @@
-import { createFromReadableStream } from '@vitejs/plugin-rsc/ssr'
+import {
+  createFromReadableStream,
+  getClientEntryUrl,
+} from '@vitejs/plugin-rsc/ssr'
 import React from 'react'
 import type { ReactFormState } from 'react-dom/client'
 import { renderToReadableStream } from 'react-dom/server.edge'
@@ -28,8 +31,7 @@ export async function renderHTML(
   }
 
   // render html (traditional SSR)
-  const bootstrapScriptContent =
-    await import.meta.viteRsc.loadBootstrapScriptContent('index')
+  const bootstrapScriptContent = `import(${JSON.stringify(getClientEntryUrl())})`
   let htmlStream: ReadableStream<Uint8Array>
   let status: number | undefined
   try {

--- a/packages/plugin-rsc/examples/use-cache-callable/src/framework/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/use-cache-callable/src/framework/entry.ssr.tsx
@@ -1,4 +1,7 @@
-import { createFromReadableStream } from '@vitejs/plugin-rsc/ssr'
+import {
+  createFromReadableStream,
+  getClientEntryUrl,
+} from '@vitejs/plugin-rsc/ssr'
 import React from 'react'
 import type { ReactFormState } from 'react-dom/client'
 import { renderToReadableStream } from 'react-dom/server.edge'
@@ -21,8 +24,7 @@ export async function renderHTML(
     return React.use(payload).root
   }
 
-  const bootstrapScriptContent =
-    await import.meta.viteRsc.loadBootstrapScriptContent('index')
+  const bootstrapScriptContent = `import(${JSON.stringify(getClientEntryUrl())})`
   let htmlStream: ReadableStream<Uint8Array>
   let status: number | undefined
   try {

--- a/packages/plugin-rsc/examples/use-cache/src/framework/entry.ssr.tsx
+++ b/packages/plugin-rsc/examples/use-cache/src/framework/entry.ssr.tsx
@@ -1,4 +1,7 @@
-import { createFromReadableStream } from '@vitejs/plugin-rsc/ssr'
+import {
+  createFromReadableStream,
+  getClientEntryUrl,
+} from '@vitejs/plugin-rsc/ssr'
 import React from 'react'
 import type { ReactFormState } from 'react-dom/client'
 import { renderToReadableStream } from 'react-dom/server.edge'
@@ -21,8 +24,7 @@ export async function renderHTML(
     return React.use(payload).root
   }
 
-  const bootstrapScriptContent =
-    await import.meta.viteRsc.loadBootstrapScriptContent('index')
+  const bootstrapScriptContent = `import(${JSON.stringify(getClientEntryUrl())})`
   let htmlStream: ReadableStream<Uint8Array>
   let status: number | undefined
   try {

--- a/packages/plugin-rsc/src/plugin.ts
+++ b/packages/plugin-rsc/src/plugin.ts
@@ -284,7 +284,8 @@ export type RscPluginOptions = {
    * - Require an entry chunk named "index"
    * - Automatically include client entry deps in each client reference's dependencies
    *
-   * Note: `import.meta.viteRsc.loadBootstrapScriptContent` cannot be used with this option.
+   * Note: `getClientEntryUrl` and `import.meta.viteRsc.loadBootstrapScriptContent`
+   * cannot be used with this option.
    *
    * Use this when you manually handle client entry setup and preloading.
    *
@@ -1129,7 +1130,9 @@ export function createRpcClient(params) {
               manager,
             )
             const manifest: AssetsManifest = {
-              bootstrapScriptContent: `import(${serializeValueWithRuntime(entryUrl)})`,
+              clientEntryUrl: rscPluginOptions.customClientEntry
+                ? undefined
+                : entryUrl,
               clientReferenceDeps: {},
               cssLinkPrecedence: rscPluginOptions.cssLinkPrecedence,
             }
@@ -1200,7 +1203,7 @@ export function createRpcClient(params) {
           }
 
           const assetDeps = collectAssetDeps(bundle)
-          let bootstrapScriptContent: string | RuntimeAsset = ''
+          let clientEntryUrl: string | RuntimeAsset | undefined
           let clientEntryDeps: AssetDeps | undefined
 
           const clientReferenceDeps: Record<string, AssetDeps> = {}
@@ -1230,18 +1233,11 @@ export function createRpcClient(params) {
             for (const [key, deps] of Object.entries(clientReferenceDeps)) {
               clientReferenceDeps[key] = mergeAssetDeps(deps, clientEntryDeps)
             }
-            const entryUrl = assetsURL(entry.chunk.fileName, manager)
-            if (typeof entryUrl === 'string') {
-              bootstrapScriptContent = `import(${JSON.stringify(entryUrl)})`
-            } else {
-              bootstrapScriptContent = new RuntimeAsset(
-                `"import(" + JSON.stringify(${entryUrl.runtime}) + ")"`,
-              )
-            }
+            clientEntryUrl = assetsURL(entry.chunk.fileName, manager)
           }
 
           manager.buildAssetsManifest = {
-            bootstrapScriptContent,
+            clientEntryUrl,
             clientEntryDeps,
             clientReferenceDeps,
             serverResources,
@@ -1268,13 +1264,6 @@ export function createRpcClient(params) {
         return
       },
     },
-    createVirtualPlugin('vite-rsc/bootstrap-script-content', function () {
-      assert(this.environment.name !== 'client')
-      return `\
-import assetsManifest from "virtual:vite-rsc/assets-manifest";
-export default assetsManifest.bootstrapScriptContent;
-`
-    }),
     {
       name: 'rsc:bootstrap-script-content',
       transform: {
@@ -1306,7 +1295,7 @@ export default assetsManifest.bootstrapScriptContent;
               entryName,
               `[vite-rsc] expected 'loadBootstrapScriptContent("index")' but got ${argCode}`,
             )
-            let replacement: string = `Promise.resolve(__vite_rsc_assets_manifest.bootstrapScriptContent)`
+            let replacement: string = `Promise.resolve("import(" + JSON.stringify(__vite_rsc_assets_manifest.clientEntryUrl) + ")")`
             const [start, end] = match.indices![0]!
             output.overwrite(start, end, replacement)
           }
@@ -2265,7 +2254,7 @@ function assetsURLOfDeps(deps: AssetDeps, manager: RscPluginManager) {
 //
 
 export type AssetsManifest = {
-  bootstrapScriptContent: string | RuntimeAsset
+  clientEntryUrl?: string | RuntimeAsset
   clientEntryDeps?: AssetDeps
   clientReferenceDeps: Record<string, AssetDeps>
   serverResources?: Record<string, Pick<AssetDeps, 'css'>>
@@ -2278,7 +2267,7 @@ export type AssetDeps = {
 }
 
 export type ResolvedAssetsManifest = {
-  bootstrapScriptContent: string
+  clientEntryUrl?: string
   clientEntryDeps?: ResolvedAssetDeps
   clientReferenceDeps: Record<string, ResolvedAssetDeps>
   serverResources?: Record<string, Pick<ResolvedAssetDeps, 'css'>>

--- a/packages/plugin-rsc/src/ssr.tsx
+++ b/packages/plugin-rsc/src/ssr.tsx
@@ -9,6 +9,14 @@ export { createServerConsumerManifest } from './core/ssr'
 
 export * from './react/ssr'
 
+export function getClientEntryUrl(): string {
+  const url = assetsManifest.clientEntryUrl
+  if (!url) {
+    throw new Error('[vite-rsc] default client entry is not configured')
+  }
+  return url
+}
+
 /**
  * Callback type for client reference dependency notifications.
  * Called during SSR when a client component's dependencies are loaded.

--- a/packages/plugin-rsc/src/ssr.tsx
+++ b/packages/plugin-rsc/src/ssr.tsx
@@ -12,7 +12,9 @@ export * from './react/ssr'
 export function getClientEntryUrl(): string {
   const url = assetsManifest.clientEntryUrl
   if (!url) {
-    throw new Error('[vite-rsc] default client entry is not configured')
+    throw new Error(
+      `[vite-rsc] getClientEntryUrl() cannot be used with the 'customClientEntry' option`,
+    )
   }
   return url
 }

--- a/packages/plugin-rsc/types/index.d.ts
+++ b/packages/plugin-rsc/types/index.d.ts
@@ -3,6 +3,7 @@ declare global {
     readonly viteRsc: {
       loadCss: (importer?: string) => import('react').ReactNode
       loadModule: <T>(environmentName: string, entryName?: string) => Promise<T>
+      /** @deprecated Use `getClientEntryUrl` from `@vitejs/plugin-rsc/ssr`. */
       loadBootstrapScriptContent: (entryName: string) => Promise<string>
       /**
        * Import a module from another environment using a module specifier.


### PR DESCRIPTION
- closes https://github.com/vitejs/vite-plugin-react/issues/1359

This PR adds `getClientEntryUrl` as `@vitejs/plugin-rsc/ssr` runtime API and deprecate old  `import.meta.viteRsc.loadBootstrapScriptContent` API.

