### PR TITLE
test(rsc): invoke re-exported server reference

### DIFF
--- a/packages/plugin-rsc/e2e/source-map.test.ts
+++ b/packages/plugin-rsc/e2e/source-map.test.ts
@@ -10,6 +10,7 @@ type ReferenceCase = {
   name: string
   rolldown: string
   rollup?: string | null
+  result?: string
 }
 
 // TODO: Add separate CDP stack coverage for Server Action and Server Component
@@ -77,6 +78,7 @@ const serverReferenceCases: {
         name: 're-export',
         rolldown: '/src/features/specifiers/reexport.ts:0:0',
         rollup: null,
+        result: 're-export called',
       },
       {
         // Rolldown resolves to the directive while Rollup has no mapping.
@@ -186,6 +188,14 @@ test.describe('source map', () => {
             ? reference.rolldown
             : reference.rollup
         expect.soft(actual).toBe(expected)
+
+        if (reference.result) {
+          const button = page.getByRole('button', {
+            name: new RegExp(`^${reference.name}:`),
+          })
+          await button.click()
+          await expect(button).toContainText(reference.result)
+        }
       }
     })
   }


### PR DESCRIPTION
- Spined off from https://github.com/vitejs/vite-plugin-react/pull/1355/

We have comprehensive server functions pattern as e2e for source map check, but it wasn't fully exercised by calling it. Some transform is exotic and so it's worth testing out end-to-end lifecycle, such as

```js
"use server"
export { action } from "./other"
```
