### PR TITLE
refactor(rsc): simplify declaration export metadata

### DIFF
--- a/packages/plugin-rsc/src/transforms/module-export-effect.ts
+++ b/packages/plugin-rsc/src/transforms/module-export-effect.ts
@@ -105,8 +105,7 @@ export function transformModuleExportEffect(
 
   for (const group of scanModuleExports(viteAst)) {
     if (group.type === 'declaration') {
-      const [entry] = group.exports
-      const { localName: binding, exportName, meta } = entry
+      const { localName: binding, exportName, meta } = group.export
       if (!filter(exportName, meta)) continue
       validateNonAsyncFunction(options, group.declaration)
       replaceAndMove(

--- a/packages/plugin-rsc/src/transforms/module-export-scan.test.ts
+++ b/packages/plugin-rsc/src/transforms/module-export-scan.test.ts
@@ -19,17 +19,15 @@ export * from './all'
   expect(groups[0]).toMatchObject({
     type: 'declaration',
     declaration: { type: 'FunctionDeclaration' },
-    exports: [
-      {
-        localName: 'action',
-        exportName: 'action',
-        meta: {
-          declName: 'action',
-          isFunction: true,
-          valueNode: { type: 'FunctionDeclaration' },
-        },
+    export: {
+      localName: 'action',
+      exportName: 'action',
+      meta: {
+        declName: 'action',
+        isFunction: true,
+        valueNode: { type: 'FunctionDeclaration' },
       },
-    ],
+    },
   })
   expect(groups[1]).toMatchObject({
     type: 'variable-declaration',

--- a/packages/plugin-rsc/src/transforms/module-export-scan.ts
+++ b/packages/plugin-rsc/src/transforms/module-export-scan.ts
@@ -79,7 +79,7 @@ export type ModuleExportGroup =
       type: 'declaration'
       node: ExportNamedDeclaration
       declaration: FunctionDeclaration | ClassDeclaration
-      exports: [ModuleExportEntry]
+      export: ModuleExportEntry
     }
   | {
       /**
@@ -168,17 +168,15 @@ export function scanModuleExports(
             type: 'declaration',
             node,
             declaration: node.declaration,
-            exports: [
-              {
-                localName: name,
-                exportName: name,
-                meta: {
-                  declName: name,
-                  isFunction: getIsFunction(node.declaration),
-                  valueNode: node.declaration,
-                },
+            export: {
+              localName: name,
+              exportName: name,
+              meta: {
+                declName: name,
+                isFunction: getIsFunction(node.declaration),
+                valueNode: node.declaration,
               },
-            ],
+            },
           })
         }
       } else {

--- a/packages/plugin-rsc/src/transforms/wrap-export.ts
+++ b/packages/plugin-rsc/src/transforms/wrap-export.ts
@@ -98,11 +98,11 @@ export function transformWrapExport(
 
   for (const group of scanModuleExports(viteAst)) {
     if (group.type === 'declaration') {
-      const [entry] = group.exports
+      const entry = group.export
       if (filter(entry.exportName, entry.meta)) {
         validateNonAsyncFunction(options, group.declaration)
       }
-      wrapSimple(group.node.start, group.declaration.start, group.exports)
+      wrapSimple(group.node.start, group.declaration.start, [entry])
     } else if (group.type === 'variable-declaration') {
       if (group.declaration.kind === 'const') {
         output.update(


### PR DESCRIPTION
There is an internal type representing single element array `exports: [ModuleExportEntry]`, but this should be effectively just `export: ModuleExportEntry`. Should've caught when it's introduced, so fixing now.