### PR TITLE
test(rsc): verify server action closure encryption

### DIFF
--- a/packages/plugin-rsc/e2e/basic.test.ts
+++ b/packages/plugin-rsc/e2e/basic.test.ts
@@ -1518,6 +1518,31 @@ function defineTest(f: Fixture) {
     )
   })
 
+  test('server action encrypts closure captures', async ({ page }) => {
+    const secret = 'server-action-capture-secret'
+    const initialResponse = await page.request.get(f.url('_.rsc'))
+    expect(initialResponse.ok()).toBe(true)
+    expect(await initialResponse.text()).not.toContain(secret)
+
+    await page.goto(f.url())
+    await waitForHydration(page)
+
+    const responsePromise = page.waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' &&
+        response.url().includes('_.rsc'),
+    )
+    await page
+      .getByRole('button', { name: 'test-server-action-encryption' })
+      .click()
+    const actionResponse = await responsePromise
+    expect(actionResponse.ok()).toBe(true)
+    expect(await actionResponse.text()).not.toContain(secret)
+    await expect(page.getByTestId('test-server-action-encryption')).toHaveText(
+      'decoded',
+    )
+  })
+
   test('action bind simple @js', async ({ page }) => {
     await page.goto(f.url())
     await waitForHydration(page)

--- a/packages/plugin-rsc/examples/basic/src/routes/action-encryption/server.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/action-encryption/server.tsx
@@ -1,0 +1,21 @@
+let result = 'not called'
+
+function isValidSecret(value: string) {
+  return value.length === 28
+}
+
+export function TestServerActionEncryption() {
+  const secret = 'server-action-capture-secret'
+
+  return (
+    <form
+      action={async () => {
+        'use server'
+        result = isValidSecret(secret) ? 'decoded' : 'invalid'
+      }}
+    >
+      <button>test-server-action-encryption</button>
+      <output data-testid="test-server-action-encryption">{result}</output>
+    </form>
+  )
+}

--- a/packages/plugin-rsc/examples/basic/src/routes/action-encryption/server.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/action-encryption/server.tsx
@@ -1,11 +1,12 @@
 let result = 'not called'
+const expectedSecret = 'server-action-capture-secret'
 
 function isValidSecret(value: string) {
-  return value.length === 28
+  return value === expectedSecret
 }
 
 export function TestServerActionEncryption() {
-  const secret = 'server-action-capture-secret'
+  const secret = expectedSecret
 
   return (
     <form

--- a/packages/plugin-rsc/examples/basic/src/routes/root.tsx
+++ b/packages/plugin-rsc/examples/basic/src/routes/root.tsx
@@ -8,6 +8,7 @@ import {
   TestServerActionBindSimple,
   TestServerActionBindMember,
 } from './action-bind/server'
+import { TestServerActionEncryption } from './action-encryption/server'
 import { TestServerActionError } from './action-error/server'
 import { TestActionExportAll } from './action-export-all/server'
 import {
@@ -106,6 +107,7 @@ export function Root(props: { url: URL }) {
         <TestUseActionState />
         <TestNonFormActionError />
         <TestNonFormActionArgs />
+        <TestServerActionEncryption />
         <TestPayloadServer url={props.url} />
         <TestServerActionBindReset />
         <TestServerActionBindSimple />


### PR DESCRIPTION
- Related https://github.com/vitejs/vite-plugin-react/pull/1398

Existing action binding tests verify that closure captures round-trip successfully, but they do not assert that plaintext captures stay out of the Flight transport. We found a way to test this for `use cache` in https://github.com/vitejs/vite-plugin-react/pull/1398, but it makes sense to test builtin `use server` too, so the similar test is ported to `examples/basic` e2e.