### PR TITLE
test(rsc): add test case for `use cache` form action cache hits after hydrated reload

### DIFF
--- a/packages/plugin-rsc/e2e/use-cache-callable.test.ts
+++ b/packages/plugin-rsc/e2e/use-cache-callable.test.ts
@@ -62,25 +62,25 @@ function defineTests(f: Fixture) {
     const submissionCount = example.getByTestId('submission-count')
     const executionCount = example.getByTestId('execution-count')
     const result = example.getByTestId('result')
-    const argument = example.getByRole('textbox', { name: 'Cache key' })
-    const initialExecutionCount = Number(await executionCount.textContent())
-    const cacheKey = `hydrated-reload-${Date.now()}`
-
-    // Hydrated SSR form (cache miss)
-    await argument.fill(cacheKey)
-    await submit(page, example)
-    await expect(submissionCount).toHaveText('1')
-    await expect(executionCount).toHaveText(`${initialExecutionCount + 1}`)
-    await expect(result).toHaveText(`captured + ${cacheKey}`)
-
-    // Hydrated SSR form after reload (cache hit)
+    await page.getByRole('button', { name: 'Reset' }).click()
+    await expect(executionCount).toHaveText('0')
     await page.reload()
     await waitForHydration(page)
-    await argument.fill(cacheKey)
+
+    // Reloading and hydrating a fresh SSR form preserves the cache hit for the same argument.
+    // alpha (cache miss)
     await submit(page, example)
     await expect(submissionCount).toHaveText('1')
-    await expect(executionCount).toHaveText(`${initialExecutionCount + 1}`)
-    await expect(result).toHaveText(`captured + ${cacheKey}`)
+    await expect(executionCount).toHaveText('1')
+    await expect(result).toHaveText('captured + alpha')
+
+    // alpha after reload (cache hit)
+    await page.reload()
+    await waitForHydration(page)
+    await submit(page, example)
+    await expect(submissionCount).toHaveText('1')
+    await expect(executionCount).toHaveText('1')
+    await expect(result).toHaveText('captured + alpha')
   })
 
   testNoJs('inline directive progressive enhancement', async ({ page }) => {
@@ -168,25 +168,25 @@ function defineTests(f: Fixture) {
     const submissionCount = example.getByTestId('submission-count')
     const executionCount = example.getByTestId('execution-count')
     const result = example.getByTestId('result')
-    const argument = example.getByRole('textbox', { name: 'Cache key' })
-    const initialExecutionCount = Number(await executionCount.textContent())
-    const cacheKey = `hydrated-reload-${Date.now()}`
-
-    // Hydrated SSR form (cache miss)
-    await argument.fill(cacheKey)
-    await submit(page, example)
-    await expect(submissionCount).toHaveText('1')
-    await expect(executionCount).toHaveText(`${initialExecutionCount + 1}`)
-    await expect(result).toHaveText(`server import + ${cacheKey}`)
-
-    // Hydrated SSR form after reload (cache hit)
+    await page.getByRole('button', { name: 'Reset' }).click()
+    await expect(executionCount).toHaveText('0')
     await page.reload()
     await waitForHydration(page)
-    await argument.fill(cacheKey)
+
+    // Reloading and hydrating a fresh SSR form preserves the cache hit for the same argument.
+    // alpha (cache miss)
     await submit(page, example)
     await expect(submissionCount).toHaveText('1')
-    await expect(executionCount).toHaveText(`${initialExecutionCount + 1}`)
-    await expect(result).toHaveText(`server import + ${cacheKey}`)
+    await expect(executionCount).toHaveText('1')
+    await expect(result).toHaveText('server import + alpha')
+
+    // alpha after reload (cache hit)
+    await page.reload()
+    await waitForHydration(page)
+    await submit(page, example)
+    await expect(submissionCount).toHaveText('1')
+    await expect(executionCount).toHaveText('1')
+    await expect(result).toHaveText('server import + alpha')
   })
 
   testNoJs(

--- a/packages/plugin-rsc/e2e/use-cache-callable.test.ts
+++ b/packages/plugin-rsc/e2e/use-cache-callable.test.ts
@@ -66,12 +66,14 @@ function defineTests(f: Fixture) {
     const initialExecutionCount = Number(await executionCount.textContent())
     const cacheKey = `hydrated-reload-${Date.now()}`
 
+    // Hydrated SSR form (cache miss)
     await argument.fill(cacheKey)
     await submit(page, example)
     await expect(submissionCount).toHaveText('1')
     await expect(executionCount).toHaveText(`${initialExecutionCount + 1}`)
     await expect(result).toHaveText(`captured + ${cacheKey}`)
 
+    // Hydrated SSR form after reload (cache hit)
     await page.reload()
     await waitForHydration(page)
     await argument.fill(cacheKey)
@@ -170,12 +172,14 @@ function defineTests(f: Fixture) {
     const initialExecutionCount = Number(await executionCount.textContent())
     const cacheKey = `hydrated-reload-${Date.now()}`
 
+    // Hydrated SSR form (cache miss)
     await argument.fill(cacheKey)
     await submit(page, example)
     await expect(submissionCount).toHaveText('1')
     await expect(executionCount).toHaveText(`${initialExecutionCount + 1}`)
     await expect(result).toHaveText(`server import + ${cacheKey}`)
 
+    // Hydrated SSR form after reload (cache hit)
     await page.reload()
     await waitForHydration(page)
     await argument.fill(cacheKey)

--- a/packages/plugin-rsc/e2e/use-cache-callable.test.ts
+++ b/packages/plugin-rsc/e2e/use-cache-callable.test.ts
@@ -64,8 +64,6 @@ function defineTests(f: Fixture) {
     const result = example.getByTestId('result')
     await page.getByRole('button', { name: 'Reset' }).click()
     await expect(executionCount).toHaveText('0')
-    await page.reload()
-    await waitForHydration(page)
 
     // Reloading and hydrating a fresh SSR form preserves the cache hit for the same argument.
     // alpha (cache miss)
@@ -170,8 +168,6 @@ function defineTests(f: Fixture) {
     const result = example.getByTestId('result')
     await page.getByRole('button', { name: 'Reset' }).click()
     await expect(executionCount).toHaveText('0')
-    await page.reload()
-    await waitForHydration(page)
 
     // Reloading and hydrating a fresh SSR form preserves the cache hit for the same argument.
     // alpha (cache miss)

--- a/packages/plugin-rsc/e2e/use-cache-callable.test.ts
+++ b/packages/plugin-rsc/e2e/use-cache-callable.test.ts
@@ -53,6 +53,34 @@ function defineTests(f: Fixture) {
     await expect(result).toHaveText('captured + beta')
   })
 
+  test('inline directive cache hit after hydrated reload', async ({ page }) => {
+    using _errors = expectNoPageError(page)
+    await page.goto(f.url('/inline-directive'))
+    await waitForHydration(page)
+
+    const example = page.getByTestId('inline-directive')
+    const submissionCount = example.getByTestId('submission-count')
+    const executionCount = example.getByTestId('execution-count')
+    const result = example.getByTestId('result')
+    const argument = example.getByRole('textbox', { name: 'Cache key' })
+    const initialExecutionCount = Number(await executionCount.textContent())
+    const cacheKey = `hydrated-reload-${Date.now()}`
+
+    await argument.fill(cacheKey)
+    await submit(page, example)
+    await expect(submissionCount).toHaveText('1')
+    await expect(executionCount).toHaveText(`${initialExecutionCount + 1}`)
+    await expect(result).toHaveText(`captured + ${cacheKey}`)
+
+    await page.reload()
+    await waitForHydration(page)
+    await argument.fill(cacheKey)
+    await submit(page, example)
+    await expect(submissionCount).toHaveText('1')
+    await expect(executionCount).toHaveText(`${initialExecutionCount + 1}`)
+    await expect(result).toHaveText(`captured + ${cacheKey}`)
+  })
+
   testNoJs('inline directive progressive enhancement', async ({ page }) => {
     await page.goto(f.url('/inline-directive'))
 
@@ -127,6 +155,34 @@ function defineTests(f: Fixture) {
     await expect(submissionCount).toHaveText('3')
     await expect(executionCount).toHaveText('2')
     await expect(result).toHaveText('server import + beta')
+  })
+
+  test('file directive cache hit after hydrated reload', async ({ page }) => {
+    using _errors = expectNoPageError(page)
+    await page.goto(f.url('/file-directive-from-server'))
+    await waitForHydration(page)
+
+    const example = page.getByTestId('file-directive-from-server')
+    const submissionCount = example.getByTestId('submission-count')
+    const executionCount = example.getByTestId('execution-count')
+    const result = example.getByTestId('result')
+    const argument = example.getByRole('textbox', { name: 'Cache key' })
+    const initialExecutionCount = Number(await executionCount.textContent())
+    const cacheKey = `hydrated-reload-${Date.now()}`
+
+    await argument.fill(cacheKey)
+    await submit(page, example)
+    await expect(submissionCount).toHaveText('1')
+    await expect(executionCount).toHaveText(`${initialExecutionCount + 1}`)
+    await expect(result).toHaveText(`server import + ${cacheKey}`)
+
+    await page.reload()
+    await waitForHydration(page)
+    await argument.fill(cacheKey)
+    await submit(page, example)
+    await expect(submissionCount).toHaveText('1')
+    await expect(executionCount).toHaveText(`${initialExecutionCount + 1}`)
+    await expect(result).toHaveText(`server import + ${cacheKey}`)
   })
 
   testNoJs(


### PR DESCRIPTION
- related https://github.com/vitejs/vite-plugin-react/pull/1398

While investigating on use cache and encryption in https://github.com/vitejs/vite-plugin-react/pull/1398, we came across some odd behaviors with form action after reloading the page (e.g. submit -> reload -> submit will cause cache miss).

I expect this scenario to pass (and it indeed passes on this PR i.e. main), but it's failing on 1398. Let's just add test case here and continue investigation in 1398.
