### PR TITLE
refactor(rsc): name transform option and result types

### DIFF
--- a/packages/plugin-rsc/src/transforms/hoist.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.ts
@@ -12,6 +12,31 @@ import type { ESTree } from 'vite'
 import { buildScopeTree, type ScopeTree } from './scope'
 import { isDirective } from './utils'
 
+export type TransformHoistInlineDirectiveOptions = {
+  runtime: (
+    value: string,
+    name: string,
+    meta: { directiveMatch: RegExpMatchArray },
+  ) => string
+  directive: string | RegExp
+  rejectNonAsyncFunction?: boolean
+  encode?: (value: string) => string
+  decode?: (value: string) => string
+  /** Keep generated hoisted declarations module-local instead of exporting them. */
+  noExport?: boolean
+  /**
+   * Evaluate the runtime expression once during module initialization.
+   * The expression can reference imports and the hoisted implementation, but
+   * must not depend on other module-local initialization.
+   */
+  hoistRuntime?: boolean
+}
+
+export type TransformHoistInlineDirectiveResult = {
+  output: MagicString
+  names: string[]
+}
+
 /**
  * Turns an inline directive function into a module-level registered function.
  * Conceptually:
@@ -90,29 +115,8 @@ export function transformHoistInlineDirective(
     runtime,
     rejectNonAsyncFunction,
     ...options
-  }: {
-    runtime: (
-      value: string,
-      name: string,
-      meta: { directiveMatch: RegExpMatchArray },
-    ) => string
-    directive: string | RegExp
-    rejectNonAsyncFunction?: boolean
-    encode?: (value: string) => string
-    decode?: (value: string) => string
-    /** Keep generated hoisted declarations module-local instead of exporting them. */
-    noExport?: boolean
-    /**
-     * Evaluate the runtime expression once during module initialization.
-     * The expression can reference imports and the hoisted implementation, but
-     * must not depend on other module-local initialization.
-     */
-    hoistRuntime?: boolean
-  },
-): {
-  output: MagicString
-  names: string[]
-} {
+  }: TransformHoistInlineDirectiveOptions,
+): TransformHoistInlineDirectiveResult {
   const ast = viteAst as unknown as Program
   // MagicString needs an existing boundary at the move destination. The newline
   // also keeps the first appended declaration separate from the original source.

--- a/packages/plugin-rsc/src/transforms/server-action.ts
+++ b/packages/plugin-rsc/src/transforms/server-action.ts
@@ -4,16 +4,14 @@ import { transformHoistInlineDirective } from './hoist'
 import { transformModuleExportEffect } from './module-export-effect'
 import { hasDirective } from './utils'
 
-export function transformServerActionServer(
-  input: string,
-  ast: ESTree.Program,
-  options: {
-    runtime: (value: string, name: string) => string
-    rejectNonAsyncFunction?: boolean
-    encode?: (value: string) => string
-    decode?: (value: string) => string
-  },
-):
+export type TransformServerActionServerOptions = {
+  runtime: (value: string, name: string) => string
+  rejectNonAsyncFunction?: boolean
+  encode?: (value: string) => string
+  decode?: (value: string) => string
+}
+
+export type TransformServerActionServerResult =
   | {
       exportNames: string[]
       output: MagicString
@@ -23,7 +21,13 @@ export function transformServerActionServer(
       output: MagicString
       names: string[]
       referenceNames: string[]
-    } {
+    }
+
+export function transformServerActionServer(
+  input: string,
+  ast: ESTree.Program,
+  options: TransformServerActionServerOptions,
+): TransformServerActionServerResult {
   // TODO: unify (generalize transformHoistInlineDirective to support top-level directive cases)
   if (hasDirective(ast.body, 'use server')) {
     const result = transformModuleExportEffect(input, ast, {

--- a/packages/plugin-rsc/src/transforms/wrap-export.ts
+++ b/packages/plugin-rsc/src/transforms/wrap-export.ts
@@ -20,6 +20,11 @@ export type TransformWrapExportOptions = {
   filter?: TransformWrapExportFilter
 }
 
+export type TransformWrapExportResult = {
+  exportNames: string[]
+  output: MagicString
+}
+
 /**
  * Replaces selected module-local export bindings with runtime wrappers.
  *
@@ -61,10 +66,7 @@ export function transformWrapExport(
   input: string,
   viteAst: ESTree.Program,
   options: TransformWrapExportOptions,
-): {
-  exportNames: string[]
-  output: MagicString
-} {
+): TransformWrapExportResult {
   const output = new MagicString(input)
   const exportNames: string[] = []
   const appendedCode: string[] = []


### PR DESCRIPTION
Several old RSC transforms still declare their option or result shapes inline (due to my old personal preference), unlike the newer transform helpers. This PR makes it consistent to declare `type` early as it seems to read better.