### PR TITLE
test(rsc): migrate hoist output fixtures

### DIFF
--- a/packages/plugin-rsc/src/transforms/fixtures/hoist/arrow.js
+++ b/packages/plugin-rsc/src/transforms/fixtures/hoist/arrow.js
@@ -1,0 +1,13 @@
+let count = 0
+
+function Counter() {
+  const name = 'value'
+
+  return {
+    type: 'form',
+    action: (formData) => {
+      'use server'
+      count += Number(formData.get(name))
+    },
+  }
+}

--- a/packages/plugin-rsc/src/transforms/fixtures/hoist/arrow.js.snap.encode.js
+++ b/packages/plugin-rsc/src/transforms/fixtures/hoist/arrow.js.snap.encode.js
@@ -1,0 +1,17 @@
+let count = 0
+
+function Counter() {
+  const name = 'value'
+
+  return {
+    type: 'form',
+    action: /* #__PURE__ */ $$register($$hoist_0_anonymous_server_function, "<id>", "$$hoist_0_anonymous_server_function").bind(null, __enc([name])),
+  }
+}
+
+;export function $$hoist_0_anonymous_server_function($$hoist_encoded, formData) {
+      const [name] = __dec($$hoist_encoded);
+'use server'
+      count += Number(formData.get(name))
+    };
+/* #__PURE__ */ Object.defineProperty($$hoist_0_anonymous_server_function, "name", { value: "anonymous_server_function" });

--- a/packages/plugin-rsc/src/transforms/fixtures/hoist/arrow.js.snap.js
+++ b/packages/plugin-rsc/src/transforms/fixtures/hoist/arrow.js.snap.js
@@ -1,0 +1,16 @@
+let count = 0
+
+function Counter() {
+  const name = 'value'
+
+  return {
+    type: 'form',
+    action: /* #__PURE__ */ $$register($$hoist_0_anonymous_server_function, "<id>", "$$hoist_0_anonymous_server_function").bind(null, name),
+  }
+}
+
+;export function $$hoist_0_anonymous_server_function(name, formData) {
+      'use server'
+      count += Number(formData.get(name))
+    };
+/* #__PURE__ */ Object.defineProperty($$hoist_0_anonymous_server_function, "name", { value: "anonymous_server_function" });

--- a/packages/plugin-rsc/src/transforms/fixtures/hoist/closure.js
+++ b/packages/plugin-rsc/src/transforms/fixtures/hoist/closure.js
@@ -1,0 +1,12 @@
+let count = 0
+
+function Counter() {
+  const name = 'value'
+
+  async function changeCount(formData) {
+    'use server'
+    count += Number(formData.get(name))
+  }
+
+  return 'something'
+}

--- a/packages/plugin-rsc/src/transforms/fixtures/hoist/closure.js.snap.encode.js
+++ b/packages/plugin-rsc/src/transforms/fixtures/hoist/closure.js.snap.encode.js
@@ -1,0 +1,16 @@
+let count = 0
+
+function Counter() {
+  const name = 'value'
+
+  const changeCount = /* #__PURE__ */ $$register($$hoist_0_changeCount, "<id>", "$$hoist_0_changeCount").bind(null, __enc([name]));
+
+  return 'something'
+}
+
+;export async function $$hoist_0_changeCount($$hoist_encoded, formData) {
+    const [name] = __dec($$hoist_encoded);
+'use server'
+    count += Number(formData.get(name))
+  };
+/* #__PURE__ */ Object.defineProperty($$hoist_0_changeCount, "name", { value: "changeCount" });

--- a/packages/plugin-rsc/src/transforms/fixtures/hoist/closure.js.snap.js
+++ b/packages/plugin-rsc/src/transforms/fixtures/hoist/closure.js.snap.js
@@ -1,0 +1,15 @@
+let count = 0
+
+function Counter() {
+  const name = 'value'
+
+  const changeCount = /* #__PURE__ */ $$register($$hoist_0_changeCount, "<id>", "$$hoist_0_changeCount").bind(null, name);
+
+  return 'something'
+}
+
+;export async function $$hoist_0_changeCount(name, formData) {
+    'use server'
+    count += Number(formData.get(name))
+  };
+/* #__PURE__ */ Object.defineProperty($$hoist_0_changeCount, "name", { value: "changeCount" });

--- a/packages/plugin-rsc/src/transforms/fixtures/hoist/export-before-import.js
+++ b/packages/plugin-rsc/src/transforms/fixtures/hoist/export-before-import.js
@@ -1,0 +1,10 @@
+// https://github.com/remix-run/react-router/blob/98367e49900701c460cb08eb16c2441da5007efc/playground/rsc-vite/src/routes/home/home.tsx
+export {} from 'edge-case'
+import { redirect } from 'react-router/rsc'
+
+export default () => {
+  const redirectOnServer = async () => {
+    'use server'
+    throw redirect()
+  }
+}

--- a/packages/plugin-rsc/src/transforms/fixtures/hoist/export-before-import.js.snap.encode.js
+++ b/packages/plugin-rsc/src/transforms/fixtures/hoist/export-before-import.js.snap.encode.js
@@ -1,0 +1,13 @@
+// https://github.com/remix-run/react-router/blob/98367e49900701c460cb08eb16c2441da5007efc/playground/rsc-vite/src/routes/home/home.tsx
+export {} from 'edge-case'
+import { redirect } from 'react-router/rsc'
+
+export default () => {
+  const redirectOnServer = /* #__PURE__ */ $$register($$hoist_0_redirectOnServer, "<id>", "$$hoist_0_redirectOnServer")
+}
+
+;export async function $$hoist_0_redirectOnServer() {
+    'use server'
+    throw redirect()
+  };
+/* #__PURE__ */ Object.defineProperty($$hoist_0_redirectOnServer, "name", { value: "redirectOnServer" });

--- a/packages/plugin-rsc/src/transforms/fixtures/hoist/export-before-import.js.snap.js
+++ b/packages/plugin-rsc/src/transforms/fixtures/hoist/export-before-import.js.snap.js
@@ -1,0 +1,13 @@
+// https://github.com/remix-run/react-router/blob/98367e49900701c460cb08eb16c2441da5007efc/playground/rsc-vite/src/routes/home/home.tsx
+export {} from 'edge-case'
+import { redirect } from 'react-router/rsc'
+
+export default () => {
+  const redirectOnServer = /* #__PURE__ */ $$register($$hoist_0_redirectOnServer, "<id>", "$$hoist_0_redirectOnServer")
+}
+
+;export async function $$hoist_0_redirectOnServer() {
+    'use server'
+    throw redirect()
+  };
+/* #__PURE__ */ Object.defineProperty($$hoist_0_redirectOnServer, "name", { value: "redirectOnServer" });

--- a/packages/plugin-rsc/src/transforms/fixtures/hoist/higher-order.js
+++ b/packages/plugin-rsc/src/transforms/fixtures/hoist/higher-order.js
@@ -1,0 +1,15 @@
+// Adapted from React's Next.js server action examples.
+export default function Page() {
+  const x = 0
+  const action = validator(async (y) => {
+    'use server'
+    return x + y
+  })
+}
+
+function validator(action) {
+  return async function (arg) {
+    'use server'
+    return action(arg)
+  }
+}

--- a/packages/plugin-rsc/src/transforms/fixtures/hoist/higher-order.js.snap.encode.js
+++ b/packages/plugin-rsc/src/transforms/fixtures/hoist/higher-order.js.snap.encode.js
@@ -1,0 +1,23 @@
+// Adapted from React's Next.js server action examples.
+export default function Page() {
+  const x = 0
+  const action = validator(/* #__PURE__ */ $$register($$hoist_0_anonymous_server_function, "<id>", "$$hoist_0_anonymous_server_function").bind(null, __enc([x])))
+}
+
+function validator(action) {
+  return /* #__PURE__ */ $$register($$hoist_1_anonymous_server_function, "<id>", "$$hoist_1_anonymous_server_function").bind(null, __enc([action]))
+}
+
+;export async function $$hoist_0_anonymous_server_function($$hoist_encoded, y) {
+    const [x] = __dec($$hoist_encoded);
+'use server'
+    return x + y
+  };
+/* #__PURE__ */ Object.defineProperty($$hoist_0_anonymous_server_function, "name", { value: "anonymous_server_function" });
+
+;export async function $$hoist_1_anonymous_server_function($$hoist_encoded, arg) {
+    const [action] = __dec($$hoist_encoded);
+'use server'
+    return action(arg)
+  };
+/* #__PURE__ */ Object.defineProperty($$hoist_1_anonymous_server_function, "name", { value: "anonymous_server_function" });

--- a/packages/plugin-rsc/src/transforms/fixtures/hoist/higher-order.js.snap.js
+++ b/packages/plugin-rsc/src/transforms/fixtures/hoist/higher-order.js.snap.js
@@ -1,0 +1,21 @@
+// Adapted from React's Next.js server action examples.
+export default function Page() {
+  const x = 0
+  const action = validator(/* #__PURE__ */ $$register($$hoist_0_anonymous_server_function, "<id>", "$$hoist_0_anonymous_server_function").bind(null, x))
+}
+
+function validator(action) {
+  return /* #__PURE__ */ $$register($$hoist_1_anonymous_server_function, "<id>", "$$hoist_1_anonymous_server_function").bind(null, action)
+}
+
+;export async function $$hoist_0_anonymous_server_function(x, y) {
+    'use server'
+    return x + y
+  };
+/* #__PURE__ */ Object.defineProperty($$hoist_0_anonymous_server_function, "name", { value: "anonymous_server_function" });
+
+;export async function $$hoist_1_anonymous_server_function(action, arg) {
+    'use server'
+    return action(arg)
+  };
+/* #__PURE__ */ Object.defineProperty($$hoist_1_anonymous_server_function, "name", { value: "anonymous_server_function" });

--- a/packages/plugin-rsc/src/transforms/fixtures/hoist/multiple.js
+++ b/packages/plugin-rsc/src/transforms/fixtures/hoist/multiple.js
@@ -1,0 +1,17 @@
+let count = 0
+
+function Counter() {
+  const name = 'value'
+
+  async function changeCount(formData) {
+    'use server'
+    count += Number(formData.get(name))
+  }
+
+  async function changeCount2(formData) {
+    'use server'
+    count += Number(formData.get(name))
+  }
+
+  return 'something'
+}

--- a/packages/plugin-rsc/src/transforms/fixtures/hoist/multiple.js.snap.encode.js
+++ b/packages/plugin-rsc/src/transforms/fixtures/hoist/multiple.js.snap.encode.js
@@ -1,0 +1,25 @@
+let count = 0
+
+function Counter() {
+  const name = 'value'
+
+  const changeCount = /* #__PURE__ */ $$register($$hoist_0_changeCount, "<id>", "$$hoist_0_changeCount").bind(null, __enc([name]));
+
+  const changeCount2 = /* #__PURE__ */ $$register($$hoist_1_changeCount2, "<id>", "$$hoist_1_changeCount2").bind(null, __enc([name]));
+
+  return 'something'
+}
+
+;export async function $$hoist_0_changeCount($$hoist_encoded, formData) {
+    const [name] = __dec($$hoist_encoded);
+'use server'
+    count += Number(formData.get(name))
+  };
+/* #__PURE__ */ Object.defineProperty($$hoist_0_changeCount, "name", { value: "changeCount" });
+
+;export async function $$hoist_1_changeCount2($$hoist_encoded, formData) {
+    const [name] = __dec($$hoist_encoded);
+'use server'
+    count += Number(formData.get(name))
+  };
+/* #__PURE__ */ Object.defineProperty($$hoist_1_changeCount2, "name", { value: "changeCount2" });

--- a/packages/plugin-rsc/src/transforms/fixtures/hoist/multiple.js.snap.js
+++ b/packages/plugin-rsc/src/transforms/fixtures/hoist/multiple.js.snap.js
@@ -1,0 +1,23 @@
+let count = 0
+
+function Counter() {
+  const name = 'value'
+
+  const changeCount = /* #__PURE__ */ $$register($$hoist_0_changeCount, "<id>", "$$hoist_0_changeCount").bind(null, name);
+
+  const changeCount2 = /* #__PURE__ */ $$register($$hoist_1_changeCount2, "<id>", "$$hoist_1_changeCount2").bind(null, name);
+
+  return 'something'
+}
+
+;export async function $$hoist_0_changeCount(name, formData) {
+    'use server'
+    count += Number(formData.get(name))
+  };
+/* #__PURE__ */ Object.defineProperty($$hoist_0_changeCount, "name", { value: "changeCount" });
+
+;export async function $$hoist_1_changeCount2(name, formData) {
+    'use server'
+    count += Number(formData.get(name))
+  };
+/* #__PURE__ */ Object.defineProperty($$hoist_1_changeCount2, "name", { value: "changeCount2" });

--- a/packages/plugin-rsc/src/transforms/fixtures/hoist/top-level.js
+++ b/packages/plugin-rsc/src/transforms/fixtures/hoist/top-level.js
@@ -1,0 +1,17 @@
+const x = 'x'
+
+async function f() {
+  'use server'
+  return x
+}
+
+async function g() {}
+
+export async function h(formData) {
+  'use server'
+  return formData.get(x)
+}
+
+export default function w() {
+  'use server'
+}

--- a/packages/plugin-rsc/src/transforms/fixtures/hoist/top-level.js.snap.encode.js
+++ b/packages/plugin-rsc/src/transforms/fixtures/hoist/top-level.js.snap.encode.js
@@ -1,0 +1,27 @@
+const x = 'x'
+
+const f = /* #__PURE__ */ $$register($$hoist_0_f, "<id>", "$$hoist_0_f");
+
+async function g() {}
+
+export const h = /* #__PURE__ */ $$register($$hoist_1_h, "<id>", "$$hoist_1_h");
+
+const w = /* #__PURE__ */ $$register($$hoist_2_w, "<id>", "$$hoist_2_w");
+export default w;
+
+;export async function $$hoist_0_f() {
+  'use server'
+  return x
+};
+/* #__PURE__ */ Object.defineProperty($$hoist_0_f, "name", { value: "f" });
+
+;export async function $$hoist_1_h(formData) {
+  'use server'
+  return formData.get(x)
+};
+/* #__PURE__ */ Object.defineProperty($$hoist_1_h, "name", { value: "h" });
+
+;export function $$hoist_2_w() {
+  'use server'
+};
+/* #__PURE__ */ Object.defineProperty($$hoist_2_w, "name", { value: "w" });

--- a/packages/plugin-rsc/src/transforms/fixtures/hoist/top-level.js.snap.js
+++ b/packages/plugin-rsc/src/transforms/fixtures/hoist/top-level.js.snap.js
@@ -1,0 +1,27 @@
+const x = 'x'
+
+const f = /* #__PURE__ */ $$register($$hoist_0_f, "<id>", "$$hoist_0_f");
+
+async function g() {}
+
+export const h = /* #__PURE__ */ $$register($$hoist_1_h, "<id>", "$$hoist_1_h");
+
+const w = /* #__PURE__ */ $$register($$hoist_2_w, "<id>", "$$hoist_2_w");
+export default w;
+
+;export async function $$hoist_0_f() {
+  'use server'
+  return x
+};
+/* #__PURE__ */ Object.defineProperty($$hoist_0_f, "name", { value: "f" });
+
+;export async function $$hoist_1_h(formData) {
+  'use server'
+  return formData.get(x)
+};
+/* #__PURE__ */ Object.defineProperty($$hoist_1_h, "name", { value: "h" });
+
+;export function $$hoist_2_w() {
+  'use server'
+};
+/* #__PURE__ */ Object.defineProperty($$hoist_2_w, "name", { value: "w" });

--- a/packages/plugin-rsc/src/transforms/hoist.test.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.test.ts
@@ -128,6 +128,21 @@ async function f() {
     expect(await testTransform(input)).toBeUndefined()
   })
 
+  it('returns generated names in order', async () => {
+    const input = `
+async function first() {
+  "use server";
+}
+async function second() {
+  "use server";
+}
+`
+    expect(await testTransformNames(input)).toEqual([
+      '$$hoist_0_first',
+      '$$hoist_1_second',
+    ])
+  })
+
   it('ignores strings outside a function directive prologue', async () => {
     const input = `
 async function initialized() {
@@ -150,21 +165,6 @@ async function action() {
 }
 `
     expect(await testTransformNames(input)).toEqual(['$$hoist_0_action'])
-  })
-
-  it('returns generated names in order', async () => {
-    const input = `
-async function first() {
-  "use server";
-}
-async function second() {
-  "use server";
-}
-`
-    expect(await testTransformNames(input)).toEqual([
-      '$$hoist_0_first',
-      '$$hoist_1_second',
-    ])
   })
 
   it('finds directives only in directive-capable bodies', async () => {

--- a/packages/plugin-rsc/src/transforms/hoist.test.ts
+++ b/packages/plugin-rsc/src/transforms/hoist.test.ts
@@ -125,7 +125,7 @@ async function f() {
   return x;
 }
 `
-    expect(await testTransform(input)).toMatchInlineSnapshot(`undefined`)
+    expect(await testTransform(input)).toBeUndefined()
   })
 
   it('ignores strings outside a function directive prologue', async () => {
@@ -152,6 +152,21 @@ async function action() {
     expect(await testTransformNames(input)).toEqual(['$$hoist_0_action'])
   })
 
+  it('returns generated names in order', async () => {
+    const input = `
+async function first() {
+  "use server";
+}
+async function second() {
+  "use server";
+}
+`
+    expect(await testTransformNames(input)).toEqual([
+      '$$hoist_0_first',
+      '$$hoist_1_second',
+    ])
+  })
+
   it('finds directives only in directive-capable bodies', async () => {
     const input = `
 {
@@ -163,322 +178,6 @@ async function action() {
 `
     const ast = await parseAstAsync(input)
     expect(findDirectives(ast, 'use server')).toHaveLength(1)
-  })
-
-  it('top level', async () => {
-    const input = `
-const x = "x";
-
-async function f() {
-  "use server";
-  return x;
-}
-
-async function g() {
-}
-
-export async function h(formData) {
-  "use server";
-  return formData.get(x);
-}
-
-export default function w() {
-  "use server";
-}
-`
-    expect(await testTransform(input)).toMatchInlineSnapshot(`
-      "
-      const x = "x";
-
-      const f = /* #__PURE__ */ $$register($$hoist_0_f, "<id>", "$$hoist_0_f");
-
-      async function g() {
-      }
-
-      export const h = /* #__PURE__ */ $$register($$hoist_1_h, "<id>", "$$hoist_1_h");
-
-      const w = /* #__PURE__ */ $$register($$hoist_2_w, "<id>", "$$hoist_2_w");
-      export default w;
-
-      ;export async function $$hoist_0_f() {
-        "use server";
-        return x;
-      };
-      /* #__PURE__ */ Object.defineProperty($$hoist_0_f, "name", { value: "f" });
-
-      ;export async function $$hoist_1_h(formData) {
-        "use server";
-        return formData.get(x);
-      };
-      /* #__PURE__ */ Object.defineProperty($$hoist_1_h, "name", { value: "h" });
-
-      ;export function $$hoist_2_w() {
-        "use server";
-      };
-      /* #__PURE__ */ Object.defineProperty($$hoist_2_w, "name", { value: "w" });
-      "
-    `)
-
-    // nothing to encode
-    expect(await testTransform(input, { encode: true })).toBe(
-      await testTransform(input),
-    )
-
-    expect(await testTransformNames(input)).toMatchInlineSnapshot(`
-      [
-        "$$hoist_0_f",
-        "$$hoist_1_h",
-        "$$hoist_2_w",
-      ]
-    `)
-  })
-
-  it('closure', async () => {
-    const input = `
-let count = 0;
-
-function Counter() {
-  const name = "value";
-
-  async function changeCount(formData) {
-    "use server";
-    count += Number(formData.get(name));
-  }
-
-  return "something";
-}
-`
-    expect(await testTransform(input)).toMatchInlineSnapshot(`
-      "
-      let count = 0;
-
-      function Counter() {
-        const name = "value";
-
-        const changeCount = /* #__PURE__ */ $$register($$hoist_0_changeCount, "<id>", "$$hoist_0_changeCount").bind(null, name);
-
-        return "something";
-      }
-
-      ;export async function $$hoist_0_changeCount(name, formData) {
-          "use server";
-          count += Number(formData.get(name));
-        };
-      /* #__PURE__ */ Object.defineProperty($$hoist_0_changeCount, "name", { value: "changeCount" });
-      "
-    `)
-  })
-
-  it('many', async () => {
-    const input = `
-let count = 0;
-
-function Counter() {
-  const name = "value";
-
-  async function changeCount(formData) {
-    "use server";
-    count += Number(formData.get(name));
-  }
-
-  async function changeCount2(formData) {
-    "use server";
-    count += Number(formData.get(name));
-  }
-
-  return "something";
-}
-`
-    expect(await testTransform(input)).toMatchInlineSnapshot(`
-      "
-      let count = 0;
-
-      function Counter() {
-        const name = "value";
-
-        const changeCount = /* #__PURE__ */ $$register($$hoist_0_changeCount, "<id>", "$$hoist_0_changeCount").bind(null, name);
-
-        const changeCount2 = /* #__PURE__ */ $$register($$hoist_1_changeCount2, "<id>", "$$hoist_1_changeCount2").bind(null, name);
-
-        return "something";
-      }
-
-      ;export async function $$hoist_0_changeCount(name, formData) {
-          "use server";
-          count += Number(formData.get(name));
-        };
-      /* #__PURE__ */ Object.defineProperty($$hoist_0_changeCount, "name", { value: "changeCount" });
-
-      ;export async function $$hoist_1_changeCount2(name, formData) {
-          "use server";
-          count += Number(formData.get(name));
-        };
-      /* #__PURE__ */ Object.defineProperty($$hoist_1_changeCount2, "name", { value: "changeCount2" });
-      "
-    `)
-  })
-
-  it('arrow', async () => {
-    const input = `
-let count = 0;
-
-function Counter() {
-  const name = "value";
-
-  return {
-    type: "form",
-    action: (formData) => {
-      "use server";
-      count += Number(formData.get(name));
-    }
-  }
-}
-`
-    expect(await testTransform(input)).toMatchInlineSnapshot(`
-      "
-      let count = 0;
-
-      function Counter() {
-        const name = "value";
-
-        return {
-          type: "form",
-          action: /* #__PURE__ */ $$register($$hoist_0_anonymous_server_function, "<id>", "$$hoist_0_anonymous_server_function").bind(null, name)
-        }
-      }
-
-      ;export function $$hoist_0_anonymous_server_function(name, formData) {
-            "use server";
-            count += Number(formData.get(name));
-          };
-      /* #__PURE__ */ Object.defineProperty($$hoist_0_anonymous_server_function, "name", { value: "anonymous_server_function" });
-      "
-    `)
-
-    expect(await testTransform(input, { encode: true })).toMatchInlineSnapshot(`
-      "
-      let count = 0;
-
-      function Counter() {
-        const name = "value";
-
-        return {
-          type: "form",
-          action: /* #__PURE__ */ $$register($$hoist_0_anonymous_server_function, "<id>", "$$hoist_0_anonymous_server_function").bind(null, __enc([name]))
-        }
-      }
-
-      ;export function $$hoist_0_anonymous_server_function($$hoist_encoded, formData) {
-            const [name] = __dec($$hoist_encoded);
-      "use server";
-            count += Number(formData.get(name));
-          };
-      /* #__PURE__ */ Object.defineProperty($$hoist_0_anonymous_server_function, "name", { value: "anonymous_server_function" });
-      "
-    `)
-  })
-
-  it('higher order', async () => {
-    // packages/react-server/examples/next/app/actions/header/page.tsx
-    // packages/react-server/examples/next/app/actions/header/validator.ts
-    const input = `
-export default function Page() {
-  const x = 0;
-  const action = validator(async (y) => {
-    "use server";
-    return x + y;
-  })
-}
-
-function validator(action) {
-  return async function (arg) {
-    "use server";
-    return action(arg);
-  };
-}
-`
-    expect(await testTransform(input)).toMatchInlineSnapshot(`
-      "
-      export default function Page() {
-        const x = 0;
-        const action = validator(/* #__PURE__ */ $$register($$hoist_0_anonymous_server_function, "<id>", "$$hoist_0_anonymous_server_function").bind(null, x))
-      }
-
-      function validator(action) {
-        return /* #__PURE__ */ $$register($$hoist_1_anonymous_server_function, "<id>", "$$hoist_1_anonymous_server_function").bind(null, action);
-      }
-
-      ;export async function $$hoist_0_anonymous_server_function(x, y) {
-          "use server";
-          return x + y;
-        };
-      /* #__PURE__ */ Object.defineProperty($$hoist_0_anonymous_server_function, "name", { value: "anonymous_server_function" });
-
-      ;export async function $$hoist_1_anonymous_server_function(action, arg) {
-          "use server";
-          return action(arg);
-        };
-      /* #__PURE__ */ Object.defineProperty($$hoist_1_anonymous_server_function, "name", { value: "anonymous_server_function" });
-      "
-    `)
-
-    expect(await testTransform(input, { encode: true })).toMatchInlineSnapshot(`
-      "
-      export default function Page() {
-        const x = 0;
-        const action = validator(/* #__PURE__ */ $$register($$hoist_0_anonymous_server_function, "<id>", "$$hoist_0_anonymous_server_function").bind(null, __enc([x])))
-      }
-
-      function validator(action) {
-        return /* #__PURE__ */ $$register($$hoist_1_anonymous_server_function, "<id>", "$$hoist_1_anonymous_server_function").bind(null, __enc([action]));
-      }
-
-      ;export async function $$hoist_0_anonymous_server_function($$hoist_encoded, y) {
-          const [x] = __dec($$hoist_encoded);
-      "use server";
-          return x + y;
-        };
-      /* #__PURE__ */ Object.defineProperty($$hoist_0_anonymous_server_function, "name", { value: "anonymous_server_function" });
-
-      ;export async function $$hoist_1_anonymous_server_function($$hoist_encoded, arg) {
-          const [action] = __dec($$hoist_encoded);
-      "use server";
-          return action(arg);
-        };
-      /* #__PURE__ */ Object.defineProperty($$hoist_1_anonymous_server_function, "name", { value: "anonymous_server_function" });
-      "
-    `)
-  })
-
-  // edge case found in https://github.com/remix-run/react-router/blob/98367e49900701c460cb08eb16c2441da5007efc/playground/rsc-vite/src/routes/home/home.tsx
-  it('export before import', async () => {
-    const input = `
-export {} from "edge-case";
-import { redirect } from "react-router/rsc";
-
-export default () => {
-  const redirectOnServer = async () => {
-    "use server";
-    throw redirect();
-  };
-}
-`
-    expect(await testTransform(input)).toMatchInlineSnapshot(`
-      "
-      export {} from "edge-case";
-      import { redirect } from "react-router/rsc";
-
-      export default () => {
-        const redirectOnServer = /* #__PURE__ */ $$register($$hoist_0_redirectOnServer, "<id>", "$$hoist_0_redirectOnServer");
-      }
-
-      ;export async function $$hoist_0_redirectOnServer() {
-          "use server";
-          throw redirect();
-        };
-      /* #__PURE__ */ Object.defineProperty($$hoist_0_redirectOnServer, "name", { value: "redirectOnServer" });
-      "
-    `)
   })
 
   it('noExport', async () => {


### PR DESCRIPTION
- more follow-up https://github.com/vitejs/vite-plugin-react/pull/1399

There is still remaining after https://github.com/vitejs/vite-plugin-react/pull/1399. This PR now also aligns `transformHoistInlineDirective` from manual inline snapshot to file fixture snapshot.