### PR TITLE
chore(rsc): clarify use cache example

### DIFF
--- a/packages/plugin-rsc/e2e/use-cache.test.ts
+++ b/packages/plugin-rsc/e2e/use-cache.test.ts
@@ -14,7 +14,7 @@ test.describe('build', () => {
 
 function defineTests(f: Fixture) {
   test('use cache function', async ({ page }) => {
-    await page.goto(f.url())
+    await page.goto(f.url('/cached-function'))
     await waitForHydration(page)
     const locator = page.getByTestId('test-use-cache-fn')
     const callCount = locator.getByTestId('call-count')
@@ -56,7 +56,7 @@ function defineTests(f: Fixture) {
   })
 
   test('use cache component', async ({ page }) => {
-    await page.goto(f.url())
+    await page.goto(f.url('/cached-component'))
     await waitForHydration(page)
     const static1 = await page
       .getByTestId('test-use-cache-component-static')
@@ -81,7 +81,7 @@ function defineTests(f: Fixture) {
   })
 
   test('use cache captured values', async ({ page }) => {
-    await page.goto(f.url())
+    await page.goto(f.url('/captured-values'))
     await waitForHydration(page)
     const locator = page.getByTestId('test-use-cache-closure')
     const callCount = locator.getByTestId('call-count')

--- a/packages/plugin-rsc/e2e/use-cache.test.ts
+++ b/packages/plugin-rsc/e2e/use-cache.test.ts
@@ -17,41 +17,42 @@ function defineTests(f: Fixture) {
     await page.goto(f.url())
     await waitForHydration(page)
     const locator = page.getByTestId('test-use-cache-fn')
-    await expect(locator.locator('span')).toHaveText(
-      '(actionCount: 0, cacheFnCount: 0)',
-    )
+    const callCount = locator.getByTestId('call-count')
+    const executionCount = locator.getByTestId('execution-count')
+    const cacheKey = locator.getByRole('textbox', { name: 'Cache key' })
+    const call = locator.getByRole('button', {
+      name: 'Call cached function',
+    })
+    await expect(callCount).toHaveText('0')
+    await expect(executionCount).toHaveText('0')
 
     // The action runs on every submit, but the cached function runs once per argument.
-    await locator.getByRole('button').click()
-    await expect(locator.locator('span')).toHaveText(
-      '(actionCount: 1, cacheFnCount: 1)',
-    )
-    await locator.getByRole('button').click()
-    await expect(locator.locator('span')).toHaveText(
-      '(actionCount: 2, cacheFnCount: 1)',
-    )
-    await locator.getByRole('textbox').fill('test')
-    await locator.getByRole('button').click()
-    await expect(locator.locator('span')).toHaveText(
-      '(actionCount: 3, cacheFnCount: 2)',
-    )
-    await locator.getByRole('textbox').fill('test')
-    await locator.getByRole('button').click()
-    await expect(locator.locator('span')).toHaveText(
-      '(actionCount: 4, cacheFnCount: 2)',
-    )
+    await call.click()
+    await expect(callCount).toHaveText('1')
+    await expect(executionCount).toHaveText('1')
+    await call.click()
+    await expect(callCount).toHaveText('2')
+    await expect(executionCount).toHaveText('1')
+    await cacheKey.fill('beta')
+    await call.click()
+    await expect(callCount).toHaveText('3')
+    await expect(executionCount).toHaveText('2')
+    await call.click()
+    await expect(callCount).toHaveText('4')
+    await expect(executionCount).toHaveText('2')
 
-    // revalidate cache
-    await locator.getByRole('textbox').fill('revalidate')
-    await locator.getByRole('button').click()
-    await expect(locator.locator('span')).toHaveText(
-      '(actionCount: 5, cacheFnCount: 3)',
-    )
-    await locator.getByRole('textbox').fill('test')
-    await locator.getByRole('button').click()
-    await expect(locator.locator('span')).toHaveText(
-      '(actionCount: 6, cacheFnCount: 4)',
-    )
+    // Clearing the cache makes the same key execute again.
+    await Promise.all([
+      page.waitForResponse(
+        (response) =>
+          response.request().method() === 'POST' &&
+          response.url().includes('_.rsc'),
+      ),
+      locator.getByRole('button', { name: 'Clear function cache' }).click(),
+    ])
+    await call.click()
+    await expect(callCount).toHaveText('5')
+    await expect(executionCount).toHaveText('3')
   })
 
   test('use cache component', async ({ page }) => {
@@ -79,53 +80,50 @@ function defineTests(f: Fixture) {
     })
   })
 
-  test('use cache closure', async ({ page }) => {
+  test('use cache captured values', async ({ page }) => {
     await page.goto(f.url())
     await waitForHydration(page)
     const locator = page.getByTestId('test-use-cache-closure')
-    await expect(locator.locator('span')).toHaveText(
-      '(actionCount: 0, innerFnCount: 0)',
-    )
+    const callCount = locator.getByTestId('call-count')
+    const executionCount = locator.getByTestId('execution-count')
+    const capturedValue = locator.getByRole('textbox', {
+      name: 'Captured value',
+    })
+    const argument = locator.getByRole('textbox', {
+      name: 'Function argument',
+    })
+    const call = locator.getByRole('button', {
+      name: 'Call cached function',
+    })
+    await expect(callCount).toHaveText('0')
+    await expect(executionCount).toHaveText('0')
 
     // Both the captured outer value and call-time inner argument form the cache key.
     // (x, y)
-    await locator.getByPlaceholder('outer').fill('x')
-    await locator.getByPlaceholder('inner').fill('y')
-    await locator.getByRole('button').click()
-    await expect(locator.locator('span')).toHaveText(
-      '(actionCount: 1, innerFnCount: 1)',
-    )
+    await call.click()
+    await expect(callCount).toHaveText('1')
+    await expect(executionCount).toHaveText('1')
 
     // (x, y)
-    await locator.getByPlaceholder('outer').fill('x')
-    await locator.getByPlaceholder('inner').fill('y')
-    await locator.getByRole('button').click()
-    await expect(locator.locator('span')).toHaveText(
-      '(actionCount: 2, innerFnCount: 1)',
-    )
+    await call.click()
+    await expect(callCount).toHaveText('2')
+    await expect(executionCount).toHaveText('1')
 
     // (xx, y)
-    await locator.getByPlaceholder('outer').fill('xx')
-    await locator.getByPlaceholder('inner').fill('y')
-    await locator.getByRole('button').click()
-    await expect(locator.locator('span')).toHaveText(
-      '(actionCount: 3, innerFnCount: 2)',
-    )
+    await capturedValue.fill('xx')
+    await call.click()
+    await expect(callCount).toHaveText('3')
+    await expect(executionCount).toHaveText('2')
 
     // (xx, y)
-    await locator.getByPlaceholder('outer').fill('xx')
-    await locator.getByPlaceholder('inner').fill('y')
-    await locator.getByRole('button').click()
-    await expect(locator.locator('span')).toHaveText(
-      '(actionCount: 4, innerFnCount: 2)',
-    )
+    await call.click()
+    await expect(callCount).toHaveText('4')
+    await expect(executionCount).toHaveText('2')
 
     // (xx, yy)
-    await locator.getByPlaceholder('outer').fill('xx')
-    await locator.getByPlaceholder('inner').fill('yy')
-    await locator.getByRole('button').click()
-    await expect(locator.locator('span')).toHaveText(
-      '(actionCount: 5, innerFnCount: 3)',
-    )
+    await argument.fill('yy')
+    await call.click()
+    await expect(callCount).toHaveText('5')
+    await expect(executionCount).toHaveText('3')
   })
 }

--- a/packages/plugin-rsc/examples/use-cache/src/features/cached-component/server.tsx
+++ b/packages/plugin-rsc/examples/use-cache/src/features/cached-component/server.tsx
@@ -1,0 +1,29 @@
+export function CachedComponent() {
+  // Wrapping children in JSX keeps their value out of the cache key, so React
+  // can restore the current value through a temporary reference on each render.
+  return (
+    <CachedShell>
+      <span>{new Date().toISOString()}</span>
+    </CachedShell>
+  )
+}
+
+async function CachedShell(props: { children?: React.ReactNode }) {
+  'use cache'
+  return (
+    <div data-testid="test-use-cache-component">
+      <p>
+        Cached timestamp:{' '}
+        <output data-testid="test-use-cache-component-static">
+          {new Date().toISOString()}
+        </output>
+      </p>
+      <p>
+        Dynamic child:{' '}
+        <output data-testid="test-use-cache-component-dynamic">
+          {props.children}
+        </output>
+      </p>
+    </div>
+  )
+}

--- a/packages/plugin-rsc/examples/use-cache/src/features/cached-function/server.tsx
+++ b/packages/plugin-rsc/examples/use-cache/src/features/cached-function/server.tsx
@@ -1,0 +1,42 @@
+import { revalidateCache } from '../../framework/use-cache-runtime'
+
+export function CachedFunction() {
+  return (
+    <div data-testid="test-use-cache-fn">
+      <form
+        action={async (formData) => {
+          'use server'
+          callCount++
+          await cachedFunction(formData.get('argument'))
+        }}
+      >
+        <label>
+          Cache key: <input name="argument" defaultValue="alpha" />
+        </label>{' '}
+        <button>Call cached function</button>
+      </form>
+      <p>
+        Call count: <output data-testid="call-count">{callCount}</output>
+        <br />
+        Execution count:{' '}
+        <output data-testid="execution-count">{executionCount}</output>
+      </p>
+      <form
+        action={async () => {
+          'use server'
+          revalidateCache(cachedFunction)
+        }}
+      >
+        <button>Clear function cache</button>
+      </form>
+    </div>
+  )
+}
+
+let callCount = 0
+let executionCount = 0
+
+async function cachedFunction(..._args: unknown[]) {
+  'use cache'
+  executionCount++
+}

--- a/packages/plugin-rsc/examples/use-cache/src/features/captured-values/server.tsx
+++ b/packages/plugin-rsc/examples/use-cache/src/features/captured-values/server.tsx
@@ -1,0 +1,41 @@
+export function CapturedValues() {
+  return (
+    <div data-testid="test-use-cache-closure">
+      <form
+        action={async (formData) => {
+          'use server'
+          callCount++
+          const captured = String(formData.get('outer'))
+          const argument = String(formData.get('inner'))
+          await createCachedFunction(captured)(argument)
+        }}
+      >
+        <label>
+          Captured value: <input name="outer" defaultValue="x" />
+        </label>{' '}
+        <label>
+          Function argument: <input name="inner" defaultValue="y" />
+        </label>{' '}
+        <button>Call cached function</button>
+      </form>
+      <p>
+        Call count: <output data-testid="call-count">{callCount}</output>
+        <br />
+        Execution count:{' '}
+        <output data-testid="execution-count">{executionCount}</output>
+      </p>
+    </div>
+  )
+}
+
+function createCachedFunction(captured: string) {
+  async function cachedFunction(argument: string) {
+    'use cache'
+    executionCount++
+    console.log({ captured, argument })
+  }
+  return cachedFunction
+}
+
+let callCount = 0
+let executionCount = 0

--- a/packages/plugin-rsc/examples/use-cache/src/root.tsx
+++ b/packages/plugin-rsc/examples/use-cache/src/root.tsx
@@ -2,7 +2,34 @@ import { CachedComponent } from './features/cached-component/server'
 import { CachedFunction } from './features/cached-function/server'
 import { CapturedValues } from './features/captured-values/server'
 
-export function Root(_props: { url: URL }) {
+const routes = [
+  {
+    path: '/cached-function',
+    title: 'Cached function',
+    description:
+      'Call the function repeatedly with the same cache key. Calls increase every time, while executions increase only on a cache miss.',
+    Component: CachedFunction,
+  },
+  {
+    path: '/cached-component',
+    title: 'Cached component',
+    description:
+      'Reload the page. The cached timestamp stays the same, while the dynamic child gets a new timestamp.',
+    Component: CachedComponent,
+  },
+  {
+    path: '/captured-values',
+    title: 'Captured values',
+    description:
+      'Both the value captured by the inner function and its argument participate in the cache key.',
+    Component: CapturedValues,
+  },
+]
+
+export function Root({ url }: { url: URL }) {
+  const route = routes.find((item) => item.path === url.pathname)
+  const Example = route?.Component
+
   return (
     <html>
       <head>
@@ -15,32 +42,30 @@ export function Root(_props: { url: URL }) {
           These examples show how arguments, dynamic children, and captured
           values interact with a cached function.
         </p>
+        <nav aria-label="Examples">
+          <ul>
+            {routes.map((item) => (
+              <li key={item.path}>
+                <a
+                  href={item.path}
+                  aria-current={route === item ? 'page' : undefined}
+                >
+                  {item.title}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </nav>
         <main>
-          <section>
-            <h2>Cached function</h2>
-            <p>
-              Call the function repeatedly with the same cache key. Calls
-              increase every time, while executions increase only on a cache
-              miss.
-            </p>
-            <CachedFunction />
-          </section>
-          <section>
-            <h2>Cached component</h2>
-            <p>
-              Reload the page. The cached timestamp stays the same, while the
-              dynamic child gets a new timestamp.
-            </p>
-            <CachedComponent />
-          </section>
-          <section>
-            <h2>Captured values</h2>
-            <p>
-              Both the value captured by the inner function and its argument
-              participate in the cache key.
-            </p>
-            <CapturedValues />
-          </section>
+          {route && Example ? (
+            <>
+              <h2>{route.title}</h2>
+              <p>{route.description}</p>
+              <Example />
+            </>
+          ) : (
+            <p>Select an example.</p>
+          )}
         </main>
       </body>
     </html>

--- a/packages/plugin-rsc/examples/use-cache/src/root.tsx
+++ b/packages/plugin-rsc/examples/use-cache/src/root.tsx
@@ -1,4 +1,6 @@
-import { revalidateCache } from './framework/use-cache-runtime'
+import { CachedComponent } from './features/cached-component/server'
+import { CachedFunction } from './features/cached-function/server'
+import { CapturedValues } from './features/captured-values/server'
 
 export function Root(_props: { url: URL }) {
   return (
@@ -9,104 +11,38 @@ export function Root(_props: { url: URL }) {
       </head>
       <body>
         <h1>RSC use cache</h1>
-        <TestUseCacheFn />
-        <TestUseCacheComponent />
-        <TestUseCacheClosure />
+        <p>
+          These examples show how arguments, dynamic children, and captured
+          values interact with a cached function.
+        </p>
+        <main>
+          <section>
+            <h2>Cached function</h2>
+            <p>
+              Call the function repeatedly with the same cache key. Calls
+              increase every time, while executions increase only on a cache
+              miss.
+            </p>
+            <CachedFunction />
+          </section>
+          <section>
+            <h2>Cached component</h2>
+            <p>
+              Reload the page. The cached timestamp stays the same, while the
+              dynamic child gets a new timestamp.
+            </p>
+            <CachedComponent />
+          </section>
+          <section>
+            <h2>Captured values</h2>
+            <p>
+              Both the value captured by the inner function and its argument
+              participate in the cache key.
+            </p>
+            <CapturedValues />
+          </section>
+        </main>
       </body>
     </html>
   )
 }
-
-function TestUseCacheFn() {
-  return (
-    <form
-      data-testid="test-use-cache-fn"
-      action={async (formData) => {
-        'use server'
-        actionCount++
-        const argument = formData.get('argument')
-        await testFn(argument)
-        if (argument === 'revalidate') {
-          revalidateCache(testFn)
-        }
-      }}
-    >
-      <button>test-use-cache-fn</button>
-      <input name="argument" placeholder="argument" />
-      <span>
-        (actionCount: {actionCount}, cacheFnCount: {cacheFnCount})
-      </span>
-    </form>
-  )
-}
-
-let actionCount = 0
-let cacheFnCount = 0
-
-async function testFn(..._args: unknown[]) {
-  'use cache'
-  cacheFnCount++
-}
-
-function TestUseCacheComponent() {
-  // NOTE: wrapping with `span` (or any jsx) is crucial because
-  // raw string `children` would get included as cache key
-  // and thus causes `TestComponent` to be evaluated in each render.
-  return (
-    <TestComponent>
-      <span>{new Date().toISOString()}</span>
-    </TestComponent>
-  )
-}
-
-async function TestComponent(props: { children?: React.ReactNode }) {
-  'use cache'
-  return (
-    <div data-testid="test-use-cache-component">
-      [test-use-cache-component]{' '}
-      <span data-testid="test-use-cache-component-static">
-        (static: {new Date().toISOString()})
-      </span>{' '}
-      <span data-testid="test-use-cache-component-dynamic">
-        (dynamic: {props.children})
-      </span>
-    </div>
-  )
-}
-
-async function TestUseCacheClosure() {
-  return (
-    <div data-testid="test-use-cache-closure">
-      <form
-        action={async (formData) => {
-          'use server'
-          actionCount2++
-          outerFnArg = formData.get('outer') as string
-          innerFnArg = formData.get('inner') as string
-          await outerFn(outerFnArg)(innerFnArg)
-        }}
-      >
-        <button>test-use-cache-closure</button>
-        <input name="outer" placeholder="outer" />
-        <input name="inner" placeholder="inner" />
-      </form>
-      <span>
-        (actionCount: {actionCount2}, innerFnCount: {innerFnCount})
-      </span>
-    </div>
-  )
-}
-
-function outerFn(outer: string) {
-  async function innerFn(inner: string) {
-    'use cache'
-    innerFnCount++
-    console.log({ outer, inner })
-  }
-  return innerFn
-}
-
-let outerFnArg = ''
-let innerFnArg = ''
-let innerFnCount = 0
-let actionCount2 = 0


### PR DESCRIPTION
- preliminary for https://github.com/vitejs/vite-plugin-react/pull/1407

The `use-cache` example currently presents its scenarios as test controls, which makes the cache behavior difficult to understand from the rendered page. This PR splits the scenarios into focused `/features/*` routes like `use-cache-callable`.