### PR TITLE
chore: use `deps.neverBundle` instead of `external` in tsdown config

### DIFF
--- a/packages/plugin-react/tsdown.config.ts
+++ b/packages/plugin-react/tsdown.config.ts
@@ -4,7 +4,9 @@ export default defineConfig({
   entry: 'src/index.ts',
   fixedExtension: false,
   dts: true,
-  external: ['#optionalTypes'],
+  deps: {
+    neverBundle: ['#optionalTypes'],
+  },
   copy: [
     {
       from: 'node_modules/@vitejs/react-common/refresh-runtime.js',


### PR DESCRIPTION
### Description

`external` is deprecated

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
