### PR TITLE
feat(react): use SSR transform of React Compiler for server envs

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -343,10 +343,9 @@ function createReactCompilerPlugin(
       async handler(code, id) {
         const isClient = this.environment?.config.consumer !== 'server'
         const shouldCompile =
-          isClient &&
-          (options.compilationMode === 'annotation'
+          options.compilationMode === 'annotation'
             ? /['"]use memo['"]/.test(code)
-            : defaultCodeFilter.test(code))
+            : defaultCodeFilter.test(code)
         // The config hook is not called when the plugin is used with Rolldown directly.
         const { transform } =
           compiler ?? (await loadCompiler((message) => this.error(message)))
@@ -358,7 +357,9 @@ function createReactCompilerPlugin(
             importSource: reactOptions.jsxImportSource,
             refresh: isClient && isFastRefreshEnabled(),
           },
-          reactCompiler: shouldCompile ? options : false,
+          reactCompiler: shouldCompile
+            ? { ...options, outputMode: isClient ? 'client' : 'ssr' }
+            : false,
           sourcemap,
         })
         const diagnostics = result.errors.map(

--- a/packages/plugin-react/tests/reactCompiler.test.ts
+++ b/packages/plugin-react/tests/reactCompiler.test.ts
@@ -88,11 +88,13 @@ describe('compiler option', () => {
     })
   })
 
-  test('uses the native JSX transform for server environments', async () => {
+  test('uses the SSR transform for server environments', async () => {
     const output = await transformWithBuildConfig({}, false, 'server')
 
     expect(output.code).toContain('react/jsx-runtime')
     expect(output.code).not.toContain('react/compiler-runtime')
+    expect(output.code).toContain('const count = 0')
+    expect(output.code).not.toContain('useState(0)')
   })
 
   test('uses the Vite build sourcemap setting', async () => {
@@ -144,9 +146,14 @@ async function transformWithBuildConfig(
   }
   return plugin.transform.handler.call(
     context as any,
-    `export function App({ name }) { return <div>{name}</div> }`,
+    /* jsx */ `import { useState } from 'react';
+
+export function App({ name }) {
+  const [count] = useState(0);
+  return <div>{name}{count}</div>
+}`,
     '/entry.tsx',
-  )
+  ) as { code: string; map: any }
 }
 
 async function getViteReactConfig(


### PR DESCRIPTION
### Description

Set `outputMode=ssr` option in React Compiler for server environments.

This has two problems:

- The `outputMode=ssr` is probably not meant to be public yet. It's not released in babel one (https://github.com/react/react/commit/4cf770d7e1a52c66401b42c7d135f40b7dc23981, https://github.com/react/react/commit/50e7ec8a694072fd6fcd52182df8a75211bf084d)
- `consumer=server` does not necessarily mean SSR. It may be an environment for RSC.

I found the option so I thought to fix it but found the problems above so I'm opening this PR as draft to discuss about these problems.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite-plugin-react/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
