### PR TITLE
fix(react): respect environment sourcemap option when `builder.sharedPlugins` is enabled

### DIFF
--- a/packages/plugin-react/CHANGELOG.md
+++ b/packages/plugin-react/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 Recoverable React Compiler diagnostics are no longer logged by default. Set `compiler.logDiagnostics` to `true` to log them through Vite. Fatal diagnostics are always logged and fail the transform.
 
+### Respect environment sourcemap option for React Compiler transform when `builder.sharedPlugins` is enabled ([#1439](https://github.com/vitejs/vite-plugin-react/pull/1439))
+
+The React Compiler transform was using the top-level sourcemap option instead of the environment sourcemap option. This caused a problem when the experimental `builder.sharedPlugins` was enabled.
+
 ## 6.1.0 (2026-08-19)
 
 ### Add experimental native React Compiler support ([#1419](https://github.com/vitejs/vite-plugin-react/pull/1419))

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -303,7 +303,6 @@ function createReactCompilerPlugin(
   reactOptions: Pick<Options, 'jsxRuntime' | 'jsxImportSource'>,
   isFastRefreshEnabled: () => boolean,
 ): Plugin {
-  let sourcemap = true
   let jsxDevelopment = false
   let compiler: typeof import('oxc-transform-react') | undefined
   const runtime =
@@ -339,7 +338,6 @@ function createReactCompilerPlugin(
       }
     },
     configResolved(config) {
-      sourcemap = config.command !== 'build' || !!config.build.sourcemap
       jsxDevelopment = !config.isProduction
     },
     transform: {
@@ -368,7 +366,10 @@ function createReactCompilerPlugin(
             refresh: isClient && isFastRefreshEnabled(),
           },
           reactCompiler: shouldCompile ? reactCompilerOptions : false,
-          sourcemap,
+          sourcemap: this.environment
+            ? this.environment.config.command !== 'build' ||
+              !!this.environment.config.build.sourcemap
+            : true /* direct Rolldown case */,
         })
         const diagnostics = result.errors.map(
           (error) =>

--- a/packages/plugin-react/tests/reactCompiler.test.ts
+++ b/packages/plugin-react/tests/reactCompiler.test.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import { type Plugin, rolldown } from 'rolldown'
+import { BuildEnvironment, type InlineConfig, resolveConfig } from 'vite'
 import { describe, expect, test } from 'vitest'
 import pluginReact, {
   type Options,
@@ -89,17 +90,54 @@ describe('compiler option', () => {
   })
 
   test('uses the native JSX transform for server environments', async () => {
-    const output = await transformWithBuildConfig({}, false, 'server')
+    const output = await transformWithBuildConfig(
+      {},
+      {
+        build: { sourcemap: false },
+        environments: { ssr: {} },
+      },
+      'ssr',
+    )
 
-    expect(output.code).toContain('react/jsx-runtime')
+    expect(output.code).toMatch(/react\/jsx(?:-dev)?-runtime/)
     expect(output.code).not.toContain('react/compiler-runtime')
   })
 
   test('uses the Vite build sourcemap setting', async () => {
-    const withoutSourcemap = await transformWithBuildConfig({}, false)
-    expect(withoutSourcemap.code).toContain('react/jsx-runtime')
+    const withoutSourcemap = await transformWithBuildConfig(
+      {},
+      { build: { sourcemap: false } },
+    )
+    expect(withoutSourcemap.code).toMatch(/react\/jsx(?:-dev)?-runtime/)
     expect(withoutSourcemap.map).toBeFalsy()
-    expect((await transformWithBuildConfig({}, true)).map).toBeTruthy()
+    expect(
+      (await transformWithBuildConfig({}, { build: { sourcemap: true } })).map,
+    ).toBeTruthy()
+  })
+
+  test('uses the environment build sourcemap setting', async () => {
+    expect(
+      (
+        await transformWithBuildConfig(
+          {},
+          {
+            build: { sourcemap: true },
+            environments: { client: { build: { sourcemap: false } } },
+          },
+        )
+      ).map,
+    ).toBeFalsy()
+    expect(
+      (
+        await transformWithBuildConfig(
+          {},
+          {
+            build: { sourcemap: false },
+            environments: { client: { build: { sourcemap: true } } },
+          },
+        )
+      ).map,
+    ).toBeTruthy()
   })
 
   test('logs recoverable diagnostics when enabled', async () => {
@@ -107,7 +145,7 @@ describe('compiler option', () => {
 
     await transformWithBuildConfig(
       { logDiagnostics: true },
-      false,
+      {},
       'client',
       `
         import { useState } from 'react'
@@ -129,12 +167,23 @@ describe('compiler option', () => {
 
 async function transformWithBuildConfig(
   compiler: ReactCompilerOptions,
-  buildSourcemap: boolean,
-  consumer: 'client' | 'server' = 'client',
+  inlineConfig: InlineConfig,
+  environmentName = 'client',
   code: string = `export function App({ name }) { return <div>{name}</div> }`,
   onWarn?: (message: unknown) => void,
 ) {
-  const plugin = pluginReact({ compiler }).find(
+  const config = await resolveConfig(
+    {
+      ...inlineConfig,
+      configFile: false,
+      logLevel: 'silent',
+      plugins: [pluginReact({ compiler })],
+    },
+    'build',
+    'production',
+    'production',
+  )
+  const plugin = config.plugins.find(
     (plugin) => plugin.name === 'vite:react-compiler',
   )!
   const context = {
@@ -144,33 +193,16 @@ async function transformWithBuildConfig(
     warn(message: unknown) {
       onWarn?.(message)
     },
-    environment: { config: { consumer } },
+    environment: new BuildEnvironment(environmentName, config),
   }
-
-  if (typeof plugin.config !== 'function')
-    throw new Error('Missing config hook')
-  await plugin.config.call(
-    context as any,
-    {},
-    { command: 'build', mode: 'production' },
-  )
-
-  if (typeof plugin.configResolved !== 'function') {
-    throw new Error('Missing configResolved hook')
-  }
-  await plugin.configResolved.call(
-    context as any,
-    {
-      command: 'build',
-      isProduction: true,
-      build: { sourcemap: buildSourcemap },
-    } as any,
-  )
 
   if (typeof plugin.transform !== 'object') {
     throw new Error('Missing transform hook')
   }
-  return plugin.transform.handler.call(context as any, code, '/entry.tsx')
+  return plugin.transform.handler.call(context as any, code, '/entry.tsx') as {
+    code: string
+    map: Record<string, unknown> | undefined
+  }
 }
 
 async function getViteReactConfig(


### PR DESCRIPTION
### Description

fixes https://github.com/vitejs/vite-plugin-react/issues/1434
close https://github.com/vitejs/vite-plugin-react/pull/1435